### PR TITLE
LogixNG - Remove "Listen to memory"

### DIFF
--- a/java/src/jmri/jmrit/display/logixng/WindowManagement.java
+++ b/java/src/jmri/jmrit/display/logixng/WindowManagement.java
@@ -27,7 +27,7 @@ import jmri.util.TypeConversionUtil;
  * @author Daniel Bergqvist Copyright 2024
  */
 public class WindowManagement extends AbstractDigitalAction
-        implements PropertyChangeListener, VetoableChangeListener {
+        implements VetoableChangeListener {
 
     private String _jmriJFrameTitle;
     private JmriJFrame _jmriJFrame;
@@ -40,13 +40,13 @@ public class WindowManagement extends AbstractDigitalAction
     private boolean _ignoreWindowNotFound = false;
 
     private final LogixNG_SelectEnum<HideOrShow> _selectEnumHideOrShow =
-            new LogixNG_SelectEnum<>(this, HideOrShow.values(), HideOrShow.DoNothing, this);
+            new LogixNG_SelectEnum<>(this, HideOrShow.values(), HideOrShow.DoNothing);
 
     private final LogixNG_SelectEnum<MaximizeMinimizeNormalize> _selectEnumMaximizeMinimizeNormalize =
-            new LogixNG_SelectEnum<>(this, MaximizeMinimizeNormalize.values(), MaximizeMinimizeNormalize.DoNothing, this);
+            new LogixNG_SelectEnum<>(this, MaximizeMinimizeNormalize.values(), MaximizeMinimizeNormalize.DoNothing);
 
     private final LogixNG_SelectEnum<BringToFrontOrBack> _selectEnumBringToFrontOrBack =
-            new LogixNG_SelectEnum<>(this, BringToFrontOrBack.values(), BringToFrontOrBack.DoNothing, this);
+            new LogixNG_SelectEnum<>(this, BringToFrontOrBack.values(), BringToFrontOrBack.DoNothing);
 
 
     public WindowManagement(String sys, String user)
@@ -354,22 +354,6 @@ public class WindowManagement extends AbstractDigitalAction
         if ((_jmriJFrameTitle != null) && (_jmriJFrame == null)) {
             setJmriJFrame(_jmriJFrameTitle);
         }
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void propertyChange(PropertyChangeEvent evt) {
-        getConditionalNG().execute();
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void registerListenersForThisClass() {
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void unregisterListenersForThisClass() {
     }
 
     /** {@inheritDoc} */

--- a/java/src/jmri/jmrit/logixng/LogixNGBundle.properties
+++ b/java/src/jmri/jmrit/logixng/LogixNGBundle.properties
@@ -114,7 +114,6 @@ BeanNotSelected                 = ''
 AddressByDirect                 = {0}
 AddressByReference              = by reference "{0}"
 AddressByMemory                 = by memory "{0}"
-AddressByMemory_Listen          = by memory "{0}" ({1})
 AddressByLocalVariable          = by local variable "{0}"
 AddressByFormula                = by formula "{0}"
 AddressByTable                  = by table {0}, row {1}, column {2}

--- a/java/src/jmri/jmrit/logixng/LogixNGBundle_cs.properties
+++ b/java/src/jmri/jmrit/logixng/LogixNGBundle_cs.properties
@@ -114,7 +114,6 @@ BeanNotSelected             = ''
 AddressByDirect             = {0}
 AddressByReference          = podle odkazu "{0}"
 AddressByMemory             = podle pam\u011bti "{0}"
-AddressByMemory_Listen      = podle pam\u011bti "{0}" ({1})
 AddressByLocalVariable      = podle lok\u00e1ln\u00ed prom\u011bnn\u00e9 "{0}"
 AddressByFormula            = podle vzorce "{0}"
 AddressByTable              = podle tabulky {0}, \u0159\u00e1dku {1}, sloupce {2}

--- a/java/src/jmri/jmrit/logixng/LogixNGBundle_nl.properties
+++ b/java/src/jmri/jmrit/logixng/LogixNGBundle_nl.properties
@@ -114,7 +114,6 @@ BeanNotSelected                 = ''
 AddressByDirect                 = {0}
 AddressByReference              = per verwijzing "{0}"
 AddressByMemory                 = per geheugen "{0}"
-AddressByMemory_Listen          = per geheugen "{0}" ({1})
 AddressByLocalVariable          = per lokale variabele "{0}"
 AddressByFormula                = per formule "{0}"
 AddressByTable                  = per tabel {0}, ruh {1}, kolom {2}

--- a/java/src/jmri/jmrit/logixng/actions/ActionAudio.java
+++ b/java/src/jmri/jmrit/logixng/actions/ActionAudio.java
@@ -1,7 +1,5 @@
 package jmri.jmrit.logixng.actions;
 
-import java.beans.PropertyChangeEvent;
-import java.beans.PropertyChangeListener;
 import java.util.*;
 
 import jmri.*;
@@ -18,15 +16,14 @@ import jmri.util.ThreadingUtil;
  *
  * @author Daniel Bergqvist Copyright 2021
  */
-public class ActionAudio extends AbstractDigitalAction
-        implements PropertyChangeListener {
+public class ActionAudio extends AbstractDigitalAction {
 
     private final LogixNG_SelectNamedBean<Audio> _selectNamedBean =
             new LogixNG_SelectNamedBean<>(
-                    this, Audio.class, InstanceManager.getDefault(AudioManager.class), this);
+                    this, Audio.class, InstanceManager.getDefault(AudioManager.class));
 
     private final LogixNG_SelectEnum<Operation> _selectEnum =
-            new LogixNG_SelectEnum<>(this, Operation.values(), Operation.Play, this);
+            new LogixNG_SelectEnum<>(this, Operation.values(), Operation.Play);
 
 
     public ActionAudio(String sys, String user)
@@ -151,20 +148,6 @@ public class ActionAudio extends AbstractDigitalAction
 
     /** {@inheritDoc} */
     @Override
-    public void registerListenersForThisClass() {
-        _selectNamedBean.registerListeners();
-        _selectEnum.registerListeners();
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void unregisterListenersForThisClass() {
-        _selectNamedBean.unregisterListeners();
-        _selectEnum.unregisterListeners();
-    }
-
-    /** {@inheritDoc} */
-    @Override
     public void disposeMe() {
     }
 
@@ -198,12 +181,6 @@ public class ActionAudio extends AbstractDigitalAction
     @Override
     public void getUsageDetail(int level, NamedBean bean, List<NamedBeanUsageReport> report, NamedBean cdl) {
         _selectNamedBean.getUsageDetail(level, bean, report, cdl, this, LogixNG_SelectNamedBean.Type.Action);
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void propertyChange(PropertyChangeEvent evt) {
-        getConditionalNG().execute();
     }
 
 //    private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(ActionAudio.class);

--- a/java/src/jmri/jmrit/logixng/actions/ActionBlock.java
+++ b/java/src/jmri/jmrit/logixng/actions/ActionBlock.java
@@ -1,7 +1,5 @@
 package jmri.jmrit.logixng.actions;
 
-import java.beans.PropertyChangeEvent;
-import java.beans.PropertyChangeListener;
 import java.util.*;
 
 import jmri.*;
@@ -20,18 +18,17 @@ import jmri.util.ThreadingUtil;
  * @author Daniel Bergqvist Copyright 2021
  * @author Dave Sand Copyright 2021
  */
-public class ActionBlock extends AbstractDigitalAction
-        implements PropertyChangeListener {
+public class ActionBlock extends AbstractDigitalAction {
 
     private final LogixNG_SelectNamedBean<Block> _selectNamedBean =
             new LogixNG_SelectNamedBean<>(
-                    this, Block.class, InstanceManager.getDefault(BlockManager.class), this);
+                    this, Block.class, InstanceManager.getDefault(BlockManager.class));
 
     private final LogixNG_SelectEnum<DirectOperation> _selectEnum =
-            new LogixNG_SelectEnum<>(this, DirectOperation.values(), DirectOperation.SetOccupied, this);
+            new LogixNG_SelectEnum<>(this, DirectOperation.values(), DirectOperation.SetOccupied);
 
     private final LogixNG_SelectString _selectBlockValue =
-            new LogixNG_SelectString(this, this);
+            new LogixNG_SelectString(this);
 
 
     public ActionBlock(String sys, String user)
@@ -182,22 +179,6 @@ public class ActionBlock extends AbstractDigitalAction
 
     /** {@inheritDoc} */
     @Override
-    public void registerListenersForThisClass() {
-        _selectNamedBean.registerListeners();
-        _selectEnum.registerListeners();
-        _selectBlockValue.registerListeners();
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void unregisterListenersForThisClass() {
-        _selectNamedBean.unregisterListeners();
-        _selectEnum.unregisterListeners();
-        _selectBlockValue.unregisterListeners();
-    }
-
-    /** {@inheritDoc} */
-    @Override
     public void disposeMe() {
     }
 
@@ -226,12 +207,6 @@ public class ActionBlock extends AbstractDigitalAction
     @Override
     public void getUsageDetail(int level, NamedBean bean, List<NamedBeanUsageReport> report, NamedBean cdl) {
         _selectNamedBean.getUsageDetail(level, bean, report, cdl, this, LogixNG_SelectNamedBean.Type.Action);
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void propertyChange(PropertyChangeEvent evt) {
-        getConditionalNG().execute();
     }
 
     private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(ActionBlock.class);

--- a/java/src/jmri/jmrit/logixng/actions/ActionClock.java
+++ b/java/src/jmri/jmrit/logixng/actions/ActionClock.java
@@ -1,7 +1,5 @@
 package jmri.jmrit.logixng.actions;
 
-import java.beans.PropertyChangeEvent;
-import java.beans.PropertyChangeListener;
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
@@ -20,13 +18,12 @@ import jmri.util.ThreadingUtil;
  * @author Daniel Bergqvist Copyright 2021
  * @author Dave Sand Copyright 2021
  */
-public class ActionClock extends AbstractDigitalAction
-        implements PropertyChangeListener {
+public class ActionClock extends AbstractDigitalAction {
 
     private final LogixNG_SelectEnum<ClockState> _selectEnum =
-            new LogixNG_SelectEnum<>(this, ClockState.values(), ClockState.SetClock, this);
+            new LogixNG_SelectEnum<>(this, ClockState.values(), ClockState.SetClock);
     private final LogixNG_SelectInteger _selectValue =
-            new LogixNG_SelectInteger(this, this, new TimeFormatterParserValidator());
+            new LogixNG_SelectInteger(this, new TimeFormatterParserValidator());
 
 
     public ActionClock(String sys, String user)
@@ -147,26 +144,6 @@ public class ActionClock extends AbstractDigitalAction
     @Override
     public void setup() {
         // Do nothing
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void registerListenersForThisClass() {
-        _selectEnum.registerListeners();
-        _selectValue.registerListeners();
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void unregisterListenersForThisClass() {
-        _selectEnum.unregisterListeners();
-        _selectValue.unregisterListeners();
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void propertyChange(PropertyChangeEvent evt) {
-        getConditionalNG().execute();
     }
 
     /** {@inheritDoc} */

--- a/java/src/jmri/jmrit/logixng/actions/ActionClockRate.java
+++ b/java/src/jmri/jmrit/logixng/actions/ActionClockRate.java
@@ -1,7 +1,5 @@
 package jmri.jmrit.logixng.actions;
 
-import java.beans.PropertyChangeEvent;
-import java.beans.PropertyChangeListener;
 import java.util.*;
 
 import jmri.*;
@@ -20,13 +18,12 @@ import jmri.util.ThreadingUtil;
  * @author Dave Sand Copyright 2021
  * @author Daniel Bergqvist Copyright 2022
  */
-public class ActionClockRate extends AbstractDigitalAction
-        implements PropertyChangeListener {
+public class ActionClockRate extends AbstractDigitalAction {
 
     private final LogixNG_SelectEnum<ClockState> _selectEnum =
-            new LogixNG_SelectEnum<>(this, ClockState.values(), ClockState.SetClockRate, this);
+            new LogixNG_SelectEnum<>(this, ClockState.values(), ClockState.SetClockRate);
     private final LogixNG_SelectDouble _selectSpeed =
-            new LogixNG_SelectDouble(this, 3, this, new DefaultFormatterParserValidator());
+            new LogixNG_SelectDouble(this, 3, new DefaultFormatterParserValidator());
 
 
     public ActionClockRate(String sys, String user)
@@ -149,26 +146,6 @@ public class ActionClockRate extends AbstractDigitalAction
     @Override
     public void setup() {
         // Do nothing
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void registerListenersForThisClass() {
-        _selectEnum.registerListeners();
-        _selectSpeed.registerListeners();
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void unregisterListenersForThisClass() {
-        _selectEnum.unregisterListeners();
-        _selectSpeed.unregisterListeners();
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void propertyChange(PropertyChangeEvent evt) {
-        getConditionalNG().execute();
     }
 
     /** {@inheritDoc} */

--- a/java/src/jmri/jmrit/logixng/actions/ActionCreateBeansFromTable.java
+++ b/java/src/jmri/jmrit/logixng/actions/ActionCreateBeansFromTable.java
@@ -18,13 +18,13 @@ import jmri.jmrit.logixng.util.parser.ParserException;
  * @author Daniel Bergqvist Copyright 2022
  */
 public class ActionCreateBeansFromTable extends AbstractDigitalAction
-        implements PropertyChangeListener, VetoableChangeListener {
+        implements VetoableChangeListener {
 
     private boolean _onlyCreatableTypes = true;
     private NamedBeanType _namedBeanType = NamedBeanType.Light;
     private final LogixNG_SelectNamedBean<NamedTable> _selectNamedBean =
             new LogixNG_SelectNamedBean<>(
-                    this, NamedTable.class, InstanceManager.getDefault(NamedTableManager.class), this);
+                    this, NamedTable.class, InstanceManager.getDefault(NamedTableManager.class));
     private TableRowOrColumn _tableRowOrColumn = TableRowOrColumn.Row;
     private String _rowOrColumnSystemName = "";
     private String _rowOrColumnUserName = "";
@@ -421,30 +421,6 @@ public class ActionCreateBeansFromTable extends AbstractDigitalAction
     @Override
     public void setup() {
         // Do nothing
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void registerListenersForThisClass() {
-        if (_listenersAreRegistered) return;
-
-        _selectNamedBean.registerListeners();
-        _listenersAreRegistered = true;
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void unregisterListenersForThisClass() {
-        if (!_listenersAreRegistered) return;
-
-        _selectNamedBean.unregisterListeners();
-        _listenersAreRegistered = false;
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void propertyChange(PropertyChangeEvent evt) {
-        getConditionalNG().execute();
     }
 
     /** {@inheritDoc} */

--- a/java/src/jmri/jmrit/logixng/actions/ActionDispatcher.java
+++ b/java/src/jmri/jmrit/logixng/actions/ActionDispatcher.java
@@ -1,7 +1,5 @@
 package jmri.jmrit.logixng.actions;
 
-import java.beans.PropertyChangeEvent;
-import java.beans.PropertyChangeListener;
 import java.util.*;
 
 import javax.annotation.Nonnull;
@@ -21,8 +19,7 @@ import jmri.util.TypeConversionUtil;
  * @author Daniel Bergqvist Copyright 2021
  * @author Dave Sand Copyright 2021
  */
-public class ActionDispatcher extends AbstractDigitalAction
-        implements PropertyChangeListener {
+public class ActionDispatcher extends AbstractDigitalAction {
 
     private NamedBeanAddressing _addressing = NamedBeanAddressing.Direct;
     private String _trainInfoFileName = "";
@@ -32,7 +29,7 @@ public class ActionDispatcher extends AbstractDigitalAction
     private ExpressionNode _expressionNode;
 
     private final LogixNG_SelectEnum<DirectOperation> _selectEnum =
-            new LogixNG_SelectEnum<>(this, DirectOperation.values(), DirectOperation.None, this);
+            new LogixNG_SelectEnum<>(this, DirectOperation.values(), DirectOperation.None);
 
     private NamedBeanAddressing _dataAddressing = NamedBeanAddressing.Direct;
     private String _dataReference = "";
@@ -452,18 +449,6 @@ public class ActionDispatcher extends AbstractDigitalAction
 
     /** {@inheritDoc} */
     @Override
-    public void registerListenersForThisClass() {
-        _selectEnum.registerListeners();
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void unregisterListenersForThisClass() {
-        _selectEnum.unregisterListeners();
-    }
-
-    /** {@inheritDoc} */
-    @Override
     public void disposeMe() {
     }
 
@@ -491,12 +476,6 @@ public class ActionDispatcher extends AbstractDigitalAction
     /** {@inheritDoc} */
     @Override
     public void getUsageDetail(int level, NamedBean bean, List<NamedBeanUsageReport> report, NamedBean cdl) {
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void propertyChange(PropertyChangeEvent evt) {
-        getConditionalNG().execute();
     }
 
     private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(ActionDispatcher.class);

--- a/java/src/jmri/jmrit/logixng/actions/ActionEntryExit.java
+++ b/java/src/jmri/jmrit/logixng/actions/ActionEntryExit.java
@@ -1,7 +1,5 @@
 package jmri.jmrit.logixng.actions;
 
-import java.beans.PropertyChangeEvent;
-import java.beans.PropertyChangeListener;
 import java.util.*;
 
 import jmri.*;
@@ -20,15 +18,14 @@ import jmri.util.ThreadingUtil;
  *
  * @author Daniel Bergqvist Copyright 2021
  */
-public class ActionEntryExit extends AbstractDigitalAction
-        implements PropertyChangeListener {
+public class ActionEntryExit extends AbstractDigitalAction {
 
     private final LogixNG_SelectNamedBean<DestinationPoints> _selectNamedBean =
             new LogixNG_SelectNamedBean<>(
-                    this, DestinationPoints.class, InstanceManager.getDefault(jmri.jmrit.entryexit.EntryExitPairs.class), this);
+                    this, DestinationPoints.class, InstanceManager.getDefault(jmri.jmrit.entryexit.EntryExitPairs.class));
 
     private final LogixNG_SelectEnum<Operation> _selectEnum =
-            new LogixNG_SelectEnum<>(this, Operation.values(), Operation.SetNXPairEnabled, this);
+            new LogixNG_SelectEnum<>(this, Operation.values(), Operation.SetNXPairEnabled);
 
 
     public ActionEntryExit(String sys, String user)
@@ -147,20 +144,6 @@ public class ActionEntryExit extends AbstractDigitalAction
 
     /** {@inheritDoc} */
     @Override
-    public void registerListenersForThisClass() {
-        _selectNamedBean.registerListeners();
-        _selectEnum.registerListeners();
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void unregisterListenersForThisClass() {
-        _selectNamedBean.unregisterListeners();
-        _selectEnum.unregisterListeners();
-    }
-
-    /** {@inheritDoc} */
-    @Override
     public void disposeMe() {
     }
 
@@ -191,12 +174,6 @@ public class ActionEntryExit extends AbstractDigitalAction
     @Override
     public void getUsageDetail(int level, NamedBean bean, List<NamedBeanUsageReport> report, NamedBean cdl) {
         _selectNamedBean.getUsageDetail(level, bean, report, cdl, this, LogixNG_SelectNamedBean.Type.Action);
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void propertyChange(PropertyChangeEvent evt) {
-        getConditionalNG().execute();
     }
 
 //    private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(ActionEntryExit.class);

--- a/java/src/jmri/jmrit/logixng/actions/ActionFindTableRowOrColumn.java
+++ b/java/src/jmri/jmrit/logixng/actions/ActionFindTableRowOrColumn.java
@@ -16,11 +16,11 @@ import jmri.jmrit.logixng.util.parser.ParserException;
  * @author Daniel Bergqvist Copyright 2022
  */
 public class ActionFindTableRowOrColumn extends AbstractDigitalAction
-        implements PropertyChangeListener, VetoableChangeListener {
+        implements VetoableChangeListener {
 
     private final LogixNG_SelectNamedBean<NamedTable> _selectNamedBean =
             new LogixNG_SelectNamedBean<>(
-                    this, NamedTable.class, InstanceManager.getDefault(NamedTableManager.class), this);
+                    this, NamedTable.class, InstanceManager.getDefault(NamedTableManager.class));
     private TableRowOrColumn _tableRowOrColumn = TableRowOrColumn.Row;
     private String _rowOrColumnName = "";
     private boolean _includeCellsWithoutHeader = false;
@@ -244,31 +244,6 @@ public class ActionFindTableRowOrColumn extends AbstractDigitalAction
     @Override
     public void setup() {
         // Do nothing
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void registerListenersForThisClass() {
-        if (_listenersAreRegistered) return;
-
-        _selectNamedBean.registerListeners();
-        _listenersAreRegistered = true;
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void unregisterListenersForThisClass() {
-        if (!_listenersAreRegistered) return;
-
-        _selectNamedBean.unregisterListeners();
-        _listenersAreRegistered = false;
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void propertyChange(PropertyChangeEvent evt) {
-//        System.out.format("Table: Property: %s, Bean: %s, Listen: %b%n", evt.getPropertyName(), ((NamedBean)evt.getSource()).getDisplayName(), _listenOnAllProperties);
-        getConditionalNG().execute();
     }
 
     /** {@inheritDoc} */

--- a/java/src/jmri/jmrit/logixng/actions/ActionLight.java
+++ b/java/src/jmri/jmrit/logixng/actions/ActionLight.java
@@ -1,7 +1,5 @@
 package jmri.jmrit.logixng.actions;
 
-import java.beans.PropertyChangeEvent;
-import java.beans.PropertyChangeListener;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -26,15 +24,14 @@ import jmri.util.TypeConversionUtil;
  *
  * @author Daniel Bergqvist Copyright 2018
  */
-public class ActionLight extends AbstractDigitalAction
-        implements PropertyChangeListener {
+public class ActionLight extends AbstractDigitalAction {
 
     private final LogixNG_SelectNamedBean<Light> _selectNamedBean =
             new LogixNG_SelectNamedBean<>(
-                    this, Light.class, InstanceManager.getDefault(LightManager.class), this);
+                    this, Light.class, InstanceManager.getDefault(LightManager.class));
 
     private final LogixNG_SelectEnum<LightState> _selectEnum =
-            new LogixNG_SelectEnum<>(this, LightState.values(), LightState.On, this);
+            new LogixNG_SelectEnum<>(this, LightState.values(), LightState.On);
 
     private NamedBeanAddressing _dataAddressing = NamedBeanAddressing.Direct;
     private String _dataReference = "";
@@ -265,20 +262,6 @@ public class ActionLight extends AbstractDigitalAction
 
     /** {@inheritDoc} */
     @Override
-    public void registerListenersForThisClass() {
-        _selectNamedBean.registerListeners();
-        _selectEnum.registerListeners();
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void unregisterListenersForThisClass() {
-        _selectNamedBean.unregisterListeners();
-        _selectEnum.unregisterListeners();
-    }
-
-    /** {@inheritDoc} */
-    @Override
     public void disposeMe() {
     }
 
@@ -344,12 +327,6 @@ public class ActionLight extends AbstractDigitalAction
     @Override
     public void getUsageDetail(int level, NamedBean bean, List<NamedBeanUsageReport> report, NamedBean cdl) {
         _selectNamedBean.getUsageDetail(level, bean, report, cdl, this, LogixNG_SelectNamedBean.Type.Action);
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void propertyChange(PropertyChangeEvent evt) {
-        getConditionalNG().execute();
     }
 
 //    private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(ActionLight.class);

--- a/java/src/jmri/jmrit/logixng/actions/ActionLightIntensity.java
+++ b/java/src/jmri/jmrit/logixng/actions/ActionLightIntensity.java
@@ -1,7 +1,5 @@
 package jmri.jmrit.logixng.actions;
 
-import java.beans.PropertyChangeEvent;
-import java.beans.PropertyChangeListener;
 import java.util.*;
 
 import jmri.*;
@@ -17,13 +15,13 @@ import jmri.jmrit.logixng.util.LogixNG_SelectNamedBean;
  * @author Daniel Bergqvist Copyright 2019
  */
 public class ActionLightIntensity extends AbstractDigitalAction
-        implements FemaleSocketListener, PropertyChangeListener {
+        implements FemaleSocketListener {
 
     public static final int INTENSITY_SOCKET = 0;
 
     private final LogixNG_SelectNamedBean<VariableLight> _selectNamedBean =
             new LogixNG_SelectNamedBean<>(
-                    this, VariableLight.class, InstanceManager.getDefault(VariableLightManager.class), this);
+                    this, VariableLight.class, InstanceManager.getDefault(VariableLightManager.class));
 
     private String _intensitySocketSystemName;
     private final FemaleAnalogExpressionSocket _intensitySocket;
@@ -173,27 +171,7 @@ public class ActionLightIntensity extends AbstractDigitalAction
 
     /** {@inheritDoc} */
     @Override
-    public void registerListenersForThisClass() {
-        _selectNamedBean.registerListeners();
-        _listenersAreRegistered = true;
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void unregisterListenersForThisClass() {
-        _selectNamedBean.unregisterListeners();
-        _listenersAreRegistered = false;
-    }
-
-    /** {@inheritDoc} */
-    @Override
     public void disposeMe() {
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void propertyChange(PropertyChangeEvent evt) {
-        getConditionalNG().execute();
     }
 
     private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(ActionLightIntensity.class);

--- a/java/src/jmri/jmrit/logixng/actions/ActionListenOnBeansTable.java
+++ b/java/src/jmri/jmrit/logixng/actions/ActionListenOnBeansTable.java
@@ -25,7 +25,7 @@ public class ActionListenOnBeansTable extends AbstractDigitalAction
     private NamedBeanType _namedBeanType = NamedBeanType.Light;
     private final LogixNG_SelectNamedBean<NamedTable> _selectNamedBean =
             new LogixNG_SelectNamedBean<>(
-                    this, NamedTable.class, InstanceManager.getDefault(NamedTableManager.class), this);
+                    this, NamedTable.class, InstanceManager.getDefault(NamedTableManager.class));
     private TableRowOrColumn _tableRowOrColumn = TableRowOrColumn.Row;
     private String _rowOrColumnName = "";
     private boolean _includeCellsWithoutHeader = false;
@@ -337,7 +337,6 @@ public class ActionListenOnBeansTable extends AbstractDigitalAction
                 log.warn("The named bean \"{}\" cannot be found in the manager for {}", item, _namedBeanType.toString());
             }
         }
-        _selectNamedBean.registerListeners();
         _listenersAreRegistered = true;
     }
 
@@ -355,7 +354,6 @@ public class ActionListenOnBeansTable extends AbstractDigitalAction
             }
             namedBeanEntry.getKey().removePropertyChangeListener(namedBeanEntry.getValue(), this);
         }
-        _selectNamedBean.unregisterListeners();
         _listenersAreRegistered = false;
     }
 

--- a/java/src/jmri/jmrit/logixng/actions/ActionLocalVariable.java
+++ b/java/src/jmri/jmrit/logixng/actions/ActionLocalVariable.java
@@ -28,15 +28,15 @@ public class ActionLocalVariable extends AbstractDigitalAction
 
     private final LogixNG_SelectNamedBean<Memory> _selectMemoryNamedBean =
             new LogixNG_SelectNamedBean<>(
-                    this, Memory.class, InstanceManager.getDefault(MemoryManager.class), this);
+                    this, Memory.class, InstanceManager.getDefault(MemoryManager.class));
 
     private final LogixNG_SelectNamedBean<Block> _selectBlockNamedBean =
             new LogixNG_SelectNamedBean<>(
-                    this, Block.class, InstanceManager.getDefault(BlockManager.class), this);
+                    this, Block.class, InstanceManager.getDefault(BlockManager.class));
 
     private final LogixNG_SelectNamedBean<Reporter> _selectReporterNamedBean =
             new LogixNG_SelectNamedBean<>(
-                    this, Reporter.class, InstanceManager.getDefault(ReporterManager.class), this);
+                    this, Reporter.class, InstanceManager.getDefault(ReporterManager.class));
 
     private VariableOperation _variableOperation = VariableOperation.SetToString;
     private ConstantType _constantType = ConstantType.String;
@@ -396,9 +396,6 @@ public class ActionLocalVariable extends AbstractDigitalAction
                     && (_variableOperation == VariableOperation.CopyReporterToVariable)) {
                 _selectReporterNamedBean.addPropertyChangeListener("currentReport", this);
             }
-            _selectMemoryNamedBean.registerListeners();
-            _selectBlockNamedBean.registerListeners();
-            _selectReporterNamedBean.registerListeners();
             _listenersAreRegistered = true;
         }
     }
@@ -419,9 +416,6 @@ public class ActionLocalVariable extends AbstractDigitalAction
                     && (_variableOperation == VariableOperation.CopyReporterToVariable)) {
                 _selectReporterNamedBean.removePropertyChangeListener("currentReport", this);
             }
-            _selectMemoryNamedBean.unregisterListeners();
-            _selectBlockNamedBean.unregisterListeners();
-            _selectReporterNamedBean.unregisterListeners();
             _listenersAreRegistered = false;
         }
     }

--- a/java/src/jmri/jmrit/logixng/actions/ActionMemory.java
+++ b/java/src/jmri/jmrit/logixng/actions/ActionMemory.java
@@ -24,10 +24,10 @@ public class ActionMemory extends AbstractDigitalAction
 
     private final LogixNG_SelectNamedBean<Memory> _selectNamedBean =
             new LogixNG_SelectNamedBean<>(
-                    this, Memory.class, InstanceManager.getDefault(MemoryManager.class), this);
+                    this, Memory.class, InstanceManager.getDefault(MemoryManager.class));
     private final LogixNG_SelectNamedBean<Memory> _selectOtherMemoryNamedBean =
             new LogixNG_SelectNamedBean<>(
-                    this, Memory.class, InstanceManager.getDefault(MemoryManager.class), this);
+                    this, Memory.class, InstanceManager.getDefault(MemoryManager.class));
 //    private NamedBeanHandle<Memory> _otherMemoryHandle;
     private MemoryOperation _memoryOperation = MemoryOperation.SetToString;
     private String _otherConstantValue = "";
@@ -264,7 +264,6 @@ public class ActionMemory extends AbstractDigitalAction
             if (_listenToMemory) {
                 _selectOtherMemoryNamedBean.addPropertyChangeListener("value", this);
             }
-            _selectNamedBean.registerListeners();
             _listenersAreRegistered = true;
         }
     }
@@ -275,7 +274,6 @@ public class ActionMemory extends AbstractDigitalAction
         if (_listenersAreRegistered && _listenToMemory) {
             _selectOtherMemoryNamedBean.removePropertyChangeListener("value", this);
         }
-        _selectNamedBean.unregisterListeners();
         _listenersAreRegistered = false;
     }
 

--- a/java/src/jmri/jmrit/logixng/actions/ActionOBlock.java
+++ b/java/src/jmri/jmrit/logixng/actions/ActionOBlock.java
@@ -29,14 +29,14 @@ public class ActionOBlock extends AbstractDigitalAction
 
     private final LogixNG_SelectNamedBean<OBlock> _selectNamedBean =
             new LogixNG_SelectNamedBean<>(
-                    this, OBlock.class, InstanceManager.getDefault(OBlockManager.class), this);
+                    this, OBlock.class, InstanceManager.getDefault(OBlockManager.class));
 
     private final LogixNG_SelectEnum<DirectOperation> _selectEnum =
-            new LogixNG_SelectEnum<>(this, DirectOperation.values(), DirectOperation.Deallocate, this);
+            new LogixNG_SelectEnum<>(this, DirectOperation.values(), DirectOperation.Deallocate);
 
     private final LogixNG_SelectNamedBean<Memory> _selectMemoryNamedBean =
             new LogixNG_SelectNamedBean<>(
-                    this, Memory.class, InstanceManager.getDefault(MemoryManager.class), this);
+                    this, Memory.class, InstanceManager.getDefault(MemoryManager.class));
 
     private NamedBeanAddressing _dataAddressing = NamedBeanAddressing.Direct;
     private String _dataReference = "";
@@ -303,16 +303,12 @@ public class ActionOBlock extends AbstractDigitalAction
     /** {@inheritDoc} */
     @Override
     public void registerListenersForThisClass() {
-        _selectNamedBean.registerListeners();
-        _selectEnum.registerListeners();
         _selectMemoryNamedBean.addPropertyChangeListener("value", this);
     }
 
     /** {@inheritDoc} */
     @Override
     public void unregisterListenersForThisClass() {
-        _selectNamedBean.unregisterListeners();
-        _selectEnum.unregisterListeners();
         _selectMemoryNamedBean.removePropertyChangeListener("value", this);
     }
 

--- a/java/src/jmri/jmrit/logixng/actions/ActionPower.java
+++ b/java/src/jmri/jmrit/logixng/actions/ActionPower.java
@@ -1,7 +1,5 @@
 package jmri.jmrit.logixng.actions;
 
-import java.beans.PropertyChangeEvent;
-import java.beans.PropertyChangeListener;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -16,11 +14,10 @@ import jmri.util.ThreadingUtil;
  *
  * @author Daniel Bergqvist Copyright 2021
  */
-public class ActionPower extends AbstractDigitalAction
-        implements PropertyChangeListener {
+public class ActionPower extends AbstractDigitalAction {
 
     private final LogixNG_SelectEnum<PowerState> _selectEnum =
-            new LogixNG_SelectEnum<>(this, PowerState.values(), PowerState.On, this);
+            new LogixNG_SelectEnum<>(this, PowerState.values(), PowerState.On);
 
 
     public ActionPower(String sys, String user)
@@ -94,18 +91,6 @@ public class ActionPower extends AbstractDigitalAction
 
     /** {@inheritDoc} */
     @Override
-    public void registerListenersForThisClass() {
-        _selectEnum.registerListeners();
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void unregisterListenersForThisClass() {
-        _selectEnum.unregisterListeners();
-    }
-
-    /** {@inheritDoc} */
-    @Override
     public void disposeMe() {
     }
 
@@ -144,12 +129,6 @@ public class ActionPower extends AbstractDigitalAction
             return _text;
         }
 
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void propertyChange(PropertyChangeEvent evt) {
-        getConditionalNG().execute();
     }
 
 //    private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(ActionPower.class);

--- a/java/src/jmri/jmrit/logixng/actions/ActionReporter.java
+++ b/java/src/jmri/jmrit/logixng/actions/ActionReporter.java
@@ -1,7 +1,5 @@
 package jmri.jmrit.logixng.actions;
 
-import java.beans.PropertyChangeEvent;
-import java.beans.PropertyChangeListener;
 import java.util.*;
 
 import javax.annotation.Nonnull;
@@ -21,16 +19,15 @@ import jmri.util.TypeConversionUtil;
  * @author Daniel Bergqvist Copyright 2021
  * @author Dave Sand Copyright 2021
  */
-public class ActionReporter extends AbstractDigitalAction
-        implements PropertyChangeListener {
+public class ActionReporter extends AbstractDigitalAction {
 
     private final LogixNG_SelectNamedBean<Reporter> _selectNamedBean =
             new LogixNG_SelectNamedBean<>(
-                    this, Reporter.class, InstanceManager.getDefault(ReporterManager.class), this);
+                    this, Reporter.class, InstanceManager.getDefault(ReporterManager.class));
 
     private final LogixNG_SelectNamedBean<Memory> _selectMemoryNamedBean =
             new LogixNG_SelectNamedBean<>(
-                    this, Memory.class, InstanceManager.getDefault(MemoryManager.class), this);
+                    this, Memory.class, InstanceManager.getDefault(MemoryManager.class));
 
     private ReporterValue _reporterValue = ReporterValue.CopyCurrentReport;
 
@@ -279,18 +276,6 @@ public class ActionReporter extends AbstractDigitalAction
 
     /** {@inheritDoc} */
     @Override
-    public void registerListenersForThisClass() {
-        _selectNamedBean.registerListeners();
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void unregisterListenersForThisClass() {
-        _selectNamedBean.unregisterListeners();
-    }
-
-    /** {@inheritDoc} */
-    @Override
     public void disposeMe() {
     }
 
@@ -317,12 +302,6 @@ public class ActionReporter extends AbstractDigitalAction
     public void getUsageDetail(int level, NamedBean bean, List<NamedBeanUsageReport> report, NamedBean cdl) {
         _selectNamedBean.getUsageDetail(level, bean, report, cdl, this, LogixNG_SelectNamedBean.Type.Action);
         _selectMemoryNamedBean.getUsageDetail(level, bean, report, cdl, this, LogixNG_SelectNamedBean.Type.Action);
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void propertyChange(PropertyChangeEvent evt) {
-        getConditionalNG().execute();
     }
 
     private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(ActionReporter.class);

--- a/java/src/jmri/jmrit/logixng/actions/ActionRequestUpdateOfSensor.java
+++ b/java/src/jmri/jmrit/logixng/actions/ActionRequestUpdateOfSensor.java
@@ -1,7 +1,5 @@
 package jmri.jmrit.logixng.actions;
 
-import java.beans.PropertyChangeEvent;
-import java.beans.PropertyChangeListener;
 import java.util.*;
 
 import jmri.*;
@@ -15,12 +13,11 @@ import jmri.util.ThreadingUtil;
  *
  * @author Daniel Bergqvist Copyright 2024
  */
-public class ActionRequestUpdateOfSensor extends AbstractDigitalAction
-        implements PropertyChangeListener {
+public class ActionRequestUpdateOfSensor extends AbstractDigitalAction {
 
     private final LogixNG_SelectNamedBean<Sensor> _selectNamedBean =
             new LogixNG_SelectNamedBean<>(
-                    this, Sensor.class, InstanceManager.getDefault(SensorManager.class), this);
+                    this, Sensor.class, InstanceManager.getDefault(SensorManager.class));
 
 
     public ActionRequestUpdateOfSensor(String sys, String user)
@@ -91,26 +88,8 @@ public class ActionRequestUpdateOfSensor extends AbstractDigitalAction
 
     /** {@inheritDoc} */
     @Override
-    public void registerListenersForThisClass() {
-        _selectNamedBean.registerListeners();
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void unregisterListenersForThisClass() {
-        _selectNamedBean.unregisterListeners();
-    }
-
-    /** {@inheritDoc} */
-    @Override
     public void getUsageDetail(int level, NamedBean bean, List<NamedBeanUsageReport> report, NamedBean cdl) {
         _selectNamedBean.getUsageDetail(level, bean, report, cdl, this, LogixNG_SelectNamedBean.Type.Action);
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void propertyChange(PropertyChangeEvent evt) {
-        getConditionalNG().execute();
     }
 
     /** {@inheritDoc} */

--- a/java/src/jmri/jmrit/logixng/actions/ActionRequestUpdateOfTurnout.java
+++ b/java/src/jmri/jmrit/logixng/actions/ActionRequestUpdateOfTurnout.java
@@ -1,7 +1,5 @@
 package jmri.jmrit.logixng.actions;
 
-import java.beans.PropertyChangeEvent;
-import java.beans.PropertyChangeListener;
 import java.util.*;
 
 import jmri.*;
@@ -15,12 +13,11 @@ import jmri.util.ThreadingUtil;
  *
  * @author Daniel Bergqvist Copyright 2025
  */
-public class ActionRequestUpdateOfTurnout extends AbstractDigitalAction
-        implements PropertyChangeListener {
+public class ActionRequestUpdateOfTurnout extends AbstractDigitalAction {
 
     private final LogixNG_SelectNamedBean<Turnout> _selectNamedBean =
             new LogixNG_SelectNamedBean<>(
-                    this, Turnout.class, InstanceManager.getDefault(TurnoutManager.class), this);
+                    this, Turnout.class, InstanceManager.getDefault(TurnoutManager.class));
 
 
     public ActionRequestUpdateOfTurnout(String sys, String user)
@@ -91,26 +88,8 @@ public class ActionRequestUpdateOfTurnout extends AbstractDigitalAction
 
     /** {@inheritDoc} */
     @Override
-    public void registerListenersForThisClass() {
-        _selectNamedBean.registerListeners();
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void unregisterListenersForThisClass() {
-        _selectNamedBean.unregisterListeners();
-    }
-
-    /** {@inheritDoc} */
-    @Override
     public void getUsageDetail(int level, NamedBean bean, List<NamedBeanUsageReport> report, NamedBean cdl) {
         _selectNamedBean.getUsageDetail(level, bean, report, cdl, this, LogixNG_SelectNamedBean.Type.Action);
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void propertyChange(PropertyChangeEvent evt) {
-        getConditionalNG().execute();
     }
 
     /** {@inheritDoc} */

--- a/java/src/jmri/jmrit/logixng/actions/ActionSensor.java
+++ b/java/src/jmri/jmrit/logixng/actions/ActionSensor.java
@@ -1,7 +1,5 @@
 package jmri.jmrit.logixng.actions;
 
-import java.beans.PropertyChangeEvent;
-import java.beans.PropertyChangeListener;
 import java.util.*;
 
 import jmri.*;
@@ -15,15 +13,14 @@ import jmri.util.ThreadingUtil;
  *
  * @author Daniel Bergqvist Copyright 2018
  */
-public class ActionSensor extends AbstractDigitalAction
-        implements PropertyChangeListener {
+public class ActionSensor extends AbstractDigitalAction {
 
     private final LogixNG_SelectNamedBean<Sensor> _selectNamedBean =
             new LogixNG_SelectNamedBean<>(
-                    this, Sensor.class, InstanceManager.getDefault(SensorManager.class), this);
+                    this, Sensor.class, InstanceManager.getDefault(SensorManager.class));
 
     private final LogixNG_SelectEnum<SensorState> _selectEnum =
-            new LogixNG_SelectEnum<>(this, SensorState.values(), SensorState.Active, this);
+            new LogixNG_SelectEnum<>(this, SensorState.values(), SensorState.Active);
 
 
     public ActionSensor(String sys, String user)
@@ -111,20 +108,6 @@ public class ActionSensor extends AbstractDigitalAction
 
     /** {@inheritDoc} */
     @Override
-    public void registerListenersForThisClass() {
-        _selectNamedBean.registerListeners();
-        _selectEnum.registerListeners();
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void unregisterListenersForThisClass() {
-        _selectNamedBean.unregisterListeners();
-        _selectEnum.unregisterListeners();
-    }
-
-    /** {@inheritDoc} */
-    @Override
     public void disposeMe() {
     }
 
@@ -186,12 +169,6 @@ public class ActionSensor extends AbstractDigitalAction
     @Override
     public void getUsageDetail(int level, NamedBean bean, List<NamedBeanUsageReport> report, NamedBean cdl) {
         _selectNamedBean.getUsageDetail(level, bean, report, cdl, this, LogixNG_SelectNamedBean.Type.Action);
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void propertyChange(PropertyChangeEvent evt) {
-        getConditionalNG().execute();
     }
 
 //    private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(ActionSensor.class);

--- a/java/src/jmri/jmrit/logixng/actions/ActionSetReporter.java
+++ b/java/src/jmri/jmrit/logixng/actions/ActionSetReporter.java
@@ -25,10 +25,10 @@ public class ActionSetReporter extends AbstractDigitalAction
 
     private final LogixNG_SelectNamedBean<Reporter> _selectNamedBean =
             new LogixNG_SelectNamedBean<>(
-                    this, Reporter.class, InstanceManager.getDefault(ReporterManager.class), this);
+                    this, Reporter.class, InstanceManager.getDefault(ReporterManager.class));
     private final LogixNG_SelectNamedBean<Memory> _selectOtherMemoryNamedBean =
             new LogixNG_SelectNamedBean<>(
-                    this, Memory.class, InstanceManager.getDefault(MemoryManager.class), this);
+                    this, Memory.class, InstanceManager.getDefault(MemoryManager.class));
     private ReporterOperation _reporterOperation = ReporterOperation.SetToString;
     private String _otherConstantValue = "";
     private String _otherLocalVariable = "";
@@ -279,7 +279,6 @@ public class ActionSetReporter extends AbstractDigitalAction
     @Override
     public void registerListenersForThisClass() {
         if (!_listenersAreRegistered) {
-            _selectNamedBean.registerListeners();
             _selectOtherMemoryNamedBean.addPropertyChangeListener("value", this);
             _listenersAreRegistered = true;
         }
@@ -289,7 +288,6 @@ public class ActionSetReporter extends AbstractDigitalAction
     @Override
     public void unregisterListenersForThisClass() {
         if (_listenersAreRegistered) {
-            _selectNamedBean.unregisterListeners();
             _selectOtherMemoryNamedBean.removePropertyChangeListener("value", this);
             _listenersAreRegistered = false;
         }

--- a/java/src/jmri/jmrit/logixng/actions/ActionSignalHead.java
+++ b/java/src/jmri/jmrit/logixng/actions/ActionSignalHead.java
@@ -21,11 +21,11 @@ import jmri.util.TypeConversionUtil;
  * @author Daniel Bergqvist Copyright 2020
  */
 public class ActionSignalHead extends AbstractDigitalAction
-        implements PropertyChangeListener, VetoableChangeListener {
+        implements VetoableChangeListener {
 
     private final LogixNG_SelectNamedBean<SignalHead> _selectNamedBean =
             new LogixNG_SelectNamedBean<>(
-                    this, SignalHead.class, InstanceManager.getDefault(SignalHeadManager.class), this);
+                    this, SignalHead.class, InstanceManager.getDefault(SignalHeadManager.class));
 
     private NamedBeanAddressing _operationAddressing = NamedBeanAddressing.Direct;
     private OperationType _operationType = OperationType.Appearance;
@@ -43,7 +43,7 @@ public class ActionSignalHead extends AbstractDigitalAction
 
     private final LogixNG_SelectNamedBean<SignalHead> _selectExampleNamedBean =
             new LogixNG_SelectNamedBean<>(
-                    this, SignalHead.class, InstanceManager.getDefault(SignalHeadManager.class), this);
+                    this, SignalHead.class, InstanceManager.getDefault(SignalHeadManager.class));
 
 
     public ActionSignalHead(String sys, String user)
@@ -408,24 +408,6 @@ public class ActionSignalHead extends AbstractDigitalAction
     @Override
     public void setup() {
         // Do nothing
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void registerListenersForThisClass() {
-        _selectNamedBean.registerListeners();
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void unregisterListenersForThisClass() {
-        _selectNamedBean.unregisterListeners();
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void propertyChange(PropertyChangeEvent evt) {
-        getConditionalNG().execute();
     }
 
     /** {@inheritDoc} */

--- a/java/src/jmri/jmrit/logixng/actions/ActionSignalMast.java
+++ b/java/src/jmri/jmrit/logixng/actions/ActionSignalMast.java
@@ -19,11 +19,11 @@ import jmri.util.TypeConversionUtil;
  * @author Daniel Bergqvist Copyright 2020
  */
 public class ActionSignalMast extends AbstractDigitalAction
-        implements PropertyChangeListener, VetoableChangeListener {
+        implements VetoableChangeListener {
 
     private final LogixNG_SelectNamedBean<SignalMast> _selectNamedBean =
             new LogixNG_SelectNamedBean<>(
-                    this, SignalMast.class, InstanceManager.getDefault(SignalMastManager.class), this);
+                    this, SignalMast.class, InstanceManager.getDefault(SignalMastManager.class));
 
     private NamedBeanAddressing _operationAddressing = NamedBeanAddressing.Direct;
     private OperationType _operationType = OperationType.Aspect;
@@ -41,7 +41,7 @@ public class ActionSignalMast extends AbstractDigitalAction
 
     private final LogixNG_SelectNamedBean<SignalMast> _selectExampleNamedBean =
             new LogixNG_SelectNamedBean<>(
-                    this, SignalMast.class, InstanceManager.getDefault(SignalMastManager.class), this);
+                    this, SignalMast.class, InstanceManager.getDefault(SignalMastManager.class));
 
 
     public ActionSignalMast(String sys, String user)
@@ -389,24 +389,6 @@ public class ActionSignalMast extends AbstractDigitalAction
     @Override
     public void setup() {
         // Do nothing
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void registerListenersForThisClass() {
-        _selectNamedBean.registerListeners();
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void unregisterListenersForThisClass() {
-        _selectNamedBean.unregisterListeners();
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void propertyChange(PropertyChangeEvent evt) {
-        getConditionalNG().execute();
     }
 
     /** {@inheritDoc} */

--- a/java/src/jmri/jmrit/logixng/actions/ActionSound.java
+++ b/java/src/jmri/jmrit/logixng/actions/ActionSound.java
@@ -1,7 +1,5 @@
 package jmri.jmrit.logixng.actions;
 
-import java.beans.PropertyChangeEvent;
-import java.beans.PropertyChangeListener;
 import java.util.*;
 
 import javax.annotation.Nonnull;
@@ -21,11 +19,10 @@ import jmri.util.TypeConversionUtil;
  *
  * @author Daniel Bergqvist Copyright 2021
  */
-public class ActionSound extends AbstractDigitalAction
-        implements PropertyChangeListener {
+public class ActionSound extends AbstractDigitalAction {
 
     private final LogixNG_SelectEnum<Operation> _selectEnum =
-            new LogixNG_SelectEnum<>(this, Operation.values(), Operation.Play, this);
+            new LogixNG_SelectEnum<>(this, Operation.values(), Operation.Play);
 
     private NamedBeanAddressing _soundAddressing = NamedBeanAddressing.Direct;
     private String _sound = "";
@@ -234,24 +231,6 @@ public class ActionSound extends AbstractDigitalAction
 
     /** {@inheritDoc} */
     @Override
-    public void registerListenersForThisClass() {
-        if (!_listenersAreRegistered) {
-            _listenersAreRegistered = true;
-        }
-        _selectEnum.registerListeners();
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void unregisterListenersForThisClass() {
-        if (_listenersAreRegistered) {
-            _listenersAreRegistered = false;
-        }
-        _selectEnum.unregisterListeners();
-    }
-
-    /** {@inheritDoc} */
-    @Override
     public void firePropertyChange(String p, Object old, Object n) {
         super.firePropertyChange(p, old, n);
     }
@@ -277,12 +256,6 @@ public class ActionSound extends AbstractDigitalAction
             return _text;
         }
 
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void propertyChange(PropertyChangeEvent evt) {
-        getConditionalNG().execute();
     }
 
 //    private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(ActionSound.class);

--- a/java/src/jmri/jmrit/logixng/actions/ActionTable.java
+++ b/java/src/jmri/jmrit/logixng/actions/ActionTable.java
@@ -29,15 +29,15 @@ public class ActionTable extends AbstractDigitalAction
 
     private final LogixNG_SelectNamedBean<Memory> _selectMemoryNamedBean =
             new LogixNG_SelectNamedBean<>(
-                    this, Memory.class, InstanceManager.getDefault(MemoryManager.class), this);
+                    this, Memory.class, InstanceManager.getDefault(MemoryManager.class));
 
     private final LogixNG_SelectNamedBean<Block> _selectBlockNamedBean =
             new LogixNG_SelectNamedBean<>(
-                    this, Block.class, InstanceManager.getDefault(BlockManager.class), this);
+                    this, Block.class, InstanceManager.getDefault(BlockManager.class));
 
     private final LogixNG_SelectNamedBean<Reporter> _selectReporterNamedBean =
             new LogixNG_SelectNamedBean<>(
-                    this, Reporter.class, InstanceManager.getDefault(ReporterManager.class), this);
+                    this, Reporter.class, InstanceManager.getDefault(ReporterManager.class));
 
     private VariableOperation _variableOperation = VariableOperation.SetToString;
     private ConstantType _constantType = ConstantType.String;
@@ -395,9 +395,6 @@ public class ActionTable extends AbstractDigitalAction
                     && (_variableOperation == VariableOperation.CopyReporterToVariable)) {
                 _selectReporterNamedBean.addPropertyChangeListener("currentReport", this);
             }
-            _selectMemoryNamedBean.registerListeners();
-            _selectBlockNamedBean.registerListeners();
-            _selectReporterNamedBean.registerListeners();
             _listenersAreRegistered = true;
         }
     }
@@ -418,9 +415,6 @@ public class ActionTable extends AbstractDigitalAction
                     && (_variableOperation == VariableOperation.CopyReporterToVariable)) {
                 _selectReporterNamedBean.removePropertyChangeListener("currentReport", this);
             }
-            _selectMemoryNamedBean.unregisterListeners();
-            _selectBlockNamedBean.unregisterListeners();
-            _selectReporterNamedBean.unregisterListeners();
             _listenersAreRegistered = false;
         }
     }

--- a/java/src/jmri/jmrit/logixng/actions/ActionThrottleFunction.java
+++ b/java/src/jmri/jmrit/logixng/actions/ActionThrottleFunction.java
@@ -1,7 +1,5 @@
 package jmri.jmrit.logixng.actions;
 
-import java.beans.PropertyChangeEvent;
-import java.beans.PropertyChangeListener;
 import java.util.Locale;
 import java.util.Map;
 
@@ -15,8 +13,7 @@ import jmri.jmrit.logixng.util.LogixNG_SelectInteger;
  *
  * @author Daniel Bergqvist Copyright 2023
  */
-public final class ActionThrottleFunction extends AbstractDigitalAction
-        implements PropertyChangeListener {
+public final class ActionThrottleFunction extends AbstractDigitalAction {
 
     private SystemConnectionMemo _memo;
     private ThrottleManager _throttleManager;
@@ -26,10 +23,10 @@ public final class ActionThrottleFunction extends AbstractDigitalAction
     private DccThrottle _throttle;
     private ThrottleListener _throttleListener;
 
-    private final LogixNG_SelectInteger _selectAddress = new LogixNG_SelectInteger(this, this);
-    private final LogixNG_SelectInteger _selectFunction = new LogixNG_SelectInteger(this, this);
+    private final LogixNG_SelectInteger _selectAddress = new LogixNG_SelectInteger(this);
+    private final LogixNG_SelectInteger _selectFunction = new LogixNG_SelectInteger(this);
     private final LogixNG_SelectEnum<FunctionState> _selectOnOff =
-            new LogixNG_SelectEnum<>(this, FunctionState.values(), FunctionState.On, this);
+            new LogixNG_SelectEnum<>(this, FunctionState.values(), FunctionState.On);
 
 
     public ActionThrottleFunction(String sys, String user) {
@@ -195,24 +192,6 @@ public final class ActionThrottleFunction extends AbstractDigitalAction
     @Override
     public void setup() {
         // Do nothing
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void registerListenersForThisClass() {
-        _listenersAreRegistered = true;
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void unregisterListenersForThisClass() {
-        _listenersAreRegistered = false;
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void propertyChange(PropertyChangeEvent evt) {
-        getConditionalNG().execute();
     }
 
     /** {@inheritDoc} */

--- a/java/src/jmri/jmrit/logixng/actions/ActionTurnout.java
+++ b/java/src/jmri/jmrit/logixng/actions/ActionTurnout.java
@@ -16,13 +16,13 @@ import jmri.util.ThreadingUtil;
  * @author Daniel Bergqvist Copyright 2018
  */
 public class ActionTurnout extends AbstractDigitalAction
-        implements PropertyChangeListener, VetoableChangeListener {
+        implements VetoableChangeListener {
 
     private final LogixNG_SelectNamedBean<Turnout> _selectNamedBean =
             new LogixNG_SelectNamedBean<>(
-                    this, Turnout.class, InstanceManager.getDefault(TurnoutManager.class), this);
+                    this, Turnout.class, InstanceManager.getDefault(TurnoutManager.class));
     private final LogixNG_SelectEnum<TurnoutState> _selectEnum =
-            new LogixNG_SelectEnum<>(this, TurnoutState.values(), TurnoutState.Thrown, this);
+            new LogixNG_SelectEnum<>(this, TurnoutState.values(), TurnoutState.Thrown);
 
 
     public ActionTurnout(String sys, String user)
@@ -153,26 +153,6 @@ public class ActionTurnout extends AbstractDigitalAction
     public void getUsageDetail(int level, NamedBean bean, List<NamedBeanUsageReport> report, NamedBean cdl) {
         log.debug("getUsageReport :: ActionTurnout: bean = {}, report = {}", cdl, report);
         _selectNamedBean.getUsageDetail(level, bean, report, cdl, this, LogixNG_SelectNamedBean.Type.Action);
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void registerListenersForThisClass() {
-        _selectNamedBean.registerListeners();
-        _selectEnum.registerListeners();
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void unregisterListenersForThisClass() {
-        _selectNamedBean.unregisterListeners();
-        _selectEnum.unregisterListeners();
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void propertyChange(PropertyChangeEvent evt) {
-        getConditionalNG().execute();
     }
 
     private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(ActionTurnout.class);

--- a/java/src/jmri/jmrit/logixng/actions/ActionTurnoutLock.java
+++ b/java/src/jmri/jmrit/logixng/actions/ActionTurnoutLock.java
@@ -1,7 +1,5 @@
 package jmri.jmrit.logixng.actions;
 
-import java.beans.PropertyChangeEvent;
-import java.beans.PropertyChangeListener;
 import java.util.*;
 
 import jmri.*;
@@ -15,15 +13,14 @@ import jmri.util.ThreadingUtil;
  *
  * @author Daniel Bergqvist Copyright 2021
  */
-public class ActionTurnoutLock extends AbstractDigitalAction
-        implements PropertyChangeListener {
+public class ActionTurnoutLock extends AbstractDigitalAction {
 
     private final LogixNG_SelectNamedBean<Turnout> _selectNamedBean =
             new LogixNG_SelectNamedBean<>(
-                    this, Turnout.class, InstanceManager.getDefault(TurnoutManager.class), this);
+                    this, Turnout.class, InstanceManager.getDefault(TurnoutManager.class));
 
     private final LogixNG_SelectEnum<TurnoutLock> _selectEnum =
-            new LogixNG_SelectEnum<>(this, TurnoutLock.values(), TurnoutLock.Unlock, this);
+            new LogixNG_SelectEnum<>(this, TurnoutLock.values(), TurnoutLock.Unlock);
 
 
     public ActionTurnoutLock(String sys, String user)
@@ -118,20 +115,6 @@ public class ActionTurnoutLock extends AbstractDigitalAction
 
     /** {@inheritDoc} */
     @Override
-    public void registerListenersForThisClass() {
-        _selectNamedBean.registerListeners();
-        _selectEnum.registerListeners();
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void unregisterListenersForThisClass() {
-        _selectNamedBean.unregisterListeners();
-        _selectEnum.unregisterListeners();
-    }
-
-    /** {@inheritDoc} */
-    @Override
     public void disposeMe() {
     }
 
@@ -158,12 +141,6 @@ public class ActionTurnoutLock extends AbstractDigitalAction
     @Override
     public void getUsageDetail(int level, NamedBean bean, List<NamedBeanUsageReport> report, NamedBean cdl) {
         _selectNamedBean.getUsageDetail(level, bean, report, cdl, this, LogixNG_SelectNamedBean.Type.Action);
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void propertyChange(PropertyChangeEvent evt) {
-        getConditionalNG().execute();
     }
 
 //    private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(ActionTurnoutLock.class);

--- a/java/src/jmri/jmrit/logixng/actions/ActionWarrant.java
+++ b/java/src/jmri/jmrit/logixng/actions/ActionWarrant.java
@@ -30,14 +30,14 @@ public class ActionWarrant extends AbstractDigitalAction
 
     private final LogixNG_SelectNamedBean<Warrant> _selectNamedBean =
             new LogixNG_SelectNamedBean<>(
-                    this, Warrant.class, InstanceManager.getDefault(WarrantManager.class), this);
+                    this, Warrant.class, InstanceManager.getDefault(WarrantManager.class));
 
     private final LogixNG_SelectEnum<DirectOperation> _selectEnum =
-            new LogixNG_SelectEnum<>(this, DirectOperation.values(), DirectOperation.AllocateWarrantRoute, this);
+            new LogixNG_SelectEnum<>(this, DirectOperation.values(), DirectOperation.AllocateWarrantRoute);
 
     private final LogixNG_SelectNamedBean<Memory> _selectMemoryNamedBean =
             new LogixNG_SelectNamedBean<>(
-                    this, Memory.class, InstanceManager.getDefault(MemoryManager.class), this);
+                    this, Memory.class, InstanceManager.getDefault(MemoryManager.class));
 
     private NamedBeanAddressing _dataAddressing = NamedBeanAddressing.Direct;
     private String _dataReference = "";
@@ -381,16 +381,12 @@ public class ActionWarrant extends AbstractDigitalAction
     /** {@inheritDoc} */
     @Override
     public void registerListenersForThisClass() {
-        _selectNamedBean.registerListeners();
-        _selectEnum.registerListeners();
         _selectMemoryNamedBean.addPropertyChangeListener("value", this);
     }
 
     /** {@inheritDoc} */
     @Override
     public void unregisterListenersForThisClass() {
-        _selectNamedBean.unregisterListeners();
-        _selectEnum.unregisterListeners();
         _selectMemoryNamedBean.removePropertyChangeListener("value", this);
     }
 

--- a/java/src/jmri/jmrit/logixng/actions/AnalogActionLightIntensity.java
+++ b/java/src/jmri/jmrit/logixng/actions/AnalogActionLightIntensity.java
@@ -1,7 +1,5 @@
 package jmri.jmrit.logixng.actions;
 
-import java.beans.PropertyChangeEvent;
-import java.beans.PropertyChangeListener;
 import java.util.*;
 
 import jmri.*;
@@ -13,14 +11,13 @@ import jmri.jmrit.logixng.util.LogixNG_SelectNamedBean;
  *
  * @author Daniel Bergqvist Copyright 2021
  */
-public class AnalogActionLightIntensity extends AbstractAnalogAction
-        implements PropertyChangeListener {
+public class AnalogActionLightIntensity extends AbstractAnalogAction {
 
     public static final int INTENSITY_SOCKET = 0;
 
     private final LogixNG_SelectNamedBean<VariableLight> _selectNamedBean =
             new LogixNG_SelectNamedBean<>(
-                    this, VariableLight.class, InstanceManager.getDefault(VariableLightManager.class), this);
+                    this, VariableLight.class, InstanceManager.getDefault(VariableLightManager.class));
 
 
     public AnalogActionLightIntensity(String sys, String user) {
@@ -97,27 +94,7 @@ public class AnalogActionLightIntensity extends AbstractAnalogAction
 
     /** {@inheritDoc} */
     @Override
-    public void registerListenersForThisClass() {
-        _selectNamedBean.registerListeners();
-        _listenersAreRegistered = true;
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void unregisterListenersForThisClass() {
-        _selectNamedBean.unregisterListeners();
-        _listenersAreRegistered = false;
-    }
-
-    /** {@inheritDoc} */
-    @Override
     public void disposeMe() {
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void propertyChange(PropertyChangeEvent evt) {
-        getConditionalNG().execute();
     }
 
 //    private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(AnalogActionLightIntensity.class);

--- a/java/src/jmri/jmrit/logixng/actions/AnalogActionMemory.java
+++ b/java/src/jmri/jmrit/logixng/actions/AnalogActionMemory.java
@@ -1,7 +1,5 @@
 package jmri.jmrit.logixng.actions;
 
-import java.beans.PropertyChangeEvent;
-import java.beans.PropertyChangeListener;
 import java.util.*;
 
 import jmri.*;
@@ -14,12 +12,11 @@ import jmri.jmrit.logixng.util.parser.ParserException;
  *
  * @author Daniel Bergqvist Copyright 2018
  */
-public class AnalogActionMemory extends AbstractAnalogAction
-        implements PropertyChangeListener {
+public class AnalogActionMemory extends AbstractAnalogAction {
 
     private final LogixNG_SelectNamedBean<Memory> _selectNamedBean =
             new LogixNG_SelectNamedBean<>(
-                    this, Memory.class, InstanceManager.getDefault(MemoryManager.class), this);
+                    this, Memory.class, InstanceManager.getDefault(MemoryManager.class));
 
     public AnalogActionMemory(String sys, String user) {
         super(sys, user);
@@ -91,18 +88,6 @@ public class AnalogActionMemory extends AbstractAnalogAction
 
     /** {@inheritDoc} */
     @Override
-    public void registerListenersForThisClass() {
-        _selectNamedBean.registerListeners();
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void unregisterListenersForThisClass() {
-        _selectNamedBean.unregisterListeners();
-    }
-
-    /** {@inheritDoc} */
-    @Override
     public void disposeMe() {
     }
 
@@ -110,12 +95,6 @@ public class AnalogActionMemory extends AbstractAnalogAction
     @Override
     public void getUsageDetail(int level, NamedBean bean, List<NamedBeanUsageReport> report, NamedBean cdl) {
         _selectNamedBean.getUsageDetail(level, bean, report, cdl, this, LogixNG_SelectNamedBean.Type.Action);
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void propertyChange(PropertyChangeEvent evt) {
-        getConditionalNG().execute();
     }
 
 //    private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(AnalogActionMemory.class);

--- a/java/src/jmri/jmrit/logixng/actions/DigitalCallModule.java
+++ b/java/src/jmri/jmrit/logixng/actions/DigitalCallModule.java
@@ -19,11 +19,11 @@ import jmri.jmrit.logixng.util.parser.ParserException;
  * @author Daniel Bergqvist Copyright 2020
  */
 public class DigitalCallModule extends AbstractDigitalAction
-        implements PropertyChangeListener, VetoableChangeListener {
+        implements VetoableChangeListener {
 
     private final LogixNG_SelectNamedBean<Module> _selectNamedBean =
             new LogixNG_SelectNamedBean<>(
-                    this, Module.class, InstanceManager.getDefault(ModuleManager.class), this);
+                    this, Module.class, InstanceManager.getDefault(ModuleManager.class));
     private final List<ParameterData> _parameterData = new ArrayList<>();
 
     public DigitalCallModule(String sys, String user)
@@ -157,24 +157,6 @@ public class DigitalCallModule extends AbstractDigitalAction
     @Override
     public void setup() {
         // Do nothing
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void registerListenersForThisClass() {
-        _selectNamedBean.registerListeners();
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void unregisterListenersForThisClass() {
-        _selectNamedBean.unregisterListeners();
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void propertyChange(PropertyChangeEvent evt) {
-        getConditionalNG().execute();
     }
 
     /** {@inheritDoc} */

--- a/java/src/jmri/jmrit/logixng/actions/EnableLogix.java
+++ b/java/src/jmri/jmrit/logixng/actions/EnableLogix.java
@@ -1,7 +1,5 @@
 package jmri.jmrit.logixng.actions;
 
-import java.beans.PropertyChangeEvent;
-import java.beans.PropertyChangeListener;
 import java.util.*;
 
 import jmri.*;
@@ -16,15 +14,14 @@ import jmri.util.ThreadingUtil;
  *
  * @author Daniel Bergqvist Copyright 2021
  */
-public class EnableLogix extends AbstractDigitalAction
-        implements PropertyChangeListener {
+public class EnableLogix extends AbstractDigitalAction {
 
     private final LogixNG_SelectNamedBean<Logix> _selectNamedBean =
             new LogixNG_SelectNamedBean<>(
-                    this, Logix.class, InstanceManager.getDefault(LogixManager.class), this);
+                    this, Logix.class, InstanceManager.getDefault(LogixManager.class));
 
     private final LogixNG_SelectEnum<Operation> _selectEnum =
-            new LogixNG_SelectEnum<>(this, Operation.values(), Operation.Disable, this);
+            new LogixNG_SelectEnum<>(this, Operation.values(), Operation.Disable);
 
 
     public EnableLogix(String sys, String user)
@@ -107,20 +104,6 @@ public class EnableLogix extends AbstractDigitalAction
 
     /** {@inheritDoc} */
     @Override
-    public void registerListenersForThisClass() {
-        _selectNamedBean.registerListeners();
-        _selectEnum.registerListeners();
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void unregisterListenersForThisClass() {
-        _selectNamedBean.unregisterListeners();
-        _selectEnum.unregisterListeners();
-    }
-
-    /** {@inheritDoc} */
-    @Override
     public void disposeMe() {
     }
 
@@ -140,12 +123,6 @@ public class EnableLogix extends AbstractDigitalAction
             return _text;
         }
 
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void propertyChange(PropertyChangeEvent evt) {
-        getConditionalNG().execute();
     }
 
 //    private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(EnableLogix.class);

--- a/java/src/jmri/jmrit/logixng/actions/EnableLogixNG.java
+++ b/java/src/jmri/jmrit/logixng/actions/EnableLogixNG.java
@@ -1,7 +1,5 @@
 package jmri.jmrit.logixng.actions;
 
-import java.beans.PropertyChangeEvent;
-import java.beans.PropertyChangeListener;
 import java.util.*;
 
 import jmri.*;
@@ -15,15 +13,14 @@ import jmri.util.ThreadingUtil;
  *
  * @author Daniel Bergqvist Copyright 2024
  */
-public class EnableLogixNG extends AbstractDigitalAction
-        implements PropertyChangeListener {
+public class EnableLogixNG extends AbstractDigitalAction {
 
     private final LogixNG_SelectNamedBean<LogixNG> _selectNamedBean =
             new LogixNG_SelectNamedBean<>(
-                    this, LogixNG.class, InstanceManager.getDefault(LogixNG_Manager.class), this);
+                    this, LogixNG.class, InstanceManager.getDefault(LogixNG_Manager.class));
 
     private final LogixNG_SelectEnum<Operation> _selectEnum =
-            new LogixNG_SelectEnum<>(this, Operation.values(), Operation.Disable, this);
+            new LogixNG_SelectEnum<>(this, Operation.values(), Operation.Disable);
 
 
     public EnableLogixNG(String sys, String user)
@@ -103,20 +100,6 @@ public class EnableLogixNG extends AbstractDigitalAction
 
     /** {@inheritDoc} */
     @Override
-    public void registerListenersForThisClass() {
-        _selectNamedBean.registerListeners();
-        _selectEnum.registerListeners();
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void unregisterListenersForThisClass() {
-        _selectNamedBean.unregisterListeners();
-        _selectEnum.unregisterListeners();
-    }
-
-    /** {@inheritDoc} */
-    @Override
     public void disposeMe() {
     }
 
@@ -149,12 +132,6 @@ public class EnableLogixNG extends AbstractDigitalAction
             return _text;
         }
 
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void propertyChange(PropertyChangeEvent evt) {
-        getConditionalNG().execute();
     }
 
 //    private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(EnableLogix.class);

--- a/java/src/jmri/jmrit/logixng/actions/Error.java
+++ b/java/src/jmri/jmrit/logixng/actions/Error.java
@@ -1,7 +1,5 @@
 package jmri.jmrit.logixng.actions;
 
-import java.beans.PropertyChangeEvent;
-import java.beans.PropertyChangeListener;
 import java.util.Locale;
 import java.util.Map;
 
@@ -15,11 +13,10 @@ import jmri.jmrit.logixng.util.LogixNG_SelectString;
  *
  * @author Daniel Bergqvist Copyright 2022
  */
-public class Error extends AbstractDigitalAction
-        implements PropertyChangeListener {
+public class Error extends AbstractDigitalAction {
 
     private final LogixNG_SelectString _selectMessage =
-            new LogixNG_SelectString(this, this);
+            new LogixNG_SelectString(this);
 
     public Error(String sys, String user) {
         super(sys, user);
@@ -69,11 +66,6 @@ public class Error extends AbstractDigitalAction
     @Override
     public void setup() {
         // Do nothing
-    }
-
-    @Override
-    public void propertyChange(PropertyChangeEvent evt) {
-        getConditionalNG().execute();
     }
 
 //    private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(WebBrowser.class);

--- a/java/src/jmri/jmrit/logixng/actions/ExecuteAction.java
+++ b/java/src/jmri/jmrit/logixng/actions/ExecuteAction.java
@@ -18,7 +18,7 @@ public class ExecuteAction extends AbstractDigitalAction
 
     private final LogixNG_SelectNamedBean<MaleDigitalActionSocket> _selectNamedBean =
             new LogixNG_SelectNamedBean<>(
-                    this, MaleDigitalActionSocket.class, InstanceManager.getDefault(DigitalActionManager.class), this);
+                    this, MaleDigitalActionSocket.class, InstanceManager.getDefault(DigitalActionManager.class));
 
     public ExecuteAction(String sys, String user)
             throws BadUserNameException, BadSystemNameException {
@@ -106,7 +106,6 @@ public class ExecuteAction extends AbstractDigitalAction
     public void registerListenersForThisClass() {
         if (!_listenersAreRegistered) {
             _selectNamedBean.addPropertyChangeListener(PROPERTY_LAST_RESULT_CHANGED, this);
-            _selectNamedBean.registerListeners();
             _listenersAreRegistered = true;
         }
     }
@@ -116,7 +115,6 @@ public class ExecuteAction extends AbstractDigitalAction
     public void unregisterListenersForThisClass() {
         if (_listenersAreRegistered) {
             _selectNamedBean.removePropertyChangeListener(PROPERTY_LAST_RESULT_CHANGED, this);
-            _selectNamedBean.unregisterListeners();
             _listenersAreRegistered = false;
         }
     }

--- a/java/src/jmri/jmrit/logixng/actions/ExecuteProgram.java
+++ b/java/src/jmri/jmrit/logixng/actions/ExecuteProgram.java
@@ -1,6 +1,5 @@
 package jmri.jmrit.logixng.actions;
 
-import java.beans.*;
 import java.io.*;
 import java.util.*;
 
@@ -15,15 +14,14 @@ import jmri.util.FileUtil;
  *
  * @author Daniel Bergqvist Copyright 2025
  */
-public class ExecuteProgram extends AbstractDigitalAction
-        implements PropertyChangeListener {
+public class ExecuteProgram extends AbstractDigitalAction {
 
     private final LogixNG_SelectString _selectProgram =
-            new LogixNG_SelectString(this, this);
+            new LogixNG_SelectString(this);
     private final LogixNG_SelectStringList _selectParameters =
             new LogixNG_SelectStringList();
     private final LogixNG_SelectString _selectWorkingDirectory =
-            new LogixNG_SelectString(this, "", this);
+            new LogixNG_SelectString(this, "");
 
 
     public ExecuteProgram(String sys, String user)
@@ -113,30 +111,6 @@ public class ExecuteProgram extends AbstractDigitalAction
     @Override
     public void setup() {
         // Do nothing
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void registerListenersForThisClass() {
-        if (!_listenersAreRegistered) {
-            _selectProgram.registerListeners();
-            _selectWorkingDirectory.registerListeners();
-            _listenersAreRegistered = true;
-        }
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void unregisterListenersForThisClass() {
-        _selectProgram.unregisterListeners();
-        _selectWorkingDirectory.unregisterListeners();
-        _listenersAreRegistered = false;
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void propertyChange(PropertyChangeEvent evt) {
-        getConditionalNG().execute();
     }
 
     /** {@inheritDoc} */

--- a/java/src/jmri/jmrit/logixng/actions/ForEach.java
+++ b/java/src/jmri/jmrit/logixng/actions/ForEach.java
@@ -1,7 +1,5 @@
 package jmri.jmrit.logixng.actions;
 
-import java.beans.PropertyChangeEvent;
-import java.beans.PropertyChangeListener;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -17,14 +15,14 @@ import jmri.util.ThreadingUtil;
  * @author Daniel Bergqvist Copyright 2018
  */
 public class ForEach extends AbstractDigitalAction
-        implements FemaleSocketListener, PropertyChangeListener {
+        implements FemaleSocketListener {
 
     private final LogixNG_SelectString _selectVariable =
-            new LogixNG_SelectString(this, this);
+            new LogixNG_SelectString(this);
 
     private final LogixNG_SelectNamedBean<Memory> _selectMemoryNamedBean =
             new LogixNG_SelectNamedBean<>(
-                    this, Memory.class, InstanceManager.getDefault(MemoryManager.class), this);
+                    this, Memory.class, InstanceManager.getDefault(MemoryManager.class));
 
     private boolean _useCommonSource = true;
     private CommonManager _commonManager = CommonManager.Sensors;
@@ -321,39 +319,6 @@ public class ForEach extends AbstractDigitalAction
         }
     }
 
-    /** {@inheritDoc} */
-    @Override
-    public void registerListenersForThisClass() {
-        if (!_listenersAreRegistered) {
-            if (_userSpecifiedSource == UserSpecifiedSource.Memory) {
-                _selectMemoryNamedBean.registerListeners();
-            }
-            _listenersAreRegistered = true;
-        }
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void unregisterListenersForThisClass() {
-        if (_listenersAreRegistered) {
-            if (_userSpecifiedSource == UserSpecifiedSource.Memory) {
-                _selectMemoryNamedBean.unregisterListeners();
-            }
-            _listenersAreRegistered = false;
-        }
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void disposeMe() {
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void propertyChange(PropertyChangeEvent evt) {
-        getConditionalNG().execute();
-    }
-
 
     public enum UserSpecifiedSource {
         Variable(Bundle.getMessage("ForEach_UserSpecifiedSource_Variable")),
@@ -372,8 +337,6 @@ public class ForEach extends AbstractDigitalAction
         }
 
     }
-
-
 
 
     private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(ForEach.class);

--- a/java/src/jmri/jmrit/logixng/actions/ForEachWithDelay.java
+++ b/java/src/jmri/jmrit/logixng/actions/ForEachWithDelay.java
@@ -1,7 +1,5 @@
 package jmri.jmrit.logixng.actions;
 
-import java.beans.PropertyChangeEvent;
-import java.beans.PropertyChangeListener;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -18,14 +16,14 @@ import jmri.util.*;
  * @author Daniel Bergqvist Copyright 2025
  */
 public class ForEachWithDelay extends AbstractDigitalAction
-        implements FemaleSocketListener, PropertyChangeListener {
+        implements FemaleSocketListener {
 
     private final LogixNG_SelectString _selectVariable =
-            new LogixNG_SelectString(this, this);
+            new LogixNG_SelectString(this);
 
     private final LogixNG_SelectNamedBean<Memory> _selectMemoryNamedBean =
             new LogixNG_SelectNamedBean<>(
-                    this, Memory.class, InstanceManager.getDefault(MemoryManager.class), this);
+                    this, Memory.class, InstanceManager.getDefault(MemoryManager.class));
 
     private boolean _useCommonSource = true;
     private CommonManager _commonManager = CommonManager.Sensors;
@@ -502,35 +500,7 @@ public class ForEachWithDelay extends AbstractDigitalAction
 
     /** {@inheritDoc} */
     @Override
-    public void registerListenersForThisClass() {
-        if (!_listenersAreRegistered) {
-            if (_userSpecifiedSource == UserSpecifiedSource.Memory) {
-                _selectMemoryNamedBean.registerListeners();
-            }
-            _listenersAreRegistered = true;
-        }
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void unregisterListenersForThisClass() {
-        if (_listenersAreRegistered) {
-            if (_userSpecifiedSource == UserSpecifiedSource.Memory) {
-                _selectMemoryNamedBean.unregisterListeners();
-            }
-            _listenersAreRegistered = false;
-        }
-    }
-
-    /** {@inheritDoc} */
-    @Override
     public void disposeMe() {
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void propertyChange(PropertyChangeEvent evt) {
-        getConditionalNG().execute();
     }
 
 

--- a/java/src/jmri/jmrit/logixng/actions/ProgramOnMain.java
+++ b/java/src/jmri/jmrit/logixng/actions/ProgramOnMain.java
@@ -1,7 +1,5 @@
 package jmri.jmrit.logixng.actions;
 
-import java.beans.PropertyChangeEvent;
-import java.beans.PropertyChangeListener;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -18,7 +16,7 @@ import jmri.jmrit.logixng.util.LogixNG_SelectInteger;
  * @author Daniel Bergqvist Copyright 2024
  */
 public class ProgramOnMain extends AbstractDigitalAction
-        implements FemaleSocketListener, PropertyChangeListener {
+        implements FemaleSocketListener {
 
     private static final ResourceBundle rbx =
             ResourceBundle.getBundle("jmri.jmrit.logixng.implementation.ImplementationBundle");
@@ -30,10 +28,10 @@ public class ProgramOnMain extends AbstractDigitalAction
     private ThrottleManager _throttleManager;
     private final LogixNG_SelectComboBox _selectProgrammingMode;
     private final LogixNG_SelectEnum<LongOrShortAddress> _selectLongOrShortAddress =
-            new LogixNG_SelectEnum<>(this, LongOrShortAddress.values(), LongOrShortAddress.Auto, this);
-    private final LogixNG_SelectInteger _selectAddress = new LogixNG_SelectInteger(this, this);
-    private final LogixNG_SelectInteger _selectCV = new LogixNG_SelectInteger(this, this);
-    private final LogixNG_SelectInteger _selectValue = new LogixNG_SelectInteger(this, this);
+            new LogixNG_SelectEnum<>(this, LongOrShortAddress.values(), LongOrShortAddress.Auto);
+    private final LogixNG_SelectInteger _selectAddress = new LogixNG_SelectInteger(this);
+    private final LogixNG_SelectInteger _selectCV = new LogixNG_SelectInteger(this);
+    private final LogixNG_SelectInteger _selectValue = new LogixNG_SelectInteger(this);
     private String _localVariableForStatus = "";
     private boolean _wait = true;
     private final InternalFemaleSocket _internalSocket = new InternalFemaleSocket();
@@ -43,7 +41,7 @@ public class ProgramOnMain extends AbstractDigitalAction
 
         // The array is updated with correct values when setMemo() is called
         POMItem[] modes = {new POMItem("")};
-        _selectProgrammingMode = new LogixNG_SelectComboBox(this, modes, modes[0], this);
+        _selectProgrammingMode = new LogixNG_SelectComboBox(this, modes, modes[0]);
 
         // Set the _programmerManager and _throttleManager variables
         setMemo(null);
@@ -346,12 +344,6 @@ public class ProgramOnMain extends AbstractDigitalAction
             // This shouldn't happen and is a runtime error if it does.
             throw new RuntimeException("socket is already connected");
         }
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void propertyChange(PropertyChangeEvent evt) {
-        getConditionalNG().execute();
     }
 
 

--- a/java/src/jmri/jmrit/logixng/actions/ShutdownComputer.java
+++ b/java/src/jmri/jmrit/logixng/actions/ShutdownComputer.java
@@ -1,7 +1,5 @@
 package jmri.jmrit.logixng.actions;
 
-import java.beans.PropertyChangeEvent;
-import java.beans.PropertyChangeListener;
 import java.util.Locale;
 import java.util.Map;
 
@@ -15,11 +13,10 @@ import jmri.jmrit.logixng.util.parser.ParserException;
  *
  * @author Daniel Bergqvist Copyright 2018
  */
-public class ShutdownComputer extends AbstractDigitalAction
-        implements PropertyChangeListener {
+public class ShutdownComputer extends AbstractDigitalAction {
 
     private final LogixNG_SelectEnum<Operation> _selectEnum =
-            new LogixNG_SelectEnum<>(this, Operation.values(), Operation.ShutdownJMRI, this);
+            new LogixNG_SelectEnum<>(this, Operation.values(), Operation.ShutdownJMRI);
 
 
     public ShutdownComputer(String sys, String user)
@@ -106,18 +103,6 @@ public class ShutdownComputer extends AbstractDigitalAction
 
     /** {@inheritDoc} */
     @Override
-    public void registerListenersForThisClass() {
-        _selectEnum.registerListeners();
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void unregisterListenersForThisClass() {
-        _selectEnum.unregisterListeners();
-    }
-
-    /** {@inheritDoc} */
-    @Override
     public void disposeMe() {
     }
 
@@ -140,12 +125,6 @@ public class ShutdownComputer extends AbstractDigitalAction
             return _text;
         }
 
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void propertyChange(PropertyChangeEvent evt) {
-        getConditionalNG().execute();
     }
 
 //     private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(ShutdownComputer.class);

--- a/java/src/jmri/jmrit/logixng/actions/StringActionMemory.java
+++ b/java/src/jmri/jmrit/logixng/actions/StringActionMemory.java
@@ -1,7 +1,5 @@
 package jmri.jmrit.logixng.actions;
 
-import java.beans.PropertyChangeEvent;
-import java.beans.PropertyChangeListener;
 import java.util.*;
 
 import jmri.*;
@@ -14,12 +12,11 @@ import jmri.jmrit.logixng.util.parser.ParserException;
  *
  * @author Daniel Bergqvist Copyright 2018
  */
-public class StringActionMemory extends AbstractStringAction
-        implements PropertyChangeListener {
+public class StringActionMemory extends AbstractStringAction {
 
     private final LogixNG_SelectNamedBean<Memory> _selectNamedBean =
             new LogixNG_SelectNamedBean<>(
-                    this, Memory.class, InstanceManager.getDefault(MemoryManager.class), this);
+                    this, Memory.class, InstanceManager.getDefault(MemoryManager.class));
 
     public StringActionMemory(String sys, String user) {
         super(sys, user);
@@ -88,18 +85,6 @@ public class StringActionMemory extends AbstractStringAction
 
     /** {@inheritDoc} */
     @Override
-    public void registerListenersForThisClass() {
-        _selectNamedBean.registerListeners();
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void unregisterListenersForThisClass() {
-        _selectNamedBean.unregisterListeners();
-    }
-
-    /** {@inheritDoc} */
-    @Override
     public void disposeMe() {
     }
 
@@ -107,12 +92,6 @@ public class StringActionMemory extends AbstractStringAction
     @Override
     public void getUsageDetail(int level, NamedBean bean, List<NamedBeanUsageReport> report, NamedBean cdl) {
         _selectNamedBean.getUsageDetail(level, bean, report, cdl, this, LogixNG_SelectNamedBean.Type.Action);
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void propertyChange(PropertyChangeEvent evt) {
-        getConditionalNG().execute();
     }
 
 //    private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(StringActionMemory.class);

--- a/java/src/jmri/jmrit/logixng/actions/StringActionStringIO.java
+++ b/java/src/jmri/jmrit/logixng/actions/StringActionStringIO.java
@@ -1,7 +1,5 @@
 package jmri.jmrit.logixng.actions;
 
-import java.beans.PropertyChangeEvent;
-import java.beans.PropertyChangeListener;
 import java.util.*;
 
 import jmri.*;
@@ -14,12 +12,11 @@ import jmri.jmrit.logixng.util.parser.ParserException;
  *
  * @author Daniel Bergqvist Copyright 2021
  */
-public class StringActionStringIO extends AbstractStringAction
-        implements PropertyChangeListener {
+public class StringActionStringIO extends AbstractStringAction {
 
     private final LogixNG_SelectNamedBean<StringIO> _selectNamedBean =
             new LogixNG_SelectNamedBean<>(
-                    this, StringIO.class, InstanceManager.getDefault(StringIOManager.class), this);
+                    this, StringIO.class, InstanceManager.getDefault(StringIOManager.class));
 
     public StringActionStringIO(String sys, String user) {
         super(sys, user);
@@ -88,18 +85,6 @@ public class StringActionStringIO extends AbstractStringAction
 
     /** {@inheritDoc} */
     @Override
-    public void registerListenersForThisClass() {
-        _selectNamedBean.registerListeners();
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void unregisterListenersForThisClass() {
-        _selectNamedBean.unregisterListeners();
-    }
-
-    /** {@inheritDoc} */
-    @Override
     public void disposeMe() {
     }
 
@@ -107,12 +92,6 @@ public class StringActionStringIO extends AbstractStringAction
     @Override
     public void getUsageDetail(int level, NamedBean bean, List<NamedBeanUsageReport> report, NamedBean cdl) {
         _selectNamedBean.getUsageDetail(level, bean, report, cdl, this, LogixNG_SelectNamedBean.Type.Action);
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void propertyChange(PropertyChangeEvent evt) {
-        getConditionalNG().execute();
     }
 
 //    private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(StringActionStringIO.class);

--- a/java/src/jmri/jmrit/logixng/actions/TableForEach.java
+++ b/java/src/jmri/jmrit/logixng/actions/TableForEach.java
@@ -1,7 +1,5 @@
 package jmri.jmrit.logixng.actions;
 
-import java.beans.PropertyChangeEvent;
-import java.beans.PropertyChangeListener;
 import java.util.*;
 
 import javax.annotation.Nonnull;
@@ -19,11 +17,11 @@ import jmri.util.TypeConversionUtil;
  * @author Daniel Bergqvist Copyright 2018
  */
 public class TableForEach extends AbstractDigitalAction
-        implements FemaleSocketListener, PropertyChangeListener {
+        implements FemaleSocketListener {
 
     private final LogixNG_SelectNamedBean<NamedTable> _selectNamedBean =
             new LogixNG_SelectNamedBean<>(
-                    this, NamedTable.class, InstanceManager.getDefault(NamedTableManager.class), this);
+                    this, NamedTable.class, InstanceManager.getDefault(NamedTableManager.class));
     private NamedBeanAddressing _rowOrColumnAddressing = NamedBeanAddressing.Direct;
     private TableRowOrColumn _tableRowOrColumn = TableRowOrColumn.Row;
     private String _rowOrColumnName = "";
@@ -382,25 +380,7 @@ public class TableForEach extends AbstractDigitalAction
 
     /** {@inheritDoc} */
     @Override
-    public void registerListenersForThisClass() {
-        _selectNamedBean.registerListeners();
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void unregisterListenersForThisClass() {
-        _selectNamedBean.unregisterListeners();
-    }
-
-    /** {@inheritDoc} */
-    @Override
     public void disposeMe() {
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void propertyChange(PropertyChangeEvent evt) {
-        getConditionalNG().execute();
     }
 
     private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(TableForEach.class);

--- a/java/src/jmri/jmrit/logixng/actions/Timeout.java
+++ b/java/src/jmri/jmrit/logixng/actions/Timeout.java
@@ -2,8 +2,6 @@ package jmri.jmrit.logixng.actions;
 
 import jmri.util.TimerUnit;
 
-import java.beans.PropertyChangeEvent;
-import java.beans.PropertyChangeListener;
 import java.util.*;
 
 import jmri.InstanceManager;
@@ -19,12 +17,12 @@ import jmri.util.TimerUtil;
  * @author Daniel Bergqvist Copyright 2021
  */
 public class Timeout extends AbstractDigitalAction
-        implements FemaleSocketListener, PropertyChangeListener {
+        implements FemaleSocketListener {
 
     private ProtectedTimerTask _timerTask;
-    private final LogixNG_SelectInteger _selectDelay = new LogixNG_SelectInteger(this, this);
+    private final LogixNG_SelectInteger _selectDelay = new LogixNG_SelectInteger(this);
     private final LogixNG_SelectEnum<TimerUnit> _selectTimerUnit =
-            new LogixNG_SelectEnum<>(this, TimerUnit.values(), TimerUnit.MilliSeconds, this);
+            new LogixNG_SelectEnum<>(this, TimerUnit.values(), TimerUnit.MilliSeconds);
     private String _expressionSocketSystemName;
     private String _actionSocketSystemName;
     private final FemaleDigitalExpressionSocket _expressionSocket;
@@ -275,26 +273,6 @@ public class Timeout extends AbstractDigitalAction
             // This shouldn't happen and is a runtime error if it does.
             throw new RuntimeException("socket is already connected");
         }
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void registerListenersForThisClass() {
-        _selectDelay.registerListeners();
-        _selectTimerUnit.registerListeners();
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void unregisterListenersForThisClass() {
-        _selectDelay.unregisterListeners();
-        _selectTimerUnit.unregisterListeners();
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void propertyChange(PropertyChangeEvent evt) {
-        getConditionalNG().execute();
     }
 
     /** {@inheritDoc} */

--- a/java/src/jmri/jmrit/logixng/actions/TriggerRoute.java
+++ b/java/src/jmri/jmrit/logixng/actions/TriggerRoute.java
@@ -1,7 +1,5 @@
 package jmri.jmrit.logixng.actions;
 
-import java.beans.PropertyChangeEvent;
-import java.beans.PropertyChangeListener;
 import java.util.*;
 
 import jmri.*;
@@ -19,15 +17,14 @@ import jmri.util.ThreadingUtil;
  *
  * @author Daniel Bergqvist Copyright 2021
  */
-public class TriggerRoute extends AbstractDigitalAction
-        implements PropertyChangeListener {
+public class TriggerRoute extends AbstractDigitalAction {
 
     private final LogixNG_SelectNamedBean<Route> _selectNamedBean =
             new LogixNG_SelectNamedBean<>(
-                    this, Route.class, InstanceManager.getDefault(RouteManager.class), this);
+                    this, Route.class, InstanceManager.getDefault(RouteManager.class));
 
     private final LogixNG_SelectEnum<Operation> _selectEnum =
-            new LogixNG_SelectEnum<>(this, Operation.values(), Operation.TriggerRoute, this);
+            new LogixNG_SelectEnum<>(this, Operation.values(), Operation.TriggerRoute);
 
 
     public TriggerRoute(String sys, String user)
@@ -111,20 +108,6 @@ public class TriggerRoute extends AbstractDigitalAction
 
     /** {@inheritDoc} */
     @Override
-    public void registerListenersForThisClass() {
-        _selectNamedBean.registerListeners();
-        _selectEnum.registerListeners();
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void unregisterListenersForThisClass() {
-        _selectNamedBean.unregisterListeners();
-        _selectEnum.unregisterListeners();
-    }
-
-    /** {@inheritDoc} */
-    @Override
     public void disposeMe() {
     }
 
@@ -149,12 +132,6 @@ public class TriggerRoute extends AbstractDigitalAction
     @Override
     public void getUsageDetail(int level, NamedBean bean, List<NamedBeanUsageReport> report, NamedBean cdl) {
         _selectNamedBean.getUsageDetail(level, bean, report, cdl, this, LogixNG_SelectNamedBean.Type.Action);
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void propertyChange(PropertyChangeEvent evt) {
-        getConditionalNG().execute();
     }
 
 //    private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(TriggerRoute.class);

--- a/java/src/jmri/jmrit/logixng/actions/ValidationError.java
+++ b/java/src/jmri/jmrit/logixng/actions/ValidationError.java
@@ -1,7 +1,5 @@
 package jmri.jmrit.logixng.actions;
 
-import java.beans.PropertyChangeEvent;
-import java.beans.PropertyChangeListener;
 import java.util.Locale;
 import java.util.Map;
 
@@ -16,11 +14,9 @@ import jmri.jmrit.logixng.util.LogixNG_SelectString;
  * @author Daniel Bergqvist Copyright 2025
  * @since 5.15.1
  */
-public class ValidationError extends AbstractDigitalAction
-        implements PropertyChangeListener {
+public class ValidationError extends AbstractDigitalAction {
 
-    private final LogixNG_SelectString _selectMessage =
-            new LogixNG_SelectString(this, this);
+    private final LogixNG_SelectString _selectMessage = new LogixNG_SelectString(this);
 
     public ValidationError(String sys, String user) {
         super(sys, user);
@@ -70,11 +66,6 @@ public class ValidationError extends AbstractDigitalAction
     @Override
     public void setup() {
         // Do nothing
-    }
-
-    @Override
-    public void propertyChange(PropertyChangeEvent evt) {
-        getConditionalNG().execute();
     }
 
 //    private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(ValidationError.class);

--- a/java/src/jmri/jmrit/logixng/actions/WebRequest.java
+++ b/java/src/jmri/jmrit/logixng/actions/WebRequest.java
@@ -27,7 +27,7 @@ import jmri.util.ThreadingUtil;
  * @author Daniel Bergqvist Copyright 2023
  */
 public class WebRequest extends AbstractDigitalAction
-        implements FemaleSocketListener, PropertyChangeListener, VetoableChangeListener {
+        implements FemaleSocketListener, VetoableChangeListener {
 
     private static final ResourceBundle rbx =
             ResourceBundle.getBundle("jmri.jmrit.logixng.implementation.ImplementationBundle");
@@ -37,23 +37,21 @@ public class WebRequest extends AbstractDigitalAction
 
     // Note that it's valid if the url has parameters as well, like https://www.mysite.org/somepage.php?name=Jim&city=Boston
     // The parameters are the string after the question mark.
-    private final LogixNG_SelectString _selectUrl =
-            new LogixNG_SelectString(this, this);
+    private final LogixNG_SelectString _selectUrl = new LogixNG_SelectString(this);
 
-    private final LogixNG_SelectCharset _selectCharset =
-            new LogixNG_SelectCharset(this, this);
+    private final LogixNG_SelectCharset _selectCharset = new LogixNG_SelectCharset(this);
 
     private final LogixNG_SelectEnum<RequestMethodType> _selectRequestMethod =
-            new LogixNG_SelectEnum<>(this, RequestMethodType.values(), RequestMethodType.Get, this);
+            new LogixNG_SelectEnum<>(this, RequestMethodType.values(), RequestMethodType.Get);
 
     private final LogixNG_SelectString _selectUserAgent =
-            new LogixNG_SelectString(this, DEFAULT_USER_AGENT, this);
+            new LogixNG_SelectString(this, DEFAULT_USER_AGENT);
 
     private final LogixNG_SelectEnum<ReplyType> _selectReplyType =
-            new LogixNG_SelectEnum<>(this, ReplyType.values(), ReplyType.String, this);
+            new LogixNG_SelectEnum<>(this, ReplyType.values(), ReplyType.String);
 
     private final LogixNG_SelectEnum<LineEnding> _selectLineEnding =
-            new LogixNG_SelectEnum<>(this, LineEnding.values(), LineEnding.System, this);
+            new LogixNG_SelectEnum<>(this, LineEnding.values(), LineEnding.System);
 
     private final List<Parameter> _parameters = new ArrayList<>();
 
@@ -519,24 +517,6 @@ public class WebRequest extends AbstractDigitalAction
             // This shouldn't happen and is a runtime error if it does.
             throw new RuntimeException("socket is already connected");
         }
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void registerListenersForThisClass() {
-        // Do nothing
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void unregisterListenersForThisClass() {
-        // Do nothing
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void propertyChange(PropertyChangeEvent evt) {
-        getConditionalNG().execute();
     }
 
     /** {@inheritDoc} */

--- a/java/src/jmri/jmrit/logixng/expressions/AnalogExpressionAnalogIO.java
+++ b/java/src/jmri/jmrit/logixng/expressions/AnalogExpressionAnalogIO.java
@@ -18,7 +18,7 @@ public class AnalogExpressionAnalogIO extends AbstractAnalogExpression
 
     private final LogixNG_SelectNamedBean<AnalogIO> _selectNamedBean =
             new LogixNG_SelectNamedBean<>(
-                    this, AnalogIO.class, InstanceManager.getDefault(AnalogIOManager.class), this);
+                    this, AnalogIO.class, InstanceManager.getDefault(AnalogIOManager.class));
 
     public AnalogExpressionAnalogIO(String sys, String user)
             throws BadUserNameException, BadSystemNameException {
@@ -95,7 +95,6 @@ public class AnalogExpressionAnalogIO extends AbstractAnalogExpression
     public void registerListenersForThisClass() {
         if (!_listenersAreRegistered) {
             _selectNamedBean.addPropertyChangeListener("value", this);
-            _selectNamedBean.registerListeners();
             _listenersAreRegistered = true;
         }
     }
@@ -105,7 +104,6 @@ public class AnalogExpressionAnalogIO extends AbstractAnalogExpression
     public void unregisterListenersForThisClass() {
         if (_listenersAreRegistered) {
             _selectNamedBean.removePropertyChangeListener("value", this);
-            _selectNamedBean.unregisterListeners();
             _listenersAreRegistered = false;
         }
     }

--- a/java/src/jmri/jmrit/logixng/expressions/AnalogExpressionLocalVariable.java
+++ b/java/src/jmri/jmrit/logixng/expressions/AnalogExpressionLocalVariable.java
@@ -1,7 +1,5 @@
 package jmri.jmrit.logixng.expressions;
 
-import java.beans.PropertyChangeEvent;
-import java.beans.PropertyChangeListener;
 import java.util.*;
 
 import jmri.*;
@@ -13,11 +11,9 @@ import jmri.jmrit.logixng.util.LogixNG_SelectString;
  *
  * @author Daniel Bergqvist Copyright 2022
  */
-public class AnalogExpressionLocalVariable extends AbstractAnalogExpression
-        implements PropertyChangeListener {
+public class AnalogExpressionLocalVariable extends AbstractAnalogExpression {
 
-    private final LogixNG_SelectString _selectNamedBean =
-            new LogixNG_SelectString(this, this);
+    private final LogixNG_SelectString _selectNamedBean = new LogixNG_SelectString(this);
 
     public AnalogExpressionLocalVariable(String sys, String user)
             throws BadUserNameException, BadSystemNameException {
@@ -90,26 +86,6 @@ public class AnalogExpressionLocalVariable extends AbstractAnalogExpression
     @Override
     public void setup() {
         // Do nothing
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void registerListenersForThisClass() {
-        // Do nothing
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void unregisterListenersForThisClass() {
-        // Do nothing
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void propertyChange(PropertyChangeEvent evt) {
-        if (getTriggerOnChange()) {
-            getConditionalNG().execute();
-        }
     }
 
     /** {@inheritDoc} */

--- a/java/src/jmri/jmrit/logixng/expressions/AnalogExpressionMemory.java
+++ b/java/src/jmri/jmrit/logixng/expressions/AnalogExpressionMemory.java
@@ -18,7 +18,7 @@ public class AnalogExpressionMemory extends AbstractAnalogExpression
 
     private final LogixNG_SelectNamedBean<Memory> _selectNamedBean =
             new LogixNG_SelectNamedBean<>(
-                    this, Memory.class, InstanceManager.getDefault(MemoryManager.class), this);
+                    this, Memory.class, InstanceManager.getDefault(MemoryManager.class));
 
     public AnalogExpressionMemory(String sys, String user)
             throws BadUserNameException, BadSystemNameException {
@@ -95,7 +95,6 @@ public class AnalogExpressionMemory extends AbstractAnalogExpression
     public void registerListenersForThisClass() {
         if (!_listenersAreRegistered) {
             _selectNamedBean.addPropertyChangeListener("value", this);
-            _selectNamedBean.registerListeners();
             _listenersAreRegistered = true;
         }
     }
@@ -105,7 +104,6 @@ public class AnalogExpressionMemory extends AbstractAnalogExpression
     public void unregisterListenersForThisClass() {
         if (_listenersAreRegistered) {
             _selectNamedBean.removePropertyChangeListener("value", this);
-            _selectNamedBean.unregisterListeners();
             _listenersAreRegistered = false;
         }
     }

--- a/java/src/jmri/jmrit/logixng/expressions/DigitalCallModule.java
+++ b/java/src/jmri/jmrit/logixng/expressions/DigitalCallModule.java
@@ -19,11 +19,11 @@ import jmri.jmrit.logixng.util.parser.ParserException;
  * @author Daniel Bergqvist Copyright 2021
  */
 public class DigitalCallModule extends AbstractDigitalExpression
-        implements PropertyChangeListener, VetoableChangeListener {
+        implements VetoableChangeListener {
 
     private final LogixNG_SelectNamedBean<Module> _selectNamedBean =
             new LogixNG_SelectNamedBean<>(
-                    this, Module.class, InstanceManager.getDefault(ModuleManager.class), this);
+                    this, Module.class, InstanceManager.getDefault(ModuleManager.class));
     private final List<ParameterData> _parameterData = new ArrayList<>();
 
     public DigitalCallModule(String sys, String user)
@@ -155,24 +155,6 @@ public class DigitalCallModule extends AbstractDigitalExpression
     @Override
     public void setup() {
         // Do nothing
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void registerListenersForThisClass() {
-        _selectNamedBean.registerListeners();
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void unregisterListenersForThisClass() {
-        _selectNamedBean.unregisterListeners();
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void propertyChange(PropertyChangeEvent evt) {
-        getConditionalNG().execute();
     }
 
     /** {@inheritDoc} */

--- a/java/src/jmri/jmrit/logixng/expressions/ExpressionAudio.java
+++ b/java/src/jmri/jmrit/logixng/expressions/ExpressionAudio.java
@@ -26,7 +26,7 @@ public class ExpressionAudio extends AbstractDigitalExpression
 
     private final LogixNG_SelectNamedBean<Audio> _selectNamedBean =
             new LogixNG_SelectNamedBean<>(
-                    this, Audio.class, InstanceManager.getDefault(AudioManager.class), this);
+                    this, Audio.class, InstanceManager.getDefault(AudioManager.class));
 
     private boolean _hasChangedState = false;
 
@@ -271,7 +271,6 @@ public class ExpressionAudio extends AbstractDigitalExpression
     public void registerListenersForThisClass() {
         if (!_listenersAreRegistered) {
             _selectNamedBean.addPropertyChangeListener(this);
-            _selectNamedBean.registerListeners();
             _listenersAreRegistered = true;
         }
     }
@@ -281,7 +280,6 @@ public class ExpressionAudio extends AbstractDigitalExpression
     public void unregisterListenersForThisClass() {
         if (_listenersAreRegistered) {
             _selectNamedBean.removePropertyChangeListener(this);
-            _selectNamedBean.unregisterListeners();
             _listenersAreRegistered = false;
         }
     }

--- a/java/src/jmri/jmrit/logixng/expressions/ExpressionBlock.java
+++ b/java/src/jmri/jmrit/logixng/expressions/ExpressionBlock.java
@@ -32,15 +32,15 @@ public class ExpressionBlock extends AbstractDigitalExpression
 
     private final LogixNG_SelectNamedBean<Block> _selectNamedBean =
             new LogixNG_SelectNamedBean<>(
-                    this, Block.class, InstanceManager.getDefault(BlockManager.class), this);
+                    this, Block.class, InstanceManager.getDefault(BlockManager.class));
 
     private Is_IsNot_Enum _is_IsNot = Is_IsNot_Enum.Is;
 
     private final LogixNG_SelectEnum<BlockState> _selectEnum =
-            new LogixNG_SelectEnum<>(this, BlockState.values(), BlockState.Occupied, this);
+            new LogixNG_SelectEnum<>(this, BlockState.values(), BlockState.Occupied);
 
     private final LogixNG_SelectString _selectBlockValue =
-            new LogixNG_SelectString(this, this);
+            new LogixNG_SelectString(this);
 
 
     public ExpressionBlock(String sys, String user)
@@ -201,9 +201,6 @@ public class ExpressionBlock extends AbstractDigitalExpression
     public void registerListenersForThisClass() {
         if (!_listenersAreRegistered) {
             _selectNamedBean.addPropertyChangeListener(this);
-            _selectNamedBean.registerListeners();
-            _selectEnum.registerListeners();
-            _selectBlockValue.registerListeners();
             _listenersAreRegistered = true;
         }
     }
@@ -213,9 +210,6 @@ public class ExpressionBlock extends AbstractDigitalExpression
     public void unregisterListenersForThisClass() {
         if (_listenersAreRegistered) {
             _selectNamedBean.removePropertyChangeListener(this);
-            _selectNamedBean.unregisterListeners();
-            _selectEnum.unregisterListeners();
-            _selectBlockValue.unregisterListeners();
             _listenersAreRegistered = false;
         }
     }

--- a/java/src/jmri/jmrit/logixng/expressions/ExpressionConditional.java
+++ b/java/src/jmri/jmrit/logixng/expressions/ExpressionConditional.java
@@ -24,7 +24,7 @@ public class ExpressionConditional extends AbstractDigitalExpression
 
     private final LogixNG_SelectNamedBean<Conditional> _selectNamedBean =
             new LogixNG_SelectNamedBean<>(
-                    this, Conditional.class, InstanceManager.getDefault(ConditionalManager.class), this);
+                    this, Conditional.class, InstanceManager.getDefault(ConditionalManager.class));
     private Is_IsNot_Enum _is_IsNot = Is_IsNot_Enum.Is;
     private NamedBeanAddressing _stateAddressing = NamedBeanAddressing.Direct;
     private ConditionalState _conditionalState = ConditionalState.False;
@@ -231,7 +231,6 @@ public class ExpressionConditional extends AbstractDigitalExpression
     public void registerListenersForThisClass() {
         if (!_listenersAreRegistered) {
             _selectNamedBean.addPropertyChangeListener("KnownState", this);
-            _selectNamedBean.registerListeners();
             _listenersAreRegistered = true;
         }
     }
@@ -241,7 +240,6 @@ public class ExpressionConditional extends AbstractDigitalExpression
     public void unregisterListenersForThisClass() {
         if (_listenersAreRegistered) {
             _selectNamedBean.removePropertyChangeListener("KnownState", this);
-            _selectNamedBean.unregisterListeners();
             _listenersAreRegistered = false;
         }
     }

--- a/java/src/jmri/jmrit/logixng/expressions/ExpressionDispatcher.java
+++ b/java/src/jmri/jmrit/logixng/expressions/ExpressionDispatcher.java
@@ -33,7 +33,7 @@ public class ExpressionDispatcher extends AbstractDigitalExpression
     private ExpressionNode _expressionNode;
 
     private final LogixNG_SelectEnum<DispatcherState> _selectEnum =
-            new LogixNG_SelectEnum<>(this, DispatcherState.values(), DispatcherState.Mode, this);
+            new LogixNG_SelectEnum<>(this, DispatcherState.values(), DispatcherState.Mode);
 
     private String _trainInfoFileName = "";
     private Is_IsNot_Enum _is_IsNot = Is_IsNot_Enum.Is;

--- a/java/src/jmri/jmrit/logixng/expressions/ExpressionEntryExit.java
+++ b/java/src/jmri/jmrit/logixng/expressions/ExpressionEntryExit.java
@@ -25,7 +25,7 @@ public class ExpressionEntryExit extends AbstractDigitalExpression
 
     private final LogixNG_SelectNamedBean<DestinationPoints> _selectNamedBean =
             new LogixNG_SelectNamedBean<>(
-                    this, DestinationPoints.class, InstanceManager.getDefault(jmri.jmrit.entryexit.EntryExitPairs.class), this);
+                    this, DestinationPoints.class, InstanceManager.getDefault(jmri.jmrit.entryexit.EntryExitPairs.class));
     private Is_IsNot_Enum _is_IsNot = Is_IsNot_Enum.Is;
     private NamedBeanAddressing _stateAddressing = NamedBeanAddressing.Direct;
     private EntryExitState _entryExitState = EntryExitState.Active;
@@ -253,7 +253,6 @@ public class ExpressionEntryExit extends AbstractDigitalExpression
     public void registerListenersForThisClass() {
         if (!_listenersAreRegistered) {
             _selectNamedBean.addPropertyChangeListener("active", this);
-            _selectNamedBean.registerListeners();
             _listenersAreRegistered = true;
         }
     }
@@ -263,7 +262,6 @@ public class ExpressionEntryExit extends AbstractDigitalExpression
     public void unregisterListenersForThisClass() {
         if (_listenersAreRegistered) {
             _selectNamedBean.removePropertyChangeListener("active", this);
-            _selectNamedBean.unregisterListeners();
             _listenersAreRegistered = false;
         }
     }

--- a/java/src/jmri/jmrit/logixng/expressions/ExpressionLight.java
+++ b/java/src/jmri/jmrit/logixng/expressions/ExpressionLight.java
@@ -24,7 +24,7 @@ public class ExpressionLight extends AbstractDigitalExpression
 
     private final LogixNG_SelectNamedBean<Light> _selectNamedBean =
             new LogixNG_SelectNamedBean<>(
-                    this, Light.class, InstanceManager.getDefault(LightManager.class), this);
+                    this, Light.class, InstanceManager.getDefault(LightManager.class));
     private Is_IsNot_Enum _is_IsNot = Is_IsNot_Enum.Is;
     private NamedBeanAddressing _stateAddressing = NamedBeanAddressing.Direct;
     private LightState _lightState = LightState.On;
@@ -232,7 +232,6 @@ public class ExpressionLight extends AbstractDigitalExpression
     public void registerListenersForThisClass() {
         if (!_listenersAreRegistered) {
             _selectNamedBean.addPropertyChangeListener("KnownState", this);
-            _selectNamedBean.registerListeners();
             _listenersAreRegistered = true;
         }
     }
@@ -242,7 +241,6 @@ public class ExpressionLight extends AbstractDigitalExpression
     public void unregisterListenersForThisClass() {
         if (_listenersAreRegistered) {
             _selectNamedBean.removePropertyChangeListener("KnownState", this);
-            _selectNamedBean.unregisterListeners();
             _listenersAreRegistered = false;
         }
     }

--- a/java/src/jmri/jmrit/logixng/expressions/ExpressionLocalVariable.java
+++ b/java/src/jmri/jmrit/logixng/expressions/ExpressionLocalVariable.java
@@ -33,7 +33,7 @@ public class ExpressionLocalVariable extends AbstractDigitalExpression
     private String _constantValue = "";
     private final LogixNG_SelectNamedBean<Memory> _selectMemoryNamedBean =
             new LogixNG_SelectNamedBean<>(
-                    this, Memory.class, InstanceManager.getDefault(MemoryManager.class), this);
+                    this, Memory.class, InstanceManager.getDefault(MemoryManager.class));
     private String _otherLocalVariable = "";
     private String _regEx = "";
     private boolean _listenToMemory = true;
@@ -340,7 +340,6 @@ public class ExpressionLocalVariable extends AbstractDigitalExpression
     public void registerListenersForThisClass() {
         if (!_listenersAreRegistered && _listenToMemory) {
             _selectMemoryNamedBean.addPropertyChangeListener("value", this);
-            _selectMemoryNamedBean.registerListeners();
             _listenersAreRegistered = true;
         }
     }
@@ -350,7 +349,6 @@ public class ExpressionLocalVariable extends AbstractDigitalExpression
     public void unregisterListenersForThisClass() {
         if (_listenersAreRegistered && _listenToMemory) {
             _selectMemoryNamedBean.removePropertyChangeListener("value", this);
-            _selectMemoryNamedBean.unregisterListeners();
             _listenersAreRegistered = false;
         }
     }

--- a/java/src/jmri/jmrit/logixng/expressions/ExpressionMemory.java
+++ b/java/src/jmri/jmrit/logixng/expressions/ExpressionMemory.java
@@ -27,11 +27,11 @@ public class ExpressionMemory extends AbstractDigitalExpression
 
     private final LogixNG_SelectNamedBean<Memory> _selectNamedBean =
             new LogixNG_SelectNamedBean<>(
-                    this, Memory.class, InstanceManager.getDefault(MemoryManager.class), this);
+                    this, Memory.class, InstanceManager.getDefault(MemoryManager.class));
 
     private final LogixNG_SelectNamedBean<Memory> _selectOtherMemoryNamedBean =
             new LogixNG_SelectNamedBean<>(
-                    this, Memory.class, InstanceManager.getDefault(MemoryManager.class), this);
+                    this, Memory.class, InstanceManager.getDefault(MemoryManager.class));
 
     private MemoryOperation _memoryOperation = MemoryOperation.Equal;
     private CompareType _compareType = CompareType.NumberOrString;
@@ -341,7 +341,6 @@ public class ExpressionMemory extends AbstractDigitalExpression
             if (_listenToOtherMemory) {
                 _selectOtherMemoryNamedBean.addPropertyChangeListener("value", this);
             }
-            _selectNamedBean.registerListeners();
             _listenersAreRegistered = true;
         }
     }
@@ -354,7 +353,6 @@ public class ExpressionMemory extends AbstractDigitalExpression
             if (_listenToOtherMemory) {
                 _selectOtherMemoryNamedBean.removePropertyChangeListener("value", this);
             }
-            _selectNamedBean.unregisterListeners();
             _listenersAreRegistered = false;
         }
     }

--- a/java/src/jmri/jmrit/logixng/expressions/ExpressionOBlock.java
+++ b/java/src/jmri/jmrit/logixng/expressions/ExpressionOBlock.java
@@ -26,7 +26,7 @@ public class ExpressionOBlock extends AbstractDigitalExpression
 
     private final LogixNG_SelectNamedBean<OBlock> _selectNamedBean =
             new LogixNG_SelectNamedBean<>(
-                    this, OBlock.class, InstanceManager.getDefault(OBlockManager.class), this);
+                    this, OBlock.class, InstanceManager.getDefault(OBlockManager.class));
     private Is_IsNot_Enum _is_IsNot = Is_IsNot_Enum.Is;
     private NamedBeanAddressing _stateAddressing = NamedBeanAddressing.Direct;
     private OBlock.OBlockStatus _oblockState = OBlock.OBlockStatus.Unoccupied;
@@ -234,7 +234,6 @@ public class ExpressionOBlock extends AbstractDigitalExpression
     public void registerListenersForThisClass() {
         if (!_listenersAreRegistered) {
             _selectNamedBean.addPropertyChangeListener("state", this);
-            _selectNamedBean.registerListeners();
             _listenersAreRegistered = true;
         }
     }
@@ -244,7 +243,6 @@ public class ExpressionOBlock extends AbstractDigitalExpression
     public void unregisterListenersForThisClass() {
         if (_listenersAreRegistered) {
             _selectNamedBean.removePropertyChangeListener("state", this);
-            _selectNamedBean.unregisterListeners();
             _listenersAreRegistered = false;
         }
     }

--- a/java/src/jmri/jmrit/logixng/expressions/ExpressionReporter.java
+++ b/java/src/jmri/jmrit/logixng/expressions/ExpressionReporter.java
@@ -24,11 +24,11 @@ public class ExpressionReporter extends AbstractDigitalExpression
 
     private final LogixNG_SelectNamedBean<Reporter> _selectNamedBean =
             new LogixNG_SelectNamedBean<>(
-                    this, Reporter.class, InstanceManager.getDefault(ReporterManager.class), this);
+                    this, Reporter.class, InstanceManager.getDefault(ReporterManager.class));
 
     private final LogixNG_SelectNamedBean<Memory> _selectMemoryNamedBean =
             new LogixNG_SelectNamedBean<>(
-                    this, Memory.class, InstanceManager.getDefault(MemoryManager.class), this);
+                    this, Memory.class, InstanceManager.getDefault(MemoryManager.class));
 
     private ReporterValue _reporterValue = ReporterValue.CurrentReport;
     private ReporterOperation _reporterOperation = ReporterOperation.Equal;
@@ -457,7 +457,6 @@ public class ExpressionReporter extends AbstractDigitalExpression
             if (_listenToMemory) {
                 _selectMemoryNamedBean.addPropertyChangeListener("value", this);
             }
-            _selectNamedBean.registerListeners();
             _listenersAreRegistered = true;
         }
     }
@@ -471,7 +470,6 @@ public class ExpressionReporter extends AbstractDigitalExpression
             if (_listenToMemory) {
                 _selectMemoryNamedBean.removePropertyChangeListener("value", this);
             }
-            _selectNamedBean.unregisterListeners();
             _listenersAreRegistered = false;
         }
     }

--- a/java/src/jmri/jmrit/logixng/expressions/ExpressionSection.java
+++ b/java/src/jmri/jmrit/logixng/expressions/ExpressionSection.java
@@ -24,12 +24,12 @@ public class ExpressionSection extends AbstractDigitalExpression
 
     private final LogixNG_SelectNamedBean<Section> _selectNamedBean =
             new LogixNG_SelectNamedBean<>(
-                    this, Section.class, InstanceManager.getDefault(SectionManager.class), this);
+                    this, Section.class, InstanceManager.getDefault(SectionManager.class));
 
     private Is_IsNot_Enum _is_IsNot = Is_IsNot_Enum.Is;
 
     private final LogixNG_SelectEnum<SectionState> _selectEnum =
-            new LogixNG_SelectEnum<>(this, SectionState.values(), SectionState.Free, this);
+            new LogixNG_SelectEnum<>(this, SectionState.values(), SectionState.Free);
 
     public ExpressionSection(String sys, String user)
             throws BadUserNameException, BadSystemNameException {
@@ -157,7 +157,6 @@ public class ExpressionSection extends AbstractDigitalExpression
 
         if (!_listenersAreRegistered) {
             _selectNamedBean.addPropertyChangeListener(this);
-            _selectNamedBean.registerListeners();
             _listenersAreRegistered = true;
         }
     }
@@ -167,7 +166,6 @@ public class ExpressionSection extends AbstractDigitalExpression
     public void unregisterListenersForThisClass() {
         if (_listenersAreRegistered) {
             _selectNamedBean.removePropertyChangeListener(this);
-            _selectNamedBean.unregisterListeners();
             _listenersAreRegistered = false;
         }
     }

--- a/java/src/jmri/jmrit/logixng/expressions/ExpressionSensor.java
+++ b/java/src/jmri/jmrit/logixng/expressions/ExpressionSensor.java
@@ -18,12 +18,12 @@ public class ExpressionSensor extends AbstractDigitalExpression
 
     private final LogixNG_SelectNamedBean<Sensor> _selectNamedBean =
             new LogixNG_SelectNamedBean<>(
-                    this, Sensor.class, InstanceManager.getDefault(SensorManager.class), this);
+                    this, Sensor.class, InstanceManager.getDefault(SensorManager.class));
 
     private Is_IsNot_Enum _is_IsNot = Is_IsNot_Enum.Is;
 
     private final LogixNG_SelectEnum<SensorState> _selectEnum =
-            new LogixNG_SelectEnum<>(this, SensorState.values(), SensorState.Active, this);
+            new LogixNG_SelectEnum<>(this, SensorState.values(), SensorState.Active);
 
 
     public ExpressionSensor(String sys, String user)
@@ -117,7 +117,6 @@ public class ExpressionSensor extends AbstractDigitalExpression
     public void registerListenersForThisClass() {
         if (!_listenersAreRegistered) {
             _selectNamedBean.addPropertyChangeListener("KnownState", this);
-            _selectNamedBean.registerListeners();
             _listenersAreRegistered = true;
         }
     }
@@ -127,7 +126,6 @@ public class ExpressionSensor extends AbstractDigitalExpression
     public void unregisterListenersForThisClass() {
         if (_listenersAreRegistered) {
             _selectNamedBean.removePropertyChangeListener("KnownState", this);
-            _selectNamedBean.unregisterListeners();
             _listenersAreRegistered = false;
         }
     }

--- a/java/src/jmri/jmrit/logixng/expressions/ExpressionSensorEdge.java
+++ b/java/src/jmri/jmrit/logixng/expressions/ExpressionSensorEdge.java
@@ -18,13 +18,13 @@ public class ExpressionSensorEdge extends AbstractDigitalExpression
 
     private final LogixNG_SelectNamedBean<Sensor> _selectNamedBean =
             new LogixNG_SelectNamedBean<>(
-                    this, Sensor.class, InstanceManager.getDefault(SensorManager.class), this);
+                    this, Sensor.class, InstanceManager.getDefault(SensorManager.class));
 
     private final LogixNG_SelectEnum<SensorState> _selectEnumFromState =
-            new LogixNG_SelectEnum<>(this, SensorState.values(), SensorState.Active, this);
+            new LogixNG_SelectEnum<>(this, SensorState.values(), SensorState.Active);
 
     private final LogixNG_SelectEnum<SensorState> _selectEnumToState =
-            new LogixNG_SelectEnum<>(this, SensorState.values(), SensorState.Active, this);
+            new LogixNG_SelectEnum<>(this, SensorState.values(), SensorState.Active);
 
     private boolean _onlyTrueOnce = false;
 
@@ -138,7 +138,6 @@ public class ExpressionSensorEdge extends AbstractDigitalExpression
     public void registerListenersForThisClass() {
         if (!_listenersAreRegistered) {
             _selectNamedBean.addPropertyChangeListener("KnownState", this);
-            _selectNamedBean.registerListeners();
             _listenersAreRegistered = true;
         }
     }
@@ -148,7 +147,6 @@ public class ExpressionSensorEdge extends AbstractDigitalExpression
     public void unregisterListenersForThisClass() {
         if (_listenersAreRegistered) {
             _selectNamedBean.removePropertyChangeListener("KnownState", this);
-            _selectNamedBean.unregisterListeners();
             _listenersAreRegistered = false;
             lastSensorState = null;
             currentSensorState = null;

--- a/java/src/jmri/jmrit/logixng/expressions/ExpressionSignalHead.java
+++ b/java/src/jmri/jmrit/logixng/expressions/ExpressionSignalHead.java
@@ -26,7 +26,7 @@ public class ExpressionSignalHead extends AbstractDigitalExpression
 
     private final LogixNG_SelectNamedBean<SignalHead> _selectNamedBean =
             new LogixNG_SelectNamedBean<>(
-                    this, SignalHead.class, InstanceManager.getDefault(SignalHeadManager.class), this);
+                    this, SignalHead.class, InstanceManager.getDefault(SignalHeadManager.class));
 
     private NamedBeanAddressing _queryAddressing = NamedBeanAddressing.Direct;
     private QueryType _queryType = QueryType.Appearance;
@@ -44,7 +44,7 @@ public class ExpressionSignalHead extends AbstractDigitalExpression
 
     private final LogixNG_SelectNamedBean<SignalHead> _selectExampleNamedBean =
             new LogixNG_SelectNamedBean<>(
-                    this, SignalHead.class, InstanceManager.getDefault(SignalHeadManager.class), this);
+                    this, SignalHead.class, InstanceManager.getDefault(SignalHeadManager.class));
 
 
     public ExpressionSignalHead(String sys, String user)
@@ -444,7 +444,6 @@ public class ExpressionSignalHead extends AbstractDigitalExpression
                 default:
                     throw new RuntimeException("Unknown enum: "+_queryType.name());
             }
-            _selectNamedBean.registerListeners();
             _listenersAreRegistered = true;
         }
     }
@@ -474,7 +473,6 @@ public class ExpressionSignalHead extends AbstractDigitalExpression
                 default:
                     throw new RuntimeException("Unknown enum: "+_queryType.name());
             }
-            _selectNamedBean.unregisterListeners();
             _listenersAreRegistered = false;
         }
     }

--- a/java/src/jmri/jmrit/logixng/expressions/ExpressionSignalMast.java
+++ b/java/src/jmri/jmrit/logixng/expressions/ExpressionSignalMast.java
@@ -26,7 +26,7 @@ public class ExpressionSignalMast extends AbstractDigitalExpression
 
     private final LogixNG_SelectNamedBean<SignalMast> _selectNamedBean =
             new LogixNG_SelectNamedBean<>(
-                    this, SignalMast.class, InstanceManager.getDefault(SignalMastManager.class), this);
+                    this, SignalMast.class, InstanceManager.getDefault(SignalMastManager.class));
 
     private NamedBeanAddressing _queryAddressing = NamedBeanAddressing.Direct;
     private QueryType _queryType = QueryType.Aspect;
@@ -44,7 +44,7 @@ public class ExpressionSignalMast extends AbstractDigitalExpression
 
     private final LogixNG_SelectNamedBean<SignalMast> _selectExampleNamedBean =
             new LogixNG_SelectNamedBean<>(
-                    this, SignalMast.class, InstanceManager.getDefault(SignalMastManager.class), this);
+                    this, SignalMast.class, InstanceManager.getDefault(SignalMastManager.class));
 
 
     public ExpressionSignalMast(String sys, String user)
@@ -427,7 +427,6 @@ public class ExpressionSignalMast extends AbstractDigitalExpression
                 default:
                     throw new RuntimeException("Unknown enum: "+_queryType.name());
             }
-            _selectNamedBean.registerListeners();
             _listenersAreRegistered = true;
         }
     }
@@ -462,7 +461,6 @@ public class ExpressionSignalMast extends AbstractDigitalExpression
                 default:
                     throw new RuntimeException("Unknown enum: "+_queryType.name());
             }
-            _selectNamedBean.unregisterListeners();
             _listenersAreRegistered = false;
         }
     }

--- a/java/src/jmri/jmrit/logixng/expressions/ExpressionTransit.java
+++ b/java/src/jmri/jmrit/logixng/expressions/ExpressionTransit.java
@@ -23,12 +23,12 @@ public class ExpressionTransit extends AbstractDigitalExpression
 
     private final LogixNG_SelectNamedBean<Transit> _selectNamedBean =
             new LogixNG_SelectNamedBean<>(
-                    this, Transit.class, InstanceManager.getDefault(TransitManager.class), this);
+                    this, Transit.class, InstanceManager.getDefault(TransitManager.class));
 
     private Is_IsNot_Enum _is_IsNot = Is_IsNot_Enum.Is;
 
     private final LogixNG_SelectEnum<TransitState> _selectEnum =
-            new LogixNG_SelectEnum<>(this, TransitState.values(), TransitState.Idle, this);
+            new LogixNG_SelectEnum<>(this, TransitState.values(), TransitState.Idle);
 
     public ExpressionTransit(String sys, String user)
             throws BadUserNameException, BadSystemNameException {
@@ -135,7 +135,6 @@ public class ExpressionTransit extends AbstractDigitalExpression
     public void registerListenersForThisClass() {
         if (!_listenersAreRegistered) {
             _selectNamedBean.addPropertyChangeListener(this);
-            _selectNamedBean.registerListeners();
             _listenersAreRegistered = true;
         }
     }
@@ -145,7 +144,6 @@ public class ExpressionTransit extends AbstractDigitalExpression
     public void unregisterListenersForThisClass() {
         if (_listenersAreRegistered) {
             _selectNamedBean.removePropertyChangeListener(this);
-            _selectNamedBean.unregisterListeners();
             _listenersAreRegistered = false;
         }
     }

--- a/java/src/jmri/jmrit/logixng/expressions/ExpressionTurnout.java
+++ b/java/src/jmri/jmrit/logixng/expressions/ExpressionTurnout.java
@@ -24,7 +24,7 @@ public class ExpressionTurnout extends AbstractDigitalExpression
 
     private final LogixNG_SelectNamedBean<Turnout> _selectNamedBean =
             new LogixNG_SelectNamedBean<>(
-                    this, Turnout.class, InstanceManager.getDefault(TurnoutManager.class), this);
+                    this, Turnout.class, InstanceManager.getDefault(TurnoutManager.class));
     private Is_IsNot_Enum _is_IsNot = Is_IsNot_Enum.Is;
     private NamedBeanAddressing _stateAddressing = NamedBeanAddressing.Direct;
     private TurnoutState _turnoutState = TurnoutState.Thrown;
@@ -232,7 +232,6 @@ public class ExpressionTurnout extends AbstractDigitalExpression
     public void registerListenersForThisClass() {
         if (!_listenersAreRegistered) {
             _selectNamedBean.addPropertyChangeListener("KnownState", this);
-            _selectNamedBean.registerListeners();
             _listenersAreRegistered = true;
         }
     }
@@ -242,7 +241,6 @@ public class ExpressionTurnout extends AbstractDigitalExpression
     public void unregisterListenersForThisClass() {
         if (_listenersAreRegistered) {
             _selectNamedBean.removePropertyChangeListener("KnownState", this);
-            _selectNamedBean.unregisterListeners();
             _listenersAreRegistered = false;
         }
     }

--- a/java/src/jmri/jmrit/logixng/expressions/ExpressionWarrant.java
+++ b/java/src/jmri/jmrit/logixng/expressions/ExpressionWarrant.java
@@ -26,7 +26,7 @@ public class ExpressionWarrant extends AbstractDigitalExpression
 
     private final LogixNG_SelectNamedBean<Warrant> _selectNamedBean =
             new LogixNG_SelectNamedBean<>(
-                    this, Warrant.class, InstanceManager.getDefault(WarrantManager.class), this);
+                    this, Warrant.class, InstanceManager.getDefault(WarrantManager.class));
     private Is_IsNot_Enum _is_IsNot = Is_IsNot_Enum.Is;
     private NamedBeanAddressing _stateAddressing = NamedBeanAddressing.Direct;
     private WarrantState _warrantState = WarrantState.RouteAllocated;
@@ -254,7 +254,6 @@ public class ExpressionWarrant extends AbstractDigitalExpression
     public void registerListenersForThisClass() {
         if (!_listenersAreRegistered) {
             _selectNamedBean.addPropertyChangeListener(this);
-            _selectNamedBean.registerListeners();
             _listenersAreRegistered = true;
         }
     }
@@ -264,7 +263,6 @@ public class ExpressionWarrant extends AbstractDigitalExpression
     public void unregisterListenersForThisClass() {
         if (_listenersAreRegistered) {
             _selectNamedBean.removePropertyChangeListener(this);
-            _selectNamedBean.unregisterListeners();
             _listenersAreRegistered = false;
         }
     }

--- a/java/src/jmri/jmrit/logixng/expressions/FileAsFlag.java
+++ b/java/src/jmri/jmrit/logixng/expressions/FileAsFlag.java
@@ -1,6 +1,5 @@
 package jmri.jmrit.logixng.expressions;
 
-import java.beans.*;
 import java.io.*;
 import java.nio.file.Files;
 import java.util.*;
@@ -16,14 +15,13 @@ import jmri.jmrit.logixng.util.*;
  *
  * @author Daniel Bergqvist Copyright 2023
  */
-public class FileAsFlag extends AbstractDigitalExpression
-        implements PropertyChangeListener {
+public class FileAsFlag extends AbstractDigitalExpression {
 
     private final LogixNG_SelectString _selectFilename =
-            new LogixNG_SelectString(this, this);
+            new LogixNG_SelectString(this);
 
     private final LogixNG_SelectEnum<DeleteOrKeep> _selectDeleteOrKeep =
-            new LogixNG_SelectEnum<>(this, DeleteOrKeep.values(), DeleteOrKeep.Keep, this);
+            new LogixNG_SelectEnum<>(this, DeleteOrKeep.values(), DeleteOrKeep.Keep);
 
 
     public FileAsFlag(String sys, String user)
@@ -109,28 +107,6 @@ public class FileAsFlag extends AbstractDigitalExpression
     @Override
     public void setup() {
         // Do nothing
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void registerListenersForThisClass() {
-        if (!_listenersAreRegistered) {
-            _listenersAreRegistered = true;
-        }
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void unregisterListenersForThisClass() {
-        if (_listenersAreRegistered) {
-            _listenersAreRegistered = false;
-        }
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void propertyChange(PropertyChangeEvent evt) {
-        getConditionalNG().execute();
     }
 
     /** {@inheritDoc} */

--- a/java/src/jmri/jmrit/logixng/expressions/LastResultOfDigitalExpression.java
+++ b/java/src/jmri/jmrit/logixng/expressions/LastResultOfDigitalExpression.java
@@ -18,7 +18,7 @@ public class LastResultOfDigitalExpression extends AbstractDigitalExpression
 
     private final LogixNG_SelectNamedBean<MaleDigitalExpressionSocket> _selectNamedBean =
             new LogixNG_SelectNamedBean<>(
-                    this, MaleDigitalExpressionSocket.class, InstanceManager.getDefault(DigitalExpressionManager.class), this);
+                    this, MaleDigitalExpressionSocket.class, InstanceManager.getDefault(DigitalExpressionManager.class));
 
     public LastResultOfDigitalExpression(String sys, String user)
             throws BadUserNameException, BadSystemNameException {
@@ -93,7 +93,6 @@ public class LastResultOfDigitalExpression extends AbstractDigitalExpression
     public void registerListenersForThisClass() {
         if (!_listenersAreRegistered) {
             _selectNamedBean.addPropertyChangeListener(PROPERTY_LAST_RESULT_CHANGED, this);
-            _selectNamedBean.registerListeners();
             _listenersAreRegistered = true;
         }
     }
@@ -103,7 +102,6 @@ public class LastResultOfDigitalExpression extends AbstractDigitalExpression
     public void unregisterListenersForThisClass() {
         if (_listenersAreRegistered) {
             _selectNamedBean.removePropertyChangeListener(PROPERTY_LAST_RESULT_CHANGED, this);
-            _selectNamedBean.unregisterListeners();
             _listenersAreRegistered = false;
         }
     }

--- a/java/src/jmri/jmrit/logixng/expressions/StringExpressionMemory.java
+++ b/java/src/jmri/jmrit/logixng/expressions/StringExpressionMemory.java
@@ -18,7 +18,7 @@ public class StringExpressionMemory extends AbstractStringExpression
 
     private final LogixNG_SelectNamedBean<Memory> _selectNamedBean =
             new LogixNG_SelectNamedBean<>(
-                    this, Memory.class, InstanceManager.getDefault(MemoryManager.class), this);
+                    this, Memory.class, InstanceManager.getDefault(MemoryManager.class));
 
     public StringExpressionMemory(String sys, String user)
             throws BadUserNameException, BadSystemNameException {
@@ -91,7 +91,6 @@ public class StringExpressionMemory extends AbstractStringExpression
     public void registerListenersForThisClass() {
         if (!_listenersAreRegistered) {
             _selectNamedBean.addPropertyChangeListener("value", this);
-            _selectNamedBean.registerListeners();
             _listenersAreRegistered = true;
         }
     }
@@ -101,7 +100,6 @@ public class StringExpressionMemory extends AbstractStringExpression
     public void unregisterListenersForThisClass() {
         if (_listenersAreRegistered) {
             _selectNamedBean.removePropertyChangeListener("value", this);
-            _selectNamedBean.unregisterListeners();
             _listenersAreRegistered = false;
         }
     }

--- a/java/src/jmri/jmrit/logixng/expressions/StringExpressionStringIO.java
+++ b/java/src/jmri/jmrit/logixng/expressions/StringExpressionStringIO.java
@@ -18,7 +18,7 @@ public class StringExpressionStringIO extends AbstractStringExpression
 
     private final LogixNG_SelectNamedBean<StringIO> _selectNamedBean =
             new LogixNG_SelectNamedBean<>(
-                    this, StringIO.class, InstanceManager.getDefault(StringIOManager.class), this);
+                    this, StringIO.class, InstanceManager.getDefault(StringIOManager.class));
 
     public StringExpressionStringIO(String sys, String user)
             throws BadUserNameException, BadSystemNameException {
@@ -91,7 +91,6 @@ public class StringExpressionStringIO extends AbstractStringExpression
     public void registerListenersForThisClass() {
         if (!_listenersAreRegistered) {
             _selectNamedBean.addPropertyChangeListener("KnownValue", this);
-            _selectNamedBean.registerListeners();
             _listenersAreRegistered = true;
         }
     }
@@ -101,7 +100,6 @@ public class StringExpressionStringIO extends AbstractStringExpression
     public void unregisterListenersForThisClass() {
         if (_listenersAreRegistered) {
             _selectNamedBean.removePropertyChangeListener("KnownValue", this);
-            _selectNamedBean.unregisterListeners();
             _listenersAreRegistered = false;
         }
     }

--- a/java/src/jmri/jmrit/logixng/util/LogixNG_SelectBoolean.java
+++ b/java/src/jmri/jmrit/logixng/util/LogixNG_SelectBoolean.java
@@ -1,7 +1,6 @@
 package jmri.jmrit.logixng.util;
 
 import java.beans.PropertyChangeEvent;
-import java.beans.PropertyChangeListener;
 import java.beans.PropertyVetoException;
 import java.beans.VetoableChangeListener;
 import java.util.HashMap;
@@ -27,9 +26,6 @@ public class LogixNG_SelectBoolean implements VetoableChangeListener {
     private final AbstractBase _base;
     private final InUse _inUse;
     private final LogixNG_SelectTable _selectTable;
-    private final PropertyChangeListener _listener;
-    private boolean _listenToMemory;
-    private boolean _listenersAreRegistered;
 
     private NamedBeanAddressing _addressing = NamedBeanAddressing.Direct;
     private boolean _value;
@@ -40,13 +36,10 @@ public class LogixNG_SelectBoolean implements VetoableChangeListener {
     private ExpressionNode _expressionNode;
 
 
-    public LogixNG_SelectBoolean(
-            @Nonnull AbstractBase base,
-            @Nonnull PropertyChangeListener listener) {
+    public LogixNG_SelectBoolean(@Nonnull AbstractBase base) {
         _base = base;
         _inUse = () -> true;
         _selectTable = new LogixNG_SelectTable(_base, _inUse);
-        _listener = listener;
     }
 
     public void copy(LogixNG_SelectBoolean copy) throws ParserException {
@@ -55,7 +48,6 @@ public class LogixNG_SelectBoolean implements VetoableChangeListener {
         copy.setLocalVariable(_localVariable);
         copy.setReference(_reference);
         copy.setMemory(_memoryHandle);
-        copy.setListenToMemory(_listenToMemory);
         copy.setFormula(_formula);
         _selectTable.copy(copy._selectTable);
     }
@@ -123,14 +115,6 @@ public class LogixNG_SelectBoolean implements VetoableChangeListener {
 
     public NamedBeanHandle<Memory> getMemory() {
         return _memoryHandle;
-    }
-
-    public void setListenToMemory(boolean listenToMemory) {
-        _listenToMemory = listenToMemory;
-    }
-
-    public boolean getListenToMemory() {
-        return _listenToMemory;
     }
 
     public void setLocalVariable(@Nonnull String localVariable) {
@@ -234,7 +218,7 @@ public class LogixNG_SelectBoolean implements VetoableChangeListener {
                 break;
 
             case Memory:
-                enumName = Bundle.getMessage(locale, "AddressByMemory_Listen", memoryName, Base.getListenString(_listenToMemory));
+                enumName = Bundle.getMessage(locale, "AddressByMemory", memoryName);
                 break;
 
             case LocalVariable:
@@ -258,32 +242,6 @@ public class LogixNG_SelectBoolean implements VetoableChangeListener {
                 throw new IllegalArgumentException("invalid _addressing: " + _addressing.name());
         }
         return enumName;
-    }
-
-    /**
-     * Register listeners if this object needs that.
-     */
-    public void registerListeners() {
-        if (!_listenersAreRegistered
-                && (_addressing == NamedBeanAddressing.Memory)
-                && (_memoryHandle != null)
-                && _listenToMemory) {
-            _memoryHandle.getBean().addPropertyChangeListener("value", _listener);
-            _listenersAreRegistered = true;
-        }
-    }
-
-    /**
-     * Unregister listeners if this object needs that.
-     */
-    public void unregisterListeners() {
-        if (_listenersAreRegistered
-                && (_addressing == NamedBeanAddressing.Memory)
-                && (_memoryHandle != null)
-                && _listenToMemory) {
-            _memoryHandle.getBean().removePropertyChangeListener("value", _listener);
-            _listenersAreRegistered = false;
-        }
     }
 
     @Override

--- a/java/src/jmri/jmrit/logixng/util/LogixNG_SelectCharset.java
+++ b/java/src/jmri/jmrit/logixng/util/LogixNG_SelectCharset.java
@@ -1,6 +1,5 @@
 package jmri.jmrit.logixng.util;
 
-import java.beans.PropertyChangeListener;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
@@ -23,7 +22,6 @@ public class LogixNG_SelectCharset {
 
     private final AbstractBase _base;
     private final InUse _inUse;
-//    private final PropertyChangeListener _listener;
 
     private Addressing _addressing = Addressing.Standard;
     private Charset _standardValue = StandardCharsets.UTF_8;
@@ -31,11 +29,10 @@ public class LogixNG_SelectCharset {
     private final LogixNG_SelectString _selectUserSpecifiedCharset;
 
 
-    public LogixNG_SelectCharset(AbstractBase base, PropertyChangeListener listener) {
+    public LogixNG_SelectCharset(AbstractBase base) {
         _base = base;
         _inUse = () -> _addressing == Addressing.UserSpecified;
-//        _listener = listener;
-        _selectUserSpecifiedCharset = new LogixNG_SelectString(base, _inUse, listener);
+        _selectUserSpecifiedCharset = new LogixNG_SelectString(base, _inUse);
     }
 
     private static List<Charset> getStandardCharsets() {
@@ -126,7 +123,7 @@ public class LogixNG_SelectCharset {
                 break;
 
             case Memory:
-                enumName = Bundle.getMessage(locale, "AddressByMemory_Listen", memoryName, Base.getListenString(_listenToMemory));
+                enumName = Bundle.getMessage(locale, "AddressByMemory", memoryName);
                 break;
 
             case LocalVariable:

--- a/java/src/jmri/jmrit/logixng/util/LogixNG_SelectComboBox.java
+++ b/java/src/jmri/jmrit/logixng/util/LogixNG_SelectComboBox.java
@@ -1,7 +1,6 @@
 package jmri.jmrit.logixng.util;
 
 import java.beans.PropertyChangeEvent;
-import java.beans.PropertyChangeListener;
 import java.beans.PropertyVetoException;
 import java.beans.VetoableChangeListener;
 import java.util.HashMap;
@@ -49,9 +48,6 @@ public class LogixNG_SelectComboBox implements VetoableChangeListener {
     private final InUse _inUse;
     private Item[] _valuesArray;
     private final LogixNG_SelectTable _selectTable;
-    private final PropertyChangeListener _listener;
-    private boolean _listenToMemory;
-    private boolean _listenersAreRegistered;
 
     private NamedBeanAddressing _addressing = NamedBeanAddressing.Direct;
     private Item _value;
@@ -62,14 +58,12 @@ public class LogixNG_SelectComboBox implements VetoableChangeListener {
     private ExpressionNode _expressionNode;
 
 
-    public LogixNG_SelectComboBox(AbstractBase base, Item[] valuesArray,
-            Item initialValue, PropertyChangeListener listener) {
+    public LogixNG_SelectComboBox(AbstractBase base, Item[] valuesArray, Item initialValue) {
         _base = base;
         _inUse = () -> true;
         _valuesArray = valuesArray;
         _value = initialValue;
         _selectTable = new LogixNG_SelectTable(_base, _inUse);
-        _listener = listener;
     }
 
 
@@ -79,7 +73,6 @@ public class LogixNG_SelectComboBox implements VetoableChangeListener {
         copy.setLocalVariable(_localVariable);
         copy.setReference(_reference);
         copy.setMemory(_memoryHandle);
-        copy.setListenToMemory(_listenToMemory);
         copy.setFormula(_formula);
         _selectTable.copy(copy._selectTable);
     }
@@ -196,14 +189,6 @@ public class LogixNG_SelectComboBox implements VetoableChangeListener {
         return _memoryHandle;
     }
 
-    public void setListenToMemory(boolean listenToMemory) {
-        _listenToMemory = listenToMemory;
-    }
-
-    public boolean getListenToMemory() {
-        return _listenToMemory;
-    }
-
     public void setLocalVariable(@Nonnull String localVariable) {
         _localVariable = localVariable;
     }
@@ -309,7 +294,7 @@ public class LogixNG_SelectComboBox implements VetoableChangeListener {
                 break;
 
             case Memory:
-                description = Bundle.getMessage(locale, "AddressByMemory_Listen", memoryName, Base.getListenString(_listenToMemory));
+                description = Bundle.getMessage(locale, "AddressByMemory", memoryName);
                 break;
 
             case LocalVariable:
@@ -333,32 +318,6 @@ public class LogixNG_SelectComboBox implements VetoableChangeListener {
                 throw new IllegalArgumentException("invalid _addressing: " + _addressing.name());
         }
         return description;
-    }
-
-    /**
-     * Register listeners if this object needs that.
-     */
-    public void registerListeners() {
-        if (!_listenersAreRegistered
-                && (_addressing == NamedBeanAddressing.Memory)
-                && (_memoryHandle != null)
-                && _listenToMemory) {
-            _memoryHandle.getBean().addPropertyChangeListener("value", _listener);
-            _listenersAreRegistered = true;
-        }
-    }
-
-    /**
-     * Unregister listeners if this object needs that.
-     */
-    public void unregisterListeners() {
-        if (_listenersAreRegistered
-                && (_addressing == NamedBeanAddressing.Memory)
-                && (_memoryHandle != null)
-                && _listenToMemory) {
-            _memoryHandle.getBean().removePropertyChangeListener("value", _listener);
-            _listenersAreRegistered = false;
-        }
     }
 
     @Override

--- a/java/src/jmri/jmrit/logixng/util/LogixNG_SelectDouble.java
+++ b/java/src/jmri/jmrit/logixng/util/LogixNG_SelectDouble.java
@@ -1,7 +1,6 @@
 package jmri.jmrit.logixng.util;
 
 import java.beans.PropertyChangeEvent;
-import java.beans.PropertyChangeListener;
 import java.beans.PropertyVetoException;
 import java.beans.VetoableChangeListener;
 import java.util.HashMap;
@@ -28,9 +27,6 @@ public class LogixNG_SelectDouble implements VetoableChangeListener {
     private final InUse _inUse;
     private final LogixNG_SelectTable _selectTable;
     private final int _numDecimals;
-    private final PropertyChangeListener _listener;
-    private boolean _listenToMemory;
-    private boolean _listenersAreRegistered;
     private final FormatterParserValidator _formatterParserValidator;
 
     private NamedBeanAddressing _addressing = NamedBeanAddressing.Direct;
@@ -42,24 +38,18 @@ public class LogixNG_SelectDouble implements VetoableChangeListener {
     private ExpressionNode _expressionNode;
 
 
-    public LogixNG_SelectDouble(
-            @Nonnull AbstractBase base,
-            int numDecimals,
-            @Nonnull PropertyChangeListener listener) {
-
-        this(base, numDecimals, listener, new DefaultFormatterParserValidator());
+    public LogixNG_SelectDouble(@Nonnull AbstractBase base, int numDecimals) {
+        this(base, numDecimals, new DefaultFormatterParserValidator());
     }
 
     public LogixNG_SelectDouble(
             @Nonnull AbstractBase base,
             int numDecimals,
-            @Nonnull PropertyChangeListener listener,
             @Nonnull FormatterParserValidator formatterParserValidator) {
         _base = base;
         _inUse = () -> true;
         _selectTable = new LogixNG_SelectTable(_base, _inUse);
         _numDecimals = numDecimals;
-        _listener = listener;
         _formatterParserValidator = formatterParserValidator;
         _value = _formatterParserValidator.getInitialValue();
     }
@@ -69,7 +59,6 @@ public class LogixNG_SelectDouble implements VetoableChangeListener {
         copy.setValue(_value);
         copy.setLocalVariable(_localVariable);
         copy.setMemory(_memoryHandle);
-        copy.setListenToMemory(_listenToMemory);
         copy.setReference(_reference);
         copy.setFormula(_formula);
         _selectTable.copy(copy._selectTable);
@@ -151,14 +140,6 @@ public class LogixNG_SelectDouble implements VetoableChangeListener {
 
     public NamedBeanHandle<Memory> getMemory() {
         return _memoryHandle;
-    }
-
-    public void setListenToMemory(boolean listenToMemory) {
-        _listenToMemory = listenToMemory;
-    }
-
-    public boolean getListenToMemory() {
-        return _listenToMemory;
     }
 
     public void setFormula(@Nonnull String formula) throws ParserException {
@@ -269,7 +250,7 @@ public class LogixNG_SelectDouble implements VetoableChangeListener {
                 break;
 
             case Memory:
-                enumName = Bundle.getMessage(locale, "AddressByMemory_Listen", memoryName, Base.getListenString(_listenToMemory));
+                enumName = Bundle.getMessage(locale, "AddressByMemory", memoryName);
                 break;
 
             case LocalVariable:
@@ -293,32 +274,6 @@ public class LogixNG_SelectDouble implements VetoableChangeListener {
                 throw new IllegalArgumentException("invalid _addressing: " + _addressing.name());
         }
         return enumName;
-    }
-
-    /**
-     * Register listeners if this object needs that.
-     */
-    public void registerListeners() {
-        if (!_listenersAreRegistered
-                && (_addressing == NamedBeanAddressing.Memory)
-                && (_memoryHandle != null)
-                && _listenToMemory) {
-            _memoryHandle.getBean().addPropertyChangeListener("value", _listener);
-            _listenersAreRegistered = true;
-        }
-    }
-
-    /**
-     * Unregister listeners if this object needs that.
-     */
-    public void unregisterListeners() {
-        if (_listenersAreRegistered
-                && (_addressing == NamedBeanAddressing.Memory)
-                && (_memoryHandle != null)
-                && _listenToMemory) {
-            _memoryHandle.getBean().removePropertyChangeListener("value", _listener);
-            _listenersAreRegistered = false;
-        }
     }
 
     @Override

--- a/java/src/jmri/jmrit/logixng/util/LogixNG_SelectEnum.java
+++ b/java/src/jmri/jmrit/logixng/util/LogixNG_SelectEnum.java
@@ -1,7 +1,6 @@
 package jmri.jmrit.logixng.util;
 
 import java.beans.PropertyChangeEvent;
-import java.beans.PropertyChangeListener;
 import java.beans.PropertyVetoException;
 import java.beans.VetoableChangeListener;
 import java.util.HashMap;
@@ -30,9 +29,6 @@ public class LogixNG_SelectEnum<E extends Enum<?>> implements VetoableChangeList
     private final InUse _inUse;
     private final E[] _enumArray;
     private final LogixNG_SelectTable _selectTable;
-    private final PropertyChangeListener _listener;
-    private boolean _listenToMemory;
-    private boolean _listenersAreRegistered;
 
     private NamedBeanAddressing _addressing = NamedBeanAddressing.Direct;
     private E _enum;
@@ -43,13 +39,12 @@ public class LogixNG_SelectEnum<E extends Enum<?>> implements VetoableChangeList
     private ExpressionNode _expressionNode;
 
 
-    public LogixNG_SelectEnum(AbstractBase base, E[] enumArray, E initialEnum, PropertyChangeListener listener) {
+    public LogixNG_SelectEnum(AbstractBase base, E[] enumArray, E initialEnum) {
         _base = base;
         _inUse = () -> true;
         _enumArray = enumArray;
         _enum = initialEnum;
         _selectTable = new LogixNG_SelectTable(_base, _inUse);
-        _listener = listener;
     }
 
 
@@ -59,7 +54,6 @@ public class LogixNG_SelectEnum<E extends Enum<?>> implements VetoableChangeList
         copy.setLocalVariable(_localVariable);
         copy.setReference(_reference);
         copy.setMemory(_memoryHandle);
-        copy.setListenToMemory(_listenToMemory);
         copy.setFormula(_formula);
         _selectTable.copy(copy._selectTable);
     }
@@ -138,14 +132,6 @@ public class LogixNG_SelectEnum<E extends Enum<?>> implements VetoableChangeList
 
     public NamedBeanHandle<Memory> getMemory() {
         return _memoryHandle;
-    }
-
-    public void setListenToMemory(boolean listenToMemory) {
-        _listenToMemory = listenToMemory;
-    }
-
-    public boolean getListenToMemory() {
-        return _listenToMemory;
     }
 
     public void setLocalVariable(@Nonnull String localVariable) {
@@ -253,7 +239,7 @@ public class LogixNG_SelectEnum<E extends Enum<?>> implements VetoableChangeList
                 break;
 
             case Memory:
-                enumName = Bundle.getMessage(locale, "AddressByMemory_Listen", memoryName, Base.getListenString(_listenToMemory));
+                enumName = Bundle.getMessage(locale, "AddressByMemory", memoryName);
                 break;
 
             case LocalVariable:
@@ -277,32 +263,6 @@ public class LogixNG_SelectEnum<E extends Enum<?>> implements VetoableChangeList
                 throw new IllegalArgumentException("invalid _addressing: " + _addressing.name());
         }
         return enumName;
-    }
-
-    /**
-     * Register listeners if this object needs that.
-     */
-    public void registerListeners() {
-        if (!_listenersAreRegistered
-                && (_addressing == NamedBeanAddressing.Memory)
-                && (_memoryHandle != null)
-                && _listenToMemory) {
-            _memoryHandle.getBean().addPropertyChangeListener("value", _listener);
-            _listenersAreRegistered = true;
-        }
-    }
-
-    /**
-     * Unregister listeners if this object needs that.
-     */
-    public void unregisterListeners() {
-        if (_listenersAreRegistered
-                && (_addressing == NamedBeanAddressing.Memory)
-                && (_memoryHandle != null)
-                && _listenToMemory) {
-            _memoryHandle.getBean().removePropertyChangeListener("value", _listener);
-            _listenersAreRegistered = false;
-        }
     }
 
     @Override

--- a/java/src/jmri/jmrit/logixng/util/LogixNG_SelectInteger.java
+++ b/java/src/jmri/jmrit/logixng/util/LogixNG_SelectInteger.java
@@ -1,7 +1,6 @@
 package jmri.jmrit.logixng.util;
 
 import java.beans.PropertyChangeEvent;
-import java.beans.PropertyChangeListener;
 import java.beans.PropertyVetoException;
 import java.beans.VetoableChangeListener;
 import java.util.HashMap;
@@ -27,9 +26,6 @@ public class LogixNG_SelectInteger implements VetoableChangeListener {
     private final AbstractBase _base;
     private final InUse _inUse;
     private final LogixNG_SelectTable _selectTable;
-    private final PropertyChangeListener _listener;
-    private boolean _listenToMemory;
-    private boolean _listenersAreRegistered;
     private final FormatterParserValidator _formatterParserValidator;
 
     private NamedBeanAddressing _addressing = NamedBeanAddressing.Direct;
@@ -41,21 +37,16 @@ public class LogixNG_SelectInteger implements VetoableChangeListener {
     private ExpressionNode _expressionNode;
 
 
-    public LogixNG_SelectInteger(
-            @Nonnull AbstractBase base,
-            @Nonnull PropertyChangeListener listener) {
-
-        this(base, listener, new DefaultFormatterParserValidator());
+    public LogixNG_SelectInteger(@Nonnull AbstractBase base) {
+        this(base, new DefaultFormatterParserValidator());
     }
 
     public LogixNG_SelectInteger(
             @Nonnull AbstractBase base,
-            @Nonnull PropertyChangeListener listener,
             @Nonnull FormatterParserValidator formatterParserValidator) {
         _base = base;
         _inUse = () -> true;
         _selectTable = new LogixNG_SelectTable(_base, _inUse);
-        _listener = listener;
         _formatterParserValidator = formatterParserValidator;
         _value = _formatterParserValidator.getInitialValue();
     }
@@ -66,7 +57,6 @@ public class LogixNG_SelectInteger implements VetoableChangeListener {
         copy.setLocalVariable(_localVariable);
         copy.setReference(_reference);
         copy.setMemory(_memoryHandle);
-        copy.setListenToMemory(_listenToMemory);
         copy.setFormula(_formula);
         _selectTable.copy(copy._selectTable);
     }
@@ -145,14 +135,6 @@ public class LogixNG_SelectInteger implements VetoableChangeListener {
 
     public NamedBeanHandle<Memory> getMemory() {
         return _memoryHandle;
-    }
-
-    public void setListenToMemory(boolean listenToMemory) {
-        _listenToMemory = listenToMemory;
-    }
-
-    public boolean getListenToMemory() {
-        return _listenToMemory;
     }
 
     public void setLocalVariable(@Nonnull String localVariable) {
@@ -269,7 +251,7 @@ public class LogixNG_SelectInteger implements VetoableChangeListener {
                 break;
 
             case Memory:
-                enumName = Bundle.getMessage(locale, "AddressByMemory_Listen", memoryName, Base.getListenString(_listenToMemory));
+                enumName = Bundle.getMessage(locale, "AddressByMemory", memoryName);
                 break;
 
             case LocalVariable:
@@ -293,32 +275,6 @@ public class LogixNG_SelectInteger implements VetoableChangeListener {
                 throw new IllegalArgumentException("invalid _addressing: " + _addressing.name());
         }
         return enumName;
-    }
-
-    /**
-     * Register listeners if this object needs that.
-     */
-    public void registerListeners() {
-        if (!_listenersAreRegistered
-                && (_addressing == NamedBeanAddressing.Memory)
-                && (_memoryHandle != null)
-                && _listenToMemory) {
-            _memoryHandle.getBean().addPropertyChangeListener("value", _listener);
-            _listenersAreRegistered = true;
-        }
-    }
-
-    /**
-     * Unregister listeners if this object needs that.
-     */
-    public void unregisterListeners() {
-        if (_listenersAreRegistered
-                && (_addressing == NamedBeanAddressing.Memory)
-                && (_memoryHandle != null)
-                && _listenToMemory) {
-            _memoryHandle.getBean().removePropertyChangeListener("value", _listener);
-            _listenersAreRegistered = false;
-        }
     }
 
     @Override

--- a/java/src/jmri/jmrit/logixng/util/LogixNG_SelectNamedBean.java
+++ b/java/src/jmri/jmrit/logixng/util/LogixNG_SelectNamedBean.java
@@ -27,9 +27,6 @@ public class LogixNG_SelectNamedBean<E extends NamedBean> implements VetoableCha
     private final Class<E> _class;
     private final Manager<E> _manager;
     private final LogixNG_SelectTable _selectTable;
-    private final PropertyChangeListener _listener;
-    private boolean _listenToMemory;
-    private boolean _listenersAreRegistered;
     private boolean _onlyDirectAddressingAllowed;
 
     private NamedBeanAddressing _addressing = NamedBeanAddressing.Direct;
@@ -43,22 +40,20 @@ public class LogixNG_SelectNamedBean<E extends NamedBean> implements VetoableCha
     private String _delayedNamedBean;
 
 
-    public LogixNG_SelectNamedBean(AbstractBase base, Class<E> clazz, Manager<E> manager, PropertyChangeListener listener) {
+    public LogixNG_SelectNamedBean(AbstractBase base, Class<E> clazz, Manager<E> manager) {
         _base = base;
         _inUse = () -> true;
         _class = clazz;
         _manager = manager;
         _selectTable = new LogixNG_SelectTable(_base, _inUse);
-        _listener = listener;
     }
 
-    public LogixNG_SelectNamedBean(AbstractBase base, Class<E> clazz, Manager<E> manager, InUse inUse, PropertyChangeListener listener) {
+    public LogixNG_SelectNamedBean(AbstractBase base, Class<E> clazz, Manager<E> manager, InUse inUse) {
         _base = base;
         _inUse = inUse;
         _class = clazz;
         _manager = manager;
         _selectTable = new LogixNG_SelectTable(_base, _inUse);
-        _listener = listener;
     }
 
     public void setOnlyDirectAddressingAllowed() {
@@ -75,7 +70,6 @@ public class LogixNG_SelectNamedBean<E extends NamedBean> implements VetoableCha
         copy.setLocalVariable(_localVariable);
         copy.setReference(_reference);
         copy.setMemory(_memoryHandle);
-        copy.setListenToMemory(_listenToMemory);
         copy.setFormula(_formula);
         _selectTable.copy(copy._selectTable);
     }
@@ -205,14 +199,6 @@ public class LogixNG_SelectNamedBean<E extends NamedBean> implements VetoableCha
         return _memoryHandle;
     }
 
-    public void setListenToMemory(boolean listenToMemory) {
-        _listenToMemory = listenToMemory;
-    }
-
-    public boolean getListenToMemory() {
-        return _listenToMemory;
-    }
-
     public void setLocalVariable(@Nonnull String localVariable) {
         _localVariable = localVariable;
     }
@@ -328,7 +314,7 @@ public class LogixNG_SelectNamedBean<E extends NamedBean> implements VetoableCha
                 break;
 
             case Memory:
-                namedBean = Bundle.getMessage(locale, "AddressByMemory_Listen", memoryName, Base.getListenString(_listenToMemory));
+                namedBean = Bundle.getMessage(locale, "AddressByMemory", memoryName);
                 break;
 
             case LocalVariable:
@@ -352,32 +338,6 @@ public class LogixNG_SelectNamedBean<E extends NamedBean> implements VetoableCha
                 throw new IllegalArgumentException("invalid _addressing: " + _addressing.name());
         }
         return namedBean;
-    }
-
-    /**
-     * Register listeners if this object needs that.
-     */
-    public void registerListeners() {
-        if (!_listenersAreRegistered
-                && (_addressing == NamedBeanAddressing.Memory)
-                && (_memoryHandle != null)
-                && _listenToMemory) {
-            _memoryHandle.getBean().addPropertyChangeListener("value", _listener);
-            _listenersAreRegistered = true;
-        }
-    }
-
-    /**
-     * Unregister listeners if this object needs that.
-     */
-    public void unregisterListeners() {
-        if (_listenersAreRegistered
-                && (_addressing == NamedBeanAddressing.Memory)
-                && (_memoryHandle != null)
-                && _listenToMemory) {
-            _memoryHandle.getBean().removePropertyChangeListener("value", _listener);
-            _listenersAreRegistered = false;
-        }
     }
 
     @Override

--- a/java/src/jmri/jmrit/logixng/util/LogixNG_SelectString.java
+++ b/java/src/jmri/jmrit/logixng/util/LogixNG_SelectString.java
@@ -1,7 +1,6 @@
 package jmri.jmrit.logixng.util;
 
 import java.beans.PropertyChangeEvent;
-import java.beans.PropertyChangeListener;
 import java.beans.PropertyVetoException;
 import java.beans.VetoableChangeListener;
 import java.util.HashMap;
@@ -27,9 +26,6 @@ public class LogixNG_SelectString implements VetoableChangeListener {
     private final AbstractBase _base;
     private final InUse _inUse;
     private final LogixNG_SelectTable _selectTable;
-    private final PropertyChangeListener _listener;
-    private boolean _listenToMemory;
-    private boolean _listenersAreRegistered;
     private boolean _onlyDirectAddressingAllowed;
 
     private NamedBeanAddressing _addressing = NamedBeanAddressing.Direct;
@@ -41,19 +37,18 @@ public class LogixNG_SelectString implements VetoableChangeListener {
     private ExpressionNode _expressionNode;
 
 
-    public LogixNG_SelectString(AbstractBase base, InUse inUse, PropertyChangeListener listener) {
+    public LogixNG_SelectString(AbstractBase base, InUse inUse) {
         _base = base;
         _inUse = inUse;
         _selectTable = new LogixNG_SelectTable(_base, _inUse);
-        _listener = listener;
     }
 
-    public LogixNG_SelectString(AbstractBase base, PropertyChangeListener listener) {
-        this(base, () -> true, listener);
+    public LogixNG_SelectString(AbstractBase base) {
+        this(base, () -> true);
     }
 
-    public LogixNG_SelectString(AbstractBase base, String defaultValue, PropertyChangeListener listener) {
-        this(base, listener);
+    public LogixNG_SelectString(AbstractBase base, String defaultValue) {
+        this(base);
         _value = defaultValue;
     }
 
@@ -71,7 +66,6 @@ public class LogixNG_SelectString implements VetoableChangeListener {
         copy.setLocalVariable(_localVariable);
         copy.setReference(_reference);
         copy.setMemory(_memoryHandle);
-        copy.setListenToMemory(_listenToMemory);
         copy.setFormula(_formula);
         _selectTable.copy(copy._selectTable);
     }
@@ -142,14 +136,6 @@ public class LogixNG_SelectString implements VetoableChangeListener {
 
     public NamedBeanHandle<Memory> getMemory() {
         return _memoryHandle;
-    }
-
-    public void setListenToMemory(boolean listenToMemory) {
-        _listenToMemory = listenToMemory;
-    }
-
-    public boolean getListenToMemory() {
-        return _listenToMemory;
     }
 
     public void setLocalVariable(@Nonnull String localVariable) {
@@ -253,7 +239,7 @@ public class LogixNG_SelectString implements VetoableChangeListener {
                 break;
 
             case Memory:
-                enumName = Bundle.getMessage(locale, "AddressByMemory_Listen", memoryName, Base.getListenString(_listenToMemory));
+                enumName = Bundle.getMessage(locale, "AddressByMemory", memoryName);
                 break;
 
             case LocalVariable:
@@ -277,32 +263,6 @@ public class LogixNG_SelectString implements VetoableChangeListener {
                 throw new IllegalArgumentException("invalid _addressing: " + _addressing.name());
         }
         return enumName;
-    }
-
-    /**
-     * Register listeners if this object needs that.
-     */
-    public void registerListeners() {
-        if (!_listenersAreRegistered
-                && (_addressing == NamedBeanAddressing.Memory)
-                && (_memoryHandle != null)
-                && _listenToMemory) {
-            _memoryHandle.getBean().addPropertyChangeListener("value", _listener);
-            _listenersAreRegistered = true;
-        }
-    }
-
-    /**
-     * Unregister listeners if this object needs that.
-     */
-    public void unregisterListeners() {
-        if (_listenersAreRegistered
-                && (_addressing == NamedBeanAddressing.Memory)
-                && (_memoryHandle != null)
-                && _listenToMemory) {
-            _memoryHandle.getBean().removePropertyChangeListener("value", _listener);
-            _listenersAreRegistered = false;
-        }
     }
 
     @Override

--- a/java/src/jmri/jmrit/logixng/util/UtilBundle.properties
+++ b/java/src/jmri/jmrit/logixng/util/UtilBundle.properties
@@ -22,8 +22,6 @@ LogixNG_SelectCharset_Addressing_UserSpecified  = User specified
 
 LogixNG_SelectInteger_MustBeValidInteger    = The value must be a valid integer
 
-ListenToMemory                  = Listen
-
 MemoryInUseMemoryExpressionVeto = Memory is in use by LogixNG action/expression "{0}"
 
 Boolean_True                    = True

--- a/java/src/jmri/jmrit/logixng/util/UtilBundle_cs.properties
+++ b/java/src/jmri/jmrit/logixng/util/UtilBundle_cs.properties
@@ -22,8 +22,6 @@ LogixNG_SelectCharset_Addressing_UserSpecified  = Zadan\u00fd u\u017eivatelem
 
 LogixNG_SelectInteger_MustBeValidInteger    = Hodnota mus\u00ed b\u00fdt platn\u00e9 cel\u00e9 \u010d\u00edslo
 
-ListenToMemory                  = Poslouchat
-
 MemoryInUseMemoryExpressionVeto = Pam\u011b\u0165 je pou\u017e\u00edv\u00e1na LogixNG akc\u00ed/v\u00fdrazem "{0}"
 
 Boolean_True                    = Pravda

--- a/java/src/jmri/jmrit/logixng/util/configurexml/LogixNG_SelectBooleanXml.java
+++ b/java/src/jmri/jmrit/logixng/util/configurexml/LogixNG_SelectBooleanXml.java
@@ -37,7 +37,8 @@ public class LogixNG_SelectBooleanXml {
         if (memory != null) {
             intElement.addContent(new Element("memory").addContent(memory.getName()));
         }
-        intElement.addContent(new Element("listenToMemory").addContent(selectBoolean.getListenToMemory() ? "yes" : "no"));
+        // Not used anymore. It's kept to not change old tables and panels files
+        intElement.addContent(new Element("listenToMemory").addContent("no"));
         if (selectBoolean.getLocalVariable() != null && !selectBoolean.getLocalVariable().isEmpty()) {
             intElement.addContent(new Element("localVariable").addContent(selectBoolean.getLocalVariable()));
         }
@@ -78,11 +79,6 @@ public class LogixNG_SelectBooleanXml {
                     Memory m = InstanceManager.getDefault(MemoryManager.class).getMemory(memoryName.getTextTrim());
                     if (m != null) selectBoolean.setMemory(m);
                     else selectBoolean.removeMemory();
-                }
-
-                Element listenToMemoryElem = booleanElement.getChild("listenToMemory");
-                if (listenToMemoryElem != null) {
-                    selectBoolean.setListenToMemory("yes".equals(listenToMemoryElem.getTextTrim()));
                 }
 
                 elem = booleanElement.getChild("localVariable");

--- a/java/src/jmri/jmrit/logixng/util/configurexml/LogixNG_SelectComboBoxXml.java
+++ b/java/src/jmri/jmrit/logixng/util/configurexml/LogixNG_SelectComboBoxXml.java
@@ -41,7 +41,8 @@ public class LogixNG_SelectComboBoxXml {
         if (memory != null) {
             comboBoxElement.addContent(new Element("memory").addContent(memory.getName()));
         }
-        comboBoxElement.addContent(new Element("listenToMemory").addContent(selectComboBox.getListenToMemory() ? "yes" : "no"));
+        // Not used anymore. It's kept to not change old tables and panels files
+        comboBoxElement.addContent(new Element("listenToMemory").addContent("no"));
         if (selectComboBox.getLocalVariable() != null && !selectComboBox.getLocalVariable().isEmpty()) {
             comboBoxElement.addContent(new Element("localVariable").addContent(selectComboBox.getLocalVariable()));
         }
@@ -82,11 +83,6 @@ public class LogixNG_SelectComboBoxXml {
                     Memory m = InstanceManager.getDefault(MemoryManager.class).getMemory(memoryName.getTextTrim());
                     if (m != null) selectComboBox.setMemory(m);
                     else selectComboBox.removeMemory();
-                }
-
-                Element listenToMemoryElem = comboBoxElement.getChild("listenToMemory");
-                if (listenToMemoryElem != null) {
-                    selectComboBox.setListenToMemory("yes".equals(listenToMemoryElem.getTextTrim()));
                 }
 
                 elem = comboBoxElement.getChild("localVariable");

--- a/java/src/jmri/jmrit/logixng/util/configurexml/LogixNG_SelectDoubleXml.java
+++ b/java/src/jmri/jmrit/logixng/util/configurexml/LogixNG_SelectDoubleXml.java
@@ -37,7 +37,8 @@ public class LogixNG_SelectDoubleXml {
         if (memory != null) {
             doubleElement.addContent(new Element("memory").addContent(memory.getName()));
         }
-        doubleElement.addContent(new Element("listenToMemory").addContent(selectDouble.getListenToMemory() ? "yes" : "no"));
+        // Not used anymore. It's kept to not change old tables and panels files
+        doubleElement.addContent(new Element("listenToMemory").addContent("no"));
         if (selectDouble.getLocalVariable() != null && !selectDouble.getLocalVariable().isEmpty()) {
             doubleElement.addContent(new Element("localVariable").addContent(selectDouble.getLocalVariable()));
         }
@@ -78,11 +79,6 @@ public class LogixNG_SelectDoubleXml {
                     Memory m = InstanceManager.getDefault(MemoryManager.class).getMemory(memoryName.getTextTrim());
                     if (m != null) selectDouble.setMemory(m);
                     else selectDouble.removeMemory();
-                }
-
-                Element listenToMemoryElem = doubleElement.getChild("listenToMemory");
-                if (listenToMemoryElem != null) {
-                    selectDouble.setListenToMemory("yes".equals(listenToMemoryElem.getTextTrim()));
                 }
 
                 elem = doubleElement.getChild("localVariable");

--- a/java/src/jmri/jmrit/logixng/util/configurexml/LogixNG_SelectEnumXml.java
+++ b/java/src/jmri/jmrit/logixng/util/configurexml/LogixNG_SelectEnumXml.java
@@ -39,7 +39,8 @@ public class LogixNG_SelectEnumXml<E extends Enum<?>> {
         if (memory != null) {
             enumElement.addContent(new Element("memory").addContent(memory.getName()));
         }
-        enumElement.addContent(new Element("listenToMemory").addContent(selectEnum.getListenToMemory() ? "yes" : "no"));
+        // Not used anymore. It's kept to not change old tables and panels files
+        enumElement.addContent(new Element("listenToMemory").addContent("no"));
         if (selectEnum.getLocalVariable() != null && !selectEnum.getLocalVariable().isEmpty()) {
             enumElement.addContent(new Element("localVariable").addContent(selectEnum.getLocalVariable()));
         }
@@ -80,11 +81,6 @@ public class LogixNG_SelectEnumXml<E extends Enum<?>> {
                     Memory m = InstanceManager.getDefault(MemoryManager.class).getMemory(memoryName.getTextTrim());
                     if (m != null) selectEnum.setMemory(m);
                     else selectEnum.removeMemory();
-                }
-
-                Element listenToMemoryElem = enumElement.getChild("listenToMemory");
-                if (listenToMemoryElem != null) {
-                    selectEnum.setListenToMemory("yes".equals(listenToMemoryElem.getTextTrim()));
                 }
 
                 elem = enumElement.getChild("localVariable");

--- a/java/src/jmri/jmrit/logixng/util/configurexml/LogixNG_SelectIntegerXml.java
+++ b/java/src/jmri/jmrit/logixng/util/configurexml/LogixNG_SelectIntegerXml.java
@@ -37,7 +37,8 @@ public class LogixNG_SelectIntegerXml {
         if (memory != null) {
             intElement.addContent(new Element("memory").addContent(memory.getName()));
         }
-        intElement.addContent(new Element("listenToMemory").addContent(selectInt.getListenToMemory() ? "yes" : "no"));
+        // Not used anymore. It's kept to not change old tables and panels files
+        intElement.addContent(new Element("listenToMemory").addContent("no"));
         if (selectInt.getLocalVariable() != null && !selectInt.getLocalVariable().isEmpty()) {
             intElement.addContent(new Element("localVariable").addContent(selectInt.getLocalVariable()));
         }
@@ -78,11 +79,6 @@ public class LogixNG_SelectIntegerXml {
                     Memory m = InstanceManager.getDefault(MemoryManager.class).getMemory(memoryName.getTextTrim());
                     if (m != null) selectInt.setMemory(m);
                     else selectInt.removeMemory();
-                }
-
-                Element listenToMemoryElem = intElement.getChild("listenToMemory");
-                if (listenToMemoryElem != null) {
-                    selectInt.setListenToMemory("yes".equals(listenToMemoryElem.getTextTrim()));
                 }
 
                 elem = intElement.getChild("localVariable");

--- a/java/src/jmri/jmrit/logixng/util/configurexml/LogixNG_SelectNamedBeanXml.java
+++ b/java/src/jmri/jmrit/logixng/util/configurexml/LogixNG_SelectNamedBeanXml.java
@@ -62,7 +62,8 @@ public class LogixNG_SelectNamedBeanXml<E extends NamedBean> {
         if (memory != null) {
             namedBeanElement.addContent(new Element("memory").addContent(memory.getName()));
         }
-        namedBeanElement.addContent(new Element("listenToMemory").addContent(selectNamedBean.getListenToMemory() ? "yes" : "no"));
+        // Not used anymore. It's kept to not change old tables and panels files
+        namedBeanElement.addContent(new Element("listenToMemory").addContent("no"));
         if (selectNamedBean.getLocalVariable() != null && !selectNamedBean.getLocalVariable().isEmpty()) {
             namedBeanElement.addContent(new Element("localVariable").addContent(selectNamedBean.getLocalVariable()));
         }
@@ -113,11 +114,6 @@ public class LogixNG_SelectNamedBeanXml<E extends NamedBean> {
                     Memory m = InstanceManager.getDefault(MemoryManager.class).getMemory(memoryName.getTextTrim());
                     if (m != null) selectNamedBean.setMemory(m);
                     else selectNamedBean.removeMemory();
-                }
-
-                Element listenToMemoryElem = namedBeanElement.getChild("listenToMemory");
-                if (listenToMemoryElem != null) {
-                    selectNamedBean.setListenToMemory("yes".equals(listenToMemoryElem.getTextTrim()));
                 }
 
                 elem = namedBeanElement.getChild("localVariable");

--- a/java/src/jmri/jmrit/logixng/util/configurexml/LogixNG_SelectStringXml.java
+++ b/java/src/jmri/jmrit/logixng/util/configurexml/LogixNG_SelectStringXml.java
@@ -39,7 +39,8 @@ public class LogixNG_SelectStringXml {
         if (memory != null) {
             enumElement.addContent(new Element("memory").addContent(memory.getName()));
         }
-        enumElement.addContent(new Element("listenToMemory").addContent(selectStr.getListenToMemory() ? "yes" : "no"));
+        // Not used anymore. It's kept to not change old tables and panels files
+        enumElement.addContent(new Element("listenToMemory").addContent("no"));
         if (selectStr.getLocalVariable() != null && !selectStr.getLocalVariable().isEmpty()) {
             enumElement.addContent(new Element("localVariable").addContent(selectStr.getLocalVariable()));
         }
@@ -80,11 +81,6 @@ public class LogixNG_SelectStringXml {
                     Memory m = InstanceManager.getDefault(MemoryManager.class).getMemory(memoryName.getTextTrim());
                     if (m != null) selectStr.setMemory(m);
                     else selectStr.removeMemory();
-                }
-
-                Element listenToMemoryElem = strElement.getChild("listenToMemory");
-                if (listenToMemoryElem != null) {
-                    selectStr.setListenToMemory("yes".equals(listenToMemoryElem.getTextTrim()));
                 }
 
                 elem = strElement.getChild("localVariable");

--- a/java/src/jmri/jmrit/logixng/util/swing/LogixNG_SelectBooleanSwing.java
+++ b/java/src/jmri/jmrit/logixng/util/swing/LogixNG_SelectBooleanSwing.java
@@ -32,7 +32,6 @@ public class LogixNG_SelectBooleanSwing {
     private JPanel _panelTable;
     private JTextField _referenceTextField;
     private BeanSelectPanel<Memory> _memoryPanel;
-    private JCheckBox _listenToMemoryCheckBox;
     private JTextField _localVariableTextField;
     private JTextField _formulaTextField;
 
@@ -57,11 +56,9 @@ public class LogixNG_SelectBooleanSwing {
         _panelTable = _selectTableSwing.createPanel(selectBoolean.getSelectTable());
 
         _memoryPanel = new BeanSelectPanel<>(InstanceManager.getDefault(MemoryManager.class), null);
-        _listenToMemoryCheckBox = new JCheckBox(Bundle.getMessage("ListenToMemory"));
 
         _panelMemory.setLayout(new BoxLayout(_panelMemory, BoxLayout.Y_AXIS));
         _panelMemory.add(_memoryPanel);
-        _panelMemory.add(_listenToMemoryCheckBox);
 
         _tabbedPane.addTab(NamedBeanAddressing.Direct.toString(), _panelDirect);
         _tabbedPane.addTab(NamedBeanAddressing.Reference.toString(), _panelReference);
@@ -98,7 +95,6 @@ public class LogixNG_SelectBooleanSwing {
         _valueCheckBox.setSelected(selectBoolean.getValue());
         _referenceTextField.setText(selectBoolean.getReference());
         _memoryPanel.setDefaultNamedBean(selectBoolean.getMemory());
-        _listenToMemoryCheckBox.setSelected(selectBoolean.getListenToMemory());
         _localVariableTextField.setText(selectBoolean.getLocalVariable());
         _formulaTextField.setText(selectBoolean.getFormula());
 
@@ -161,7 +157,6 @@ public class LogixNG_SelectBooleanSwing {
             } else if (_tabbedPane.getSelectedComponent() == _panelMemory) {
                 selectBoolean.setAddressing(NamedBeanAddressing.Memory);
                 selectBoolean.setMemory(_memoryPanel.getNamedBean());
-                selectBoolean.setListenToMemory(_listenToMemoryCheckBox.isSelected());
             } else if (_tabbedPane.getSelectedComponent() == _panelLocalVariable) {
                 selectBoolean.setAddressing(NamedBeanAddressing.LocalVariable);
                 selectBoolean.setLocalVariable(_localVariableTextField.getText());
@@ -185,7 +180,6 @@ public class LogixNG_SelectBooleanSwing {
         _valueCheckBox.setEnabled(enabled);
         _referenceTextField.setEnabled(enabled);
         _memoryPanel.getBeanCombo().setEnabled(enabled);
-        _listenToMemoryCheckBox.setEnabled(enabled);
         _localVariableTextField.setEnabled(enabled);
         _formulaTextField.setEnabled(enabled);
         _selectTableSwing.setEnabled(enabled);

--- a/java/src/jmri/jmrit/logixng/util/swing/LogixNG_SelectComboBoxSwing.java
+++ b/java/src/jmri/jmrit/logixng/util/swing/LogixNG_SelectComboBoxSwing.java
@@ -37,7 +37,6 @@ public class LogixNG_SelectComboBoxSwing {
     private JPanel _panelTable;
     private JTextField _referenceTextField;
     private BeanSelectPanel<Memory> _memoryPanel;
-    private JCheckBox _listenToMemoryCheckBox;
     private JTextField _localVariableTextField;
     private JTextField _formulaTextField;
 
@@ -68,11 +67,9 @@ public class LogixNG_SelectComboBoxSwing {
         _panelTable = _selectTableSwing.createPanel(selectComboBox.getSelectTable());
 
         _memoryPanel = new BeanSelectPanel<>(InstanceManager.getDefault(MemoryManager.class), null);
-        _listenToMemoryCheckBox = new JCheckBox(Bundle.getMessage("ListenToMemory"));
 
         _panelMemory.setLayout(new BoxLayout(_panelMemory, BoxLayout.Y_AXIS));
         _panelMemory.add(_memoryPanel);
-        _panelMemory.add(_listenToMemoryCheckBox);
 
         _tabbedPane.addTab(NamedBeanAddressing.Direct.toString(), _panelDirect);
         _tabbedPane.addTab(NamedBeanAddressing.Reference.toString(), _panelReference);
@@ -121,7 +118,6 @@ public class LogixNG_SelectComboBoxSwing {
         }
         _referenceTextField.setText(selectComboBox.getReference());
         _memoryPanel.setDefaultNamedBean(selectComboBox.getMemory());
-        _listenToMemoryCheckBox.setSelected(selectComboBox.getListenToMemory());
         _localVariableTextField.setText(selectComboBox.getLocalVariable());
         _formulaTextField.setText(selectComboBox.getFormula());
 
@@ -181,7 +177,6 @@ public class LogixNG_SelectComboBoxSwing {
             } else if (_tabbedPane.getSelectedComponent() == _panelMemory) {
                 selectComboBox.setAddressing(NamedBeanAddressing.Memory);
                 selectComboBox.setMemory(_memoryPanel.getNamedBean());
-                selectComboBox.setListenToMemory(_listenToMemoryCheckBox.isSelected());
             } else if (_tabbedPane.getSelectedComponent() == _panelLocalVariable) {
                 selectComboBox.setAddressing(NamedBeanAddressing.LocalVariable);
                 selectComboBox.setLocalVariable(_localVariableTextField.getText());

--- a/java/src/jmri/jmrit/logixng/util/swing/LogixNG_SelectDoubleSwing.java
+++ b/java/src/jmri/jmrit/logixng/util/swing/LogixNG_SelectDoubleSwing.java
@@ -32,7 +32,6 @@ public class LogixNG_SelectDoubleSwing {
     private JPanel _panelTable;
     private JTextField _referenceTextField;
     private BeanSelectPanel<Memory> _memoryPanel;
-    private JCheckBox _listenToMemoryCheckBox;
     private JTextField _localVariableTextField;
     private JTextField _formulaTextField;
 
@@ -60,11 +59,9 @@ public class LogixNG_SelectDoubleSwing {
         _panelTable = _selectTableSwing.createPanel(selectDouble.getSelectTable());
 
         _memoryPanel = new BeanSelectPanel<>(InstanceManager.getDefault(MemoryManager.class), null);
-        _listenToMemoryCheckBox = new JCheckBox(Bundle.getMessage("ListenToMemory"));
 
         _panelMemory.setLayout(new BoxLayout(_panelMemory, BoxLayout.Y_AXIS));
         _panelMemory.add(_memoryPanel);
-        _panelMemory.add(_listenToMemoryCheckBox);
 
         _tabbedPane.addTab(NamedBeanAddressing.Direct.toString(), _panelDirect);
         _tabbedPane.addTab(NamedBeanAddressing.Reference.toString(), _panelReference);
@@ -103,7 +100,6 @@ public class LogixNG_SelectDoubleSwing {
         _valueTextField.setText(_formatterParserValidator.format(selectDouble.getValue()));
         _referenceTextField.setText(selectDouble.getReference());
         _memoryPanel.setDefaultNamedBean(selectDouble.getMemory());
-        _listenToMemoryCheckBox.setSelected(selectDouble.getListenToMemory());
         _localVariableTextField.setText(selectDouble.getLocalVariable());
         _formulaTextField.setText(selectDouble.getFormula());
 
@@ -173,7 +169,6 @@ public class LogixNG_SelectDoubleSwing {
             } else if (_tabbedPane.getSelectedComponent() == _panelMemory) {
                 selectDouble.setAddressing(NamedBeanAddressing.Memory);
                 selectDouble.setMemory(_memoryPanel.getNamedBean());
-                selectDouble.setListenToMemory(_listenToMemoryCheckBox.isSelected());
             } else if (_tabbedPane.getSelectedComponent() == _panelLocalVariable) {
                 selectDouble.setAddressing(NamedBeanAddressing.LocalVariable);
                 selectDouble.setLocalVariable(_localVariableTextField.getText());

--- a/java/src/jmri/jmrit/logixng/util/swing/LogixNG_SelectEnumSwing.java
+++ b/java/src/jmri/jmrit/logixng/util/swing/LogixNG_SelectEnumSwing.java
@@ -29,7 +29,7 @@ public class LogixNG_SelectEnumSwing<E extends Enum<?>> {
 
     private final JDialog _dialog;
     private final LogixNG_SelectTableSwing _selectTableSwing;
-    
+
     private LogixNG_SelectEnumSwing_EnumDialog<E> _enumDialog;
     private E[] _enumArray;
 
@@ -43,7 +43,6 @@ public class LogixNG_SelectEnumSwing<E extends Enum<?>> {
     private JPanel _panelTable;
     private JTextField _referenceTextField;
     private BeanSelectPanel<Memory> _memoryPanel;
-    private JCheckBox _listenToMemoryCheckBox;
     private JTextField _localVariableTextField;
     private JTextField _formulaTextField;
 
@@ -80,12 +79,10 @@ public class LogixNG_SelectEnumSwing<E extends Enum<?>> {
         }
 
         _memoryPanel = new BeanSelectPanel<>(InstanceManager.getDefault(MemoryManager.class), null);
-        _listenToMemoryCheckBox = new JCheckBox(Bundle.getMessage("ListenToMemory"));
 
         _panelMemory.setLayout(new BoxLayout(_panelMemory, BoxLayout.Y_AXIS));
         _panelMemory.add(_memoryPanel);
         _panelMemory.add(createEnumDialogButton());
-        _panelMemory.add(_listenToMemoryCheckBox);
 
         _tabbedPane.addTab(NamedBeanAddressing.Direct.toString(), _panelDirect);
         _tabbedPane.addTab(NamedBeanAddressing.Reference.toString(), _panelReference);
@@ -140,7 +137,6 @@ public class LogixNG_SelectEnumSwing<E extends Enum<?>> {
             }
             _referenceTextField.setText(selectEnum.getReference());
             _memoryPanel.setDefaultNamedBean(selectEnum.getMemory());
-            _listenToMemoryCheckBox.setSelected(selectEnum.getListenToMemory());
             _localVariableTextField.setText(selectEnum.getLocalVariable());
             _formulaTextField.setText(selectEnum.getFormula());
         }
@@ -148,13 +144,13 @@ public class LogixNG_SelectEnumSwing<E extends Enum<?>> {
         panel.add(_tabbedPane);
         return panel;
     }
-    
+
     public JButton createEnumDialogButton() {
         JButton enumDialogButton = new JButton(Bundle.getMessage("LogixNG_SelectEnumSwing_ButtonEnumDialog"));  // NOI18N
         enumDialogButton.addActionListener(this::showEnumDialog);
         return enumDialogButton;
     }
-    
+
     public void showEnumDialog(ActionEvent e) {
         if (_enumDialog != null) {
             _enumDialog.setVisible(true);
@@ -212,7 +208,6 @@ public class LogixNG_SelectEnumSwing<E extends Enum<?>> {
             } else if (_tabbedPane.getSelectedComponent() == _panelMemory) {
                 selectEnum.setAddressing(NamedBeanAddressing.Memory);
                 selectEnum.setMemory(_memoryPanel.getNamedBean());
-                selectEnum.setListenToMemory(_listenToMemoryCheckBox.isSelected());
             } else if (_tabbedPane.getSelectedComponent() == _panelLocalVariable) {
                 selectEnum.setAddressing(NamedBeanAddressing.LocalVariable);
                 selectEnum.setLocalVariable(_localVariableTextField.getText());

--- a/java/src/jmri/jmrit/logixng/util/swing/LogixNG_SelectIntegerSwing.java
+++ b/java/src/jmri/jmrit/logixng/util/swing/LogixNG_SelectIntegerSwing.java
@@ -32,7 +32,6 @@ public class LogixNG_SelectIntegerSwing {
     private JPanel _panelTable;
     private JTextField _referenceTextField;
     private BeanSelectPanel<Memory> _memoryPanel;
-    private JCheckBox _listenToMemoryCheckBox;
     private JTextField _localVariableTextField;
     private JTextField _formulaTextField;
 
@@ -60,11 +59,9 @@ public class LogixNG_SelectIntegerSwing {
         _panelTable = _selectTableSwing.createPanel(selectInteger.getSelectTable());
 
         _memoryPanel = new BeanSelectPanel<>(InstanceManager.getDefault(MemoryManager.class), null);
-        _listenToMemoryCheckBox = new JCheckBox(Bundle.getMessage("ListenToMemory"));
 
         _panelMemory.setLayout(new BoxLayout(_panelMemory, BoxLayout.Y_AXIS));
         _panelMemory.add(_memoryPanel);
-        _panelMemory.add(_listenToMemoryCheckBox);
 
         _tabbedPane.addTab(NamedBeanAddressing.Direct.toString(), _panelDirect);
         _tabbedPane.addTab(NamedBeanAddressing.Reference.toString(), _panelReference);
@@ -103,7 +100,6 @@ public class LogixNG_SelectIntegerSwing {
         _valueTextField.setText(_formatterParserValidator.format(selectInteger.getValue()));
         _referenceTextField.setText(selectInteger.getReference());
         _memoryPanel.setDefaultNamedBean(selectInteger.getMemory());
-        _listenToMemoryCheckBox.setSelected(selectInteger.getListenToMemory());
         _localVariableTextField.setText(selectInteger.getLocalVariable());
         _formulaTextField.setText(selectInteger.getFormula());
 
@@ -173,7 +169,6 @@ public class LogixNG_SelectIntegerSwing {
             } else if (_tabbedPane.getSelectedComponent() == _panelMemory) {
                 selectInteger.setAddressing(NamedBeanAddressing.Memory);
                 selectInteger.setMemory(_memoryPanel.getNamedBean());
-                selectInteger.setListenToMemory(_listenToMemoryCheckBox.isSelected());
             } else if (_tabbedPane.getSelectedComponent() == _panelLocalVariable) {
                 selectInteger.setAddressing(NamedBeanAddressing.LocalVariable);
                 selectInteger.setLocalVariable(_localVariableTextField.getText());
@@ -197,7 +192,6 @@ public class LogixNG_SelectIntegerSwing {
         _valueTextField.setEnabled(enabled);
         _referenceTextField.setEnabled(enabled);
         _memoryPanel.getBeanCombo().setEnabled(enabled);
-        _listenToMemoryCheckBox.setEnabled(enabled);
         _localVariableTextField.setEnabled(enabled);
         _formulaTextField.setEnabled(enabled);
         _selectTableSwing.setEnabled(enabled);

--- a/java/src/jmri/jmrit/logixng/util/swing/LogixNG_SelectNamedBeanSwing.java
+++ b/java/src/jmri/jmrit/logixng/util/swing/LogixNG_SelectNamedBeanSwing.java
@@ -39,7 +39,6 @@ public class LogixNG_SelectNamedBeanSwing<E extends NamedBean> {
     private JPanel _panelTable;
     private JTextField _referenceTextField;
     private BeanSelectPanel<Memory> _memoryPanel;
-    private JCheckBox _listenToMemoryCheckBox;
     private JTextField _localVariableTextField;
     private JTextField _formulaTextField;
 
@@ -80,11 +79,9 @@ public class LogixNG_SelectNamedBeanSwing<E extends NamedBean> {
         }
 
         _memoryPanel = new BeanSelectPanel<>(InstanceManager.getDefault(MemoryManager.class), null);
-        _listenToMemoryCheckBox = new JCheckBox(Bundle.getMessage("ListenToMemory"));
 
         _panelMemory.setLayout(new BoxLayout(_panelMemory, BoxLayout.Y_AXIS));
         _panelMemory.add(_memoryPanel);
-        _panelMemory.add(_listenToMemoryCheckBox);
 
         _tabbedPane.addTab(NamedBeanAddressing.Direct.toString(), _panelDirect);
         _tabbedPane.addTab(NamedBeanAddressing.Reference.toString(), _panelReference);
@@ -124,7 +121,6 @@ public class LogixNG_SelectNamedBeanSwing<E extends NamedBean> {
             }
             _referenceTextField.setText(selectNamedBean.getReference());
             _memoryPanel.setDefaultNamedBean(selectNamedBean.getMemory());
-            _listenToMemoryCheckBox.setSelected(selectNamedBean.getListenToMemory());
             _localVariableTextField.setText(selectNamedBean.getLocalVariable());
             _formulaTextField.setText(selectNamedBean.getFormula());
         }
@@ -193,7 +189,6 @@ public class LogixNG_SelectNamedBeanSwing<E extends NamedBean> {
                     if (_memoryPanel.getNamedBean() != null) {
                         selectNamedBean.setMemory(_memoryPanel.getNamedBean());
                     }
-                    selectNamedBean.setListenToMemory(_listenToMemoryCheckBox.isSelected());
                     break;
                 case LocalVariable:
                     selectNamedBean.setLocalVariable(_localVariableTextField.getText());

--- a/java/src/jmri/jmrit/logixng/util/swing/LogixNG_SelectStringSwing.java
+++ b/java/src/jmri/jmrit/logixng/util/swing/LogixNG_SelectStringSwing.java
@@ -36,7 +36,6 @@ public class LogixNG_SelectStringSwing {
     private JPanel _panelTable;
     private JTextField _referenceTextField;
     private BeanSelectPanel<Memory> _memoryPanel;
-    private JCheckBox _listenToMemoryCheckBox;
     private JTextField _localVariableTextField;
     private JTextField _formulaTextField;
 
@@ -108,11 +107,9 @@ public class LogixNG_SelectStringSwing {
         }
 
         _memoryPanel = new BeanSelectPanel<>(InstanceManager.getDefault(MemoryManager.class), null);
-        _listenToMemoryCheckBox = new JCheckBox(Bundle.getMessage("ListenToMemory"));
 
         _panelMemory.setLayout(new BoxLayout(_panelMemory, BoxLayout.Y_AXIS));
         _panelMemory.add(_memoryPanel);
-        _panelMemory.add(_listenToMemoryCheckBox);
 
         _tabbedPane.addTab(NamedBeanAddressing.Direct.toString(), _panelDirect);
         _tabbedPane.addTab(NamedBeanAddressing.Reference.toString(), _panelReference);
@@ -149,7 +146,6 @@ public class LogixNG_SelectStringSwing {
             }
             _referenceTextField.setText(selectStr.getReference());
             _memoryPanel.setDefaultNamedBean(selectStr.getMemory());
-            _listenToMemoryCheckBox.setSelected(selectStr.getListenToMemory());
             _localVariableTextField.setText(selectStr.getLocalVariable());
             _formulaTextField.setText(selectStr.getFormula());
         }
@@ -223,7 +219,6 @@ public class LogixNG_SelectStringSwing {
             } else if (_tabbedPane.getSelectedComponent() == _panelMemory) {
                 selectStr.setAddressing(NamedBeanAddressing.Memory);
                 selectStr.setMemory(_memoryPanel.getNamedBean());
-                selectStr.setListenToMemory(_listenToMemoryCheckBox.isSelected());
             } else if (_tabbedPane.getSelectedComponent() == _panelLocalVariable) {
                 selectStr.setAddressing(NamedBeanAddressing.LocalVariable);
                 selectStr.setLocalVariable(_localVariableTextField.getText());

--- a/java/src/jmri/jmrit/operations/logixng/OperationsProStartAutomation.java
+++ b/java/src/jmri/jmrit/operations/logixng/OperationsProStartAutomation.java
@@ -22,7 +22,7 @@ public class OperationsProStartAutomation extends AbstractDigitalAction
         implements PropertyChangeListener {
 
     private final LogixNG_SelectComboBox _selectAutomation =
-            new LogixNG_SelectComboBox(this, new AutomationItem[]{}, null, this);
+            new LogixNG_SelectComboBox(this, new AutomationItem[]{}, null);
 
     private final AutomationManager _automationManager;
     private final List<AutomationItem> _automationList = new ArrayList<>();
@@ -98,18 +98,6 @@ public class OperationsProStartAutomation extends AbstractDigitalAction
     @Override
     public void setup() {
         // Do nothing
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void registerListenersForThisClass() {
-        _selectAutomation.registerListeners();
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void unregisterListenersForThisClass() {
-        _selectAutomation.unregisterListeners();
     }
 
     /** {@inheritDoc} */

--- a/java/src/jmri/jmrix/can/cbus/logixng/SendMergCbusEvent.java
+++ b/java/src/jmri/jmrix/can/cbus/logixng/SendMergCbusEvent.java
@@ -1,7 +1,5 @@
 package jmri.jmrix.can.cbus.logixng;
 
-import java.beans.PropertyChangeEvent;
-import java.beans.PropertyChangeListener;
 import java.util.Locale;
 import java.util.Map;
 
@@ -21,19 +19,14 @@ import jmri.util.ThreadingUtil;
  *
  * @author Daniel Bergqvist Copyright 2025
  */
-public class SendMergCbusEvent extends AbstractDigitalAction
-        implements PropertyChangeListener {
+public class SendMergCbusEvent extends AbstractDigitalAction {
 
-    private final LogixNG_SelectInteger _selectNodeNumber =
-            new LogixNG_SelectInteger(
-                    this, this);
+    private final LogixNG_SelectInteger _selectNodeNumber = new LogixNG_SelectInteger(this);
 
-    private final LogixNG_SelectInteger _selectEventNumber =
-            new LogixNG_SelectInteger(
-                    this, this);
+    private final LogixNG_SelectInteger _selectEventNumber = new LogixNG_SelectInteger(this);
 
     private final LogixNG_SelectEnum<CbusEventType> _selectEventType =
-            new LogixNG_SelectEnum<>(this, CbusEventType.values(), CbusEventType.Off, this);
+            new LogixNG_SelectEnum<>(this, CbusEventType.values(), CbusEventType.Off);
 
     private CanSystemConnectionMemo _memo;
 
@@ -142,26 +135,6 @@ public class SendMergCbusEvent extends AbstractDigitalAction
     @Override
     public void setup() {
         // Do nothing
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void registerListenersForThisClass() {
-        _selectNodeNumber.registerListeners();
-        _selectEventType.registerListeners();
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void unregisterListenersForThisClass() {
-        _selectNodeNumber.unregisterListeners();
-        _selectEventType.unregisterListeners();
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void propertyChange(PropertyChangeEvent evt) {
-        getConditionalNG().execute();
     }
 
     /** {@inheritDoc} */

--- a/java/src/jmri/jmrix/mqtt/logixng/Publish.java
+++ b/java/src/jmri/jmrix/mqtt/logixng/Publish.java
@@ -2,8 +2,6 @@ package jmri.jmrix.mqtt.logixng;
 
 import jmri.jmrit.logixng.actions.*;
 
-import java.beans.PropertyChangeEvent;
-import java.beans.PropertyChangeListener;
 import java.util.*;
 
 import jmri.*;
@@ -18,13 +16,10 @@ import jmri.util.ThreadingUtil;
  *
  * @author Daniel Bergqvist Copyright 2022
  */
-public class Publish extends AbstractDigitalAction
-        implements PropertyChangeListener {
+public class Publish extends AbstractDigitalAction {
 
-    private final LogixNG_SelectString _selectTopic =
-            new LogixNG_SelectString(this, this);
-    private final LogixNG_SelectString _selectMessage =
-            new LogixNG_SelectString(this, this);
+    private final LogixNG_SelectString _selectTopic = new LogixNG_SelectString(this);
+    private final LogixNG_SelectString _selectMessage = new LogixNG_SelectString(this);
 
     private MqttSystemConnectionMemo _memo;
 
@@ -125,26 +120,6 @@ public class Publish extends AbstractDigitalAction
     @Override
     public void setup() {
         // Do nothing
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void registerListenersForThisClass() {
-        _selectTopic.registerListeners();
-        _selectMessage.registerListeners();
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void unregisterListenersForThisClass() {
-        _selectTopic.unregisterListeners();
-        _selectMessage.unregisterListeners();
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void propertyChange(PropertyChangeEvent evt) {
-        getConditionalNG().execute();
     }
 
     /** {@inheritDoc} */

--- a/java/test/jmri/jmrit/logixng/CreateLogixNGTreeScaffold.java
+++ b/java/test/jmri/jmrit/logixng/CreateLogixNGTreeScaffold.java
@@ -649,7 +649,6 @@ public class CreateLogixNGTreeScaffold {
         actionClockRate.getSelectEnum().setMemory(memory2);
         actionClockRate.getSelectSpeed().setAddressing(NamedBeanAddressing.Memory);
         actionClockRate.getSelectSpeed().setMemory(memory1);
-        actionClockRate.getSelectSpeed().setListenToMemory(true);
 
         maleSocket = digitalActionManager.registerAction(actionClockRate);
         maleSocket.setEnabled(false);

--- a/java/test/jmri/jmrit/logixng/configurexml/load/LogixNG.xml
+++ b/java/test/jmri/jmrit/logixng/configurexml/load/LogixNG.xml
@@ -22249,7 +22249,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
         <addressing>Memory</addressing>
         <value>1.000</value>
         <memory>IM1</memory>
-        <listenToMemory>yes</listenToMemory>
+        <listenToMemory>no</listenToMemory>
       </rate>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />

--- a/java/test/jmri/jmrit/logixng/configurexml/loadref/LogixNG.5.1.3.xml
+++ b/java/test/jmri/jmrit/logixng/configurexml/loadref/LogixNG.5.1.3.xml
@@ -14552,7 +14552,7 @@
         <addressing>Memory</addressing>
         <value>1.000</value>
         <memory>IM1</memory>
-        <listenToMemory>yes</listenToMemory>
+        <listenToMemory>no</listenToMemory>
       </rate>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />

--- a/java/test/jmri/jmrit/logixng/configurexml/loadref/LogixNG.5.1.4.xml
+++ b/java/test/jmri/jmrit/logixng/configurexml/loadref/LogixNG.5.1.4.xml
@@ -14829,7 +14829,7 @@
         <addressing>Memory</addressing>
         <value>1.000</value>
         <memory>IM1</memory>
-        <listenToMemory>yes</listenToMemory>
+        <listenToMemory>no</listenToMemory>
       </rate>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />

--- a/java/test/jmri/jmrit/logixng/configurexml/loadref/LogixNG.5.5.5.xml
+++ b/java/test/jmri/jmrit/logixng/configurexml/loadref/LogixNG.5.5.5.xml
@@ -18185,7 +18185,7 @@
         <addressing>Memory</addressing>
         <value>1.000</value>
         <memory>IM1</memory>
-        <listenToMemory>yes</listenToMemory>
+        <listenToMemory>no</listenToMemory>
       </rate>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />

--- a/java/test/jmri/jmrit/logixng/configurexml/loadref/LogixNG.5.7.5.xml
+++ b/java/test/jmri/jmrit/logixng/configurexml/loadref/LogixNG.5.7.5.xml
@@ -19588,7 +19588,7 @@
         <addressing>Memory</addressing>
         <value>1.000</value>
         <memory>IM1</memory>
-        <listenToMemory>yes</listenToMemory>
+        <listenToMemory>no</listenToMemory>
       </rate>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />

--- a/java/test/jmri/jmrit/logixng/configurexml2/load/LogixNG.xml
+++ b/java/test/jmri/jmrit/logixng/configurexml2/load/LogixNG.xml
@@ -22051,7 +22051,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
         <addressing>Memory</addressing>
         <value>1.000</value>
         <memory>IM1</memory>
-        <listenToMemory>yes</listenToMemory>
+        <listenToMemory>no</listenToMemory>
       </rate>
       <MaleSocket>
         <AbstractMaleSocket enabled="no" locked="no" system="no" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalActionSocketXml">

--- a/java/test/jmri/jmrit/logixng/configurexml2/loadref/LogixNG.5.1.3.xml
+++ b/java/test/jmri/jmrit/logixng/configurexml2/loadref/LogixNG.5.1.3.xml
@@ -14407,7 +14407,7 @@
         <addressing>Memory</addressing>
         <value>1.000</value>
         <memory>IM1</memory>
-        <listenToMemory>yes</listenToMemory>
+        <listenToMemory>no</listenToMemory>
       </rate>
       <MaleSocket>
         <AbstractMaleSocket enabled="no" locked="no" system="no" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalActionSocketXml">

--- a/java/test/jmri/jmrit/logixng/configurexml2/loadref/LogixNG.5.1.4.xml
+++ b/java/test/jmri/jmrit/logixng/configurexml2/loadref/LogixNG.5.1.4.xml
@@ -14682,7 +14682,7 @@
         <addressing>Memory</addressing>
         <value>1.000</value>
         <memory>IM1</memory>
-        <listenToMemory>yes</listenToMemory>
+        <listenToMemory>no</listenToMemory>
       </rate>
       <MaleSocket>
         <AbstractMaleSocket enabled="no" locked="no" system="no" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalActionSocketXml">

--- a/java/test/jmri/jmrit/logixng/configurexml2/loadref/LogixNG.5.5.5.xml
+++ b/java/test/jmri/jmrit/logixng/configurexml2/loadref/LogixNG.5.5.5.xml
@@ -18002,7 +18002,7 @@
         <addressing>Memory</addressing>
         <value>1.000</value>
         <memory>IM1</memory>
-        <listenToMemory>yes</listenToMemory>
+        <listenToMemory>no</listenToMemory>
       </rate>
       <MaleSocket>
         <AbstractMaleSocket enabled="no" locked="no" system="no" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalActionSocketXml">

--- a/java/test/jmri/jmrit/logixng/configurexml2/loadref/LogixNG.5.7.5.xml
+++ b/java/test/jmri/jmrit/logixng/configurexml2/loadref/LogixNG.5.7.5.xml
@@ -19404,7 +19404,7 @@
         <addressing>Memory</addressing>
         <value>1.000</value>
         <memory>IM1</memory>
-        <listenToMemory>yes</listenToMemory>
+        <listenToMemory>no</listenToMemory>
       </rate>
       <MaleSocket>
         <AbstractMaleSocket enabled="no" locked="no" system="no" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalActionSocketXml">


### PR DESCRIPTION
The option "Listen" for Memory when using indirect addressing didn't do anything useful so it has been removed.