### PR TITLE
Doehler & Haass sound decoders: complete firmware 1.13, plus older fixes

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -248,6 +248,13 @@
 
         <h4>Doehler &amp; Haas</h4>
             <ul>
+                <li>Sound decoders, firmware 1.13: added CV137 bit 6 and CV28 bit 2.</li>
+                <li>Sound decoders: firmware 1.01, 1.02.084, 1.05.115, 1.08.027, 1.09.117,
+                    1.11.069 and 1.13.101 are now identified correctly.</li>
+                <li>Sound decoders: corrected the CV131, CV132 and CV133 defaults to F8, F4
+                    and F9, and the CV361 threshold to 7.</li>
+                <li>SUSI sound modules: corrected the CV961 threshold default and the SH05A
+                    and SH10A model comments.</li>
                 <li>The decoder schema now offers <code>E24</code> as a connector type (NEM 664 /
                     RCN-124, marketed by ESU as "Next28"); the D&amp;H DH24A uses it.</li>
                 <li>New definitions for firmware 3.15.016, covering the non-sound decoders (DH05C,

--- a/xml/decoders/Doehler_Haass_fw1.06-07_SD10-16-18-21-22A.xml
+++ b/xml/decoders/Doehler_Haass_fw1.06-07_SD10-16-18-21-22A.xml
@@ -12,6 +12,8 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" showEmptyPanes="no" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
+<version version="2" author="Pierre Billon, pierre.bln@me.com" lastUpdated="20260727"/>
+<!--  Firmware 1.08.027 and 1.09.117 identified by the 1.07 models, which have no definition of their own  -->
 <version version="1.1" author="Pierre Billon, pierre.bln@me.com" lastUpdated="20210312"/>
 <!--  Added update paths to newest fw 1.12.050 -->
 <version version="1" author="Ronald Kuhn, ronald@wirkuhns.de" lastUpdated="2016-12-14"/>

--- a/xml/decoders/Doehler_Haass_fw1.06-07_SD10-16-18-21-22A.xml
+++ b/xml/decoders/Doehler_Haass_fw1.06-07_SD10-16-18-21-22A.xml
@@ -242,6 +242,8 @@
 	</protocols>
   </model>
   <model model="SD10A (firmware 1.07+)" replacementModel="SD10A (firmware 1.12+)" replacementFamily="query:Sound Decoders (2020)" lowVersionID="056" highVersionID="056" numOuts="6" numFns="16" productID="SD10A_1.07" comment="SD10A-0 / SD10A-1 / SD10A-3 with update from June 2016" maxInputVolts="30V" maxMotorCurrent="1A" maxTotalCurrent="1A" connector="Wires/NEM651">
+    <versionCV lowVersionID="27" highVersionID="27" comment="firmware 1.08.027 has no dedicated definition; this is the nearest earlier CV set"/>
+    <versionCV lowVersionID="117" highVersionID="117" comment="firmware 1.09.117 has no dedicated definition; this is the nearest earlier CV set"/>
 	<output name="1" label="Front|Light" maxcurrent="150mA">
 	  <label xml:lang="de">LV</label>
 	  <label xml:lang="ca">Llum frontal</label>
@@ -282,6 +284,8 @@
 	</protocols>
   </model>
   <model model="SD16A (firmware 1.07+)" replacementModel="SD16A (firmware 1.12+)" replacementFamily="query:Sound Decoders (2020)" lowVersionID="056" highVersionID="056" numOuts="8" numFns="16" productID="SD16A_1.07" comment="SD16A-4 with update from June 2016" maxInputVolts="30V" maxMotorCurrent="1,5A" maxTotalCurrent="1,5A" connector="PluX16">
+    <versionCV lowVersionID="27" highVersionID="27" comment="firmware 1.08.027 has no dedicated definition; this is the nearest earlier CV set"/>
+    <versionCV lowVersionID="117" highVersionID="117" comment="firmware 1.09.117 has no dedicated definition; this is the nearest earlier CV set"/>
 	<output name="1" label="Front|Light" maxcurrent="150mA">
 	  <label xml:lang="de">LV</label>
 	  <label xml:lang="ca">Llum Frontal</label>
@@ -325,6 +329,8 @@
         </protocols>
   </model>
   <model model="SD18A (firmware 1.07+)" replacementModel="SD18A (firmware 1.12+)" replacementFamily="query:Sound Decoders (2020)" lowVersionID="056" highVersionID="056" numOuts="6" numFns="16" productID="SD18A_1.07" comment="SD18A with update from June 2016" maxInputVolts="30V" maxMotorCurrent="1A" maxTotalCurrent="1A" connector="Next18">
+    <versionCV lowVersionID="27" highVersionID="27" comment="firmware 1.08.027 has no dedicated definition; this is the nearest earlier CV set"/>
+    <versionCV lowVersionID="117" highVersionID="117" comment="firmware 1.09.117 has no dedicated definition; this is the nearest earlier CV set"/>
       <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
       </output>
@@ -357,6 +363,8 @@
       </protocols>
   </model>
   <model model="SD21A (firmware 1.07+)" replacementModel="SD21A-4 (firmware 1.12+)" replacementFamily="query:Sound Decoders (2020)" lowVersionID="056" highVersionID="056" numOuts="8" numFns="16" productID="SD21A_1.07" comment="SD21A-4 with update from June 2016" maxInputVolts="30V" maxMotorCurrent="2A" maxTotalCurrent="2A" connector="21MTC">
+    <versionCV lowVersionID="27" highVersionID="27" comment="firmware 1.08.027 has no dedicated definition; this is the nearest earlier CV set"/>
+    <versionCV lowVersionID="117" highVersionID="117" comment="firmware 1.09.117 has no dedicated definition; this is the nearest earlier CV set"/>
       <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
       </output>
@@ -395,6 +403,8 @@
       </protocols>
   </model>
   <model model="SD22A (firmware 1.07+)" replacementModel="SD22A (firmware 1.12+)" replacementFamily="query:Sound Decoders (2020)" lowVersionID="056" highVersionID="056" numOuts="8" numFns="16" productID="SD22A_1.07" comment="SD22A-4 with update from June 2016" maxInputVolts="30V" maxMotorCurrent="2A" maxTotalCurrent="2A" connector="PluX22">
+    <versionCV lowVersionID="27" highVersionID="27" comment="firmware 1.08.027 has no dedicated definition; this is the nearest earlier CV set"/>
+    <versionCV lowVersionID="117" highVersionID="117" comment="firmware 1.09.117 has no dedicated definition; this is the nearest earlier CV set"/>
       <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
       </output>

--- a/xml/decoders/Doehler_Haass_fw1.11_SD10-16-18-21-22A.xml
+++ b/xml/decoders/Doehler_Haass_fw1.11_SD10-16-18-21-22A.xml
@@ -22,6 +22,7 @@
 <decoder>
 <family name="Sound Decoders (2018)" mfg="Doehler und Haass">
   <model model="SD10A (firmware 1.11+)" replacementModel="SD10A (firmware 1.12+)" replacementFamily="query:Sound Decoders (2020)" lowVersionID="098" highVersionID="098" numOuts="6" numFns="16" productID="SD10A_1.11" comment="SD10A-0 / SD10A-1 / SD10A-3 with update from October 2018" maxInputVolts="30V" maxMotorCurrent="1A" maxTotalCurrent="1A" connector="Wires/NEM651">
+    <versionCV lowVersionID="69" highVersionID="69" comment="firmware 1.11.069"/>
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum frontal</label>
@@ -62,6 +63,7 @@
         </protocols>
   </model>
   <model model="SD16A (firmware 1.11+)" replacementModel="SD16A (firmware 1.12+)" replacementFamily="query:Sound Decoders (2020)" lowVersionID="098" highVersionID="098" numOuts="8" numFns="16" productID="SD16A_1.11" comment="SD16A-4 with update from October 2018" maxInputVolts="30V" maxMotorCurrent="1,5A" maxTotalCurrent="1,5A" connector="PluX16">
+    <versionCV lowVersionID="69" highVersionID="69" comment="firmware 1.11.069"/>
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum Frontal</label>
@@ -105,6 +107,7 @@
         </protocols>
   </model>
   <model model="SD18A (firmware 1.11+)" replacementModel="SD18A (firmware 1.12+)" replacementFamily="query:Sound Decoders (2020)" lowVersionID="098" highVersionID="098" numOuts="6" numFns="16" productID="SD18A_1.11" comment="SD18A with update from October 2018" maxInputVolts="30V" maxMotorCurrent="1A" maxTotalCurrent="1A" connector="Next18">
+    <versionCV lowVersionID="69" highVersionID="69" comment="firmware 1.11.069"/>
       <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
       </output>
@@ -137,6 +140,7 @@
       </protocols>
   </model>
   <model model="SD21A (firmware 1.11+)" replacementModel="SD21A-4 (firmware 1.12+)" replacementFamily="query:Sound Decoders (2020)" lowVersionID="098" highVersionID="098" numOuts="8" numFns="16" productID="SD21A_1.11" comment="SD21A-4 with update from October 2018" maxInputVolts="30V" maxMotorCurrent="2A" maxTotalCurrent="2A" connector="21MTC">
+    <versionCV lowVersionID="69" highVersionID="69" comment="firmware 1.11.069"/>
       <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
       </output>
@@ -175,6 +179,7 @@
       </protocols>
   </model>
   <model model="SD22A (firmware 1.11+)" replacementModel="SD22A (firmware 1.12+)" replacementFamily="query:Sound Decoders (2020)" lowVersionID="098" highVersionID="098" numOuts="8" numFns="16" productID="SD22A_1.11" comment="SD22A-4 with update from October 2018" maxInputVolts="30V" maxMotorCurrent="2A" maxTotalCurrent="2A" connector="PluX22">
+    <versionCV lowVersionID="69" highVersionID="69" comment="firmware 1.11.069"/>
       <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
       </output>

--- a/xml/decoders/Doehler_Haass_fw1.11_SD10-16-18-21-22A.xml
+++ b/xml/decoders/Doehler_Haass_fw1.11_SD10-16-18-21-22A.xml
@@ -12,6 +12,8 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" showEmptyPanes="no" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
+<version version="2" author="Pierre Billon, pierre.bln@me.com" lastUpdated="20260727"/>
+<!--  Firmware 1.11.069 now identified  -->
 <version version="1.1" author="Pierre Billon, pierre.bln@me.com" lastUpdated="20210312"/>
 <!--  Added update paths to newest fw 1.12.050 -->
 <version version="1" author="Ronald Kuhn, ronald@wirkuhns.de" lastUpdated="2020-05-02"/>

--- a/xml/decoders/Doehler_Haass_fw1.13_SD05-22A.xml
+++ b/xml/decoders/Doehler_Haass_fw1.13_SD05-22A.xml
@@ -270,6 +270,7 @@
     <xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv14_analogModeFunction.xml"/>
     <!-- Railcom feedback  -->
     <xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv28-29_railcom_base.xml"/>
+    <xi:include href="http://jmri.org/xml/decoders/doehler_haass/SD_cv28_bit2_fw1.13.xml"/>
     <!-- SECTION 5    - Extra Railcom feedback options as of fw3.06 -->
     <xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv135-136_144_railcom_fw3.06.xml"/>
     <!-- Motorola support -->
@@ -288,6 +289,7 @@
     <xi:include href="http://jmri.org/xml/decoders/doehler_haass/SD_cv349_949.xml"/>
     <!-- 2015-05 fw1.04+ -->
     <xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv137.xml"/>
+    <xi:include href="http://jmri.org/xml/decoders/doehler_haass/SD_cv137_bit6_fw1.13.xml"/>
     <xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv138-143.xml"/>
     <xi:include href="http://jmri.org/xml/decoders/doehler_haass/SD_cv125-133.xml"/>
     <xi:include href="http://jmri.org/xml/decoders/doehler_haass/SD_cv374-377_974-977.xml"/>

--- a/xml/decoders/Doehler_Haass_fw1.13_SD05-22A.xml
+++ b/xml/decoders/Doehler_Haass_fw1.13_SD05-22A.xml
@@ -17,6 +17,7 @@
 <decoder>
   <family name="Sound Decoders (2022)" mfg="Doehler und Haass">
     <model model="SD05A (firmware 1.13+)" lowVersionID="112" highVersionID="112" numOuts="8" numFns="16" productID="205" comment="SD05A-0 / SD05A-1 / SD05A-3 from July 2020" maxInputVolts="18V" maxMotorCurrent="0.5A" maxTotalCurrent="0.5A">
+      <versionCV lowVersionID="101" highVersionID="101" comment="firmware 1.13.101, not a regular release"/>
       <!--lowVersionID="098" highVersionID="098"-->
       <output name="1" label="Front|Light" maxcurrent="150mA">
         <label xml:lang="de">LV</label>
@@ -52,6 +53,7 @@
       </protocols>
     </model>
     <model model="SD10A (firmware 1.13+)" lowVersionID="112" highVersionID="112" numOuts="8" numFns="16" productID="210" comment="SD10A-0 / SD10A-1 / SD10A-3 with update from July 2020" maxInputVolts="30V" maxMotorCurrent="1A" maxTotalCurrent="1A">
+      <versionCV lowVersionID="101" highVersionID="101" comment="firmware 1.13.101, not a regular release"/>
     <!--lowVersionID="098" highVersionID="098"-->
     <output name="1" label="Front|Light" maxcurrent="150mA">
       <label xml:lang="de">LV</label>
@@ -87,6 +89,7 @@
     </protocols>
   </model>
     <model model="SD16A (firmware 1.13+)" lowVersionID="112" highVersionID="112" numOuts="10" numFns="16" productID="216" comment="SD16A-0 / SD16A-2 / SD16A-3 / SD16A-4 with update from October 2020" maxInputVolts="30V" maxMotorCurrent="1,5A" maxTotalCurrent="1,5A">
+      <versionCV lowVersionID="101" highVersionID="101" comment="firmware 1.13.101, not a regular release"/>
      <output name="1" label="Front|Light" maxcurrent="150mA">
       <label xml:lang="de">LV</label>
       <label xml:lang="nl">Kop|lampen</label>
@@ -117,6 +120,7 @@
     </protocols>
   </model>
     <model model="SD18A (firmware 1.13+)" lowVersionID="112" highVersionID="112" numOuts="8" numFns="16" productID="218" comment="SD18A with update from October 2020" maxInputVolts="30V" maxMotorCurrent="1A" maxTotalCurrent="1A" connector="Next18">
+      <versionCV lowVersionID="101" highVersionID="101" comment="firmware 1.13.101, not a regular release"/>
     <!--lowVersionID="098" highVersionID="098"-->
     <output name="1" label="Front|Light" maxcurrent="150mA">
       <label xml:lang="de">LV</label>
@@ -152,6 +156,7 @@
     </protocols>
   </model>
     <model model="SD21A-4 (firmware 1.13+)" lowVersionID="112" highVersionID="112" numOuts="10" numFns="16" productID="221" comment="SD21A-4 with update from October 2020" maxInputVolts="30V" maxMotorCurrent="2A" maxTotalCurrent="2A" connector="21MTC">
+      <versionCV lowVersionID="101" highVersionID="101" comment="firmware 1.13.101, not a regular release"/>
     <output name="1" label="Front|Light" maxcurrent="150mA">
       <label xml:lang="de">LV</label>
       <label xml:lang="nl">Kop|lampen</label>
@@ -182,6 +187,7 @@
     </protocols>
   </model>
     <model model="SD21A-5 (firmware 1.13+)" lowVersionID="112" highVersionID="112" numOuts="10" numFns="16" productID="221" comment="SD21A-5 with update from October 2020" maxInputVolts="30V" maxMotorCurrent="2A" maxTotalCurrent="2A" connector="21MTC">
+      <versionCV lowVersionID="101" highVersionID="101" comment="firmware 1.13.101, not a regular release"/>
     <output name="1" label="Front|Light" maxcurrent="150mA">
       <label xml:lang="de">LV</label>
       <label xml:lang="nl">Kop|lampen</label>
@@ -212,6 +218,7 @@
     </protocols>
   </model>
     <model model="SD22A (firmware 1.13+)" lowVersionID="112" highVersionID="112" numOuts="12" numFns="16" productID="222" comment="SD22A-0 / SD22A-2 / SD22A-3 / SD22A-4 with update from October 2020" maxInputVolts="30V" maxMotorCurrent="2A" maxTotalCurrent="2A">
+      <versionCV lowVersionID="101" highVersionID="101" comment="firmware 1.13.101, not a regular release"/>
     <output name="1" label="Front|Light" maxcurrent="150mA">
       <label xml:lang="de">LV</label>
       <label xml:lang="nl">Kop|lampen</label>

--- a/xml/decoders/Doehler_Haass_fw1.13_SD05-22A.xml
+++ b/xml/decoders/Doehler_Haass_fw1.13_SD05-22A.xml
@@ -12,6 +12,8 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" showEmptyPanes="no" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
+<version version="2" author="Pierre Billon, pierre.bln@me.com" lastUpdated="20260727"/>
+<!--  Firmware 1.13.101 now identified; added CV137 bit 6 and CV28 bit 2, both new in 1.13  -->
 <version version="1" author="Ronald Kuhn" lastUpdated="2023-07-22"/>
 <!--  Creation Decoder template for the Doehler & Haass combo sound decoder with Firmware v1.13  -->
 <decoder>

--- a/xml/decoders/Doehler_Haass_fw1.15_SH05-10A.xml
+++ b/xml/decoders/Doehler_Haass_fw1.15_SH05-10A.xml
@@ -12,6 +12,8 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" showEmptyPanes="no" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
+  <version version="2" author="Pierre Billon, pierre.bln@me.com" lastUpdated="20260727"/>
+  <!--  Corrected the SH05A and SH10A model comments  -->
   <version version="1" author="Ronald Kuhn, ronald@wirkuhns.de" lastUpdated="20230720"/>
   <!--  Creation, based on Doehler_Haass_susi_sd_fw1.14_SH05-10A.xml
         -->

--- a/xml/decoders/Doehler_Haass_fw1.15_SH05-10A.xml
+++ b/xml/decoders/Doehler_Haass_fw1.15_SH05-10A.xml
@@ -17,12 +17,12 @@
         -->
   <decoder>
     <family name="SUSI sound modules (2022)" mfg="Doehler und Haass">
-      <model model="SH05A (firmware 1.15.112+)" lowVersionID="112" highVersionID="112" numOuts="2" numFns="30" productID="50" comment="SH10A with firmware 1.14 or later" maxInputVolts="30V" connector="SUSI">
+      <model model="SH05A (firmware 1.15.112+)" lowVersionID="112" highVersionID="112" numOuts="2" numFns="30" productID="50" comment="SH05A with firmware 1.15 or later" maxInputVolts="30V" connector="SUSI">
         <output name="1" label="AUX|1" maxcurrent="20mA"/>
         <output name="2" label="AUX|2" maxcurrent="20mA"/>
         <size length="14.3" width="9.3" height="2.9" units="mm"/>
       </model>
-      <model model="SH10A (firmware 1.15.112+)" lowVersionID="112" highVersionID="112" numOuts="2" numFns="30" productID="100" comment="SH10A with firmware 1.14 or later" maxInputVolts="30V" connector="SUSI">
+      <model model="SH10A (firmware 1.15.112+)" lowVersionID="112" highVersionID="112" numOuts="2" numFns="30" productID="100" comment="SH10A with firmware 1.15 or later" maxInputVolts="30V" connector="SUSI">
         <output name="1" label="AUX|1" maxcurrent="20mA"/>
         <output name="2" label="AUX|2" maxcurrent="20mA"/>
         <size length="20" width="12" height="1.9" units="mm"/>

--- a/xml/decoders/Doehler_Haass_sd_SD18A.xml
+++ b/xml/decoders/Doehler_Haass_sd_SD18A.xml
@@ -12,6 +12,8 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" showEmptyPanes="no" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
+  <version version="4" author="Pierre Billon, pierre.bln@me.com" lastUpdated="20260727"/>
+  <!--  Firmware 1.01 identified by CV7=54 (was 1, which is 1.00); firmware 1.02.084 and 1.05.115 now identified  -->
   <version version="3.1" author="Pierre Billon, pierre.bln@me.com" lastUpdated="20210416"/>
   <!--  Added update paths to newest fw 1.12.050 -->
   <version version="3" author="Pierre Billon, pierre.bln@me.com" lastUpdated="20151014"/>

--- a/xml/decoders/Doehler_Haass_sd_SD18A.xml
+++ b/xml/decoders/Doehler_Haass_sd_SD18A.xml
@@ -43,7 +43,7 @@
             <protocol>selectrix</protocol>
         </protocols>
       </model>
-      <model model="SD18A (firmware 1.01+)" replacementModel="SD18A (firmware 1.12+)" replacementFamily="query:Sound Decoders (2020)" lowVersionID="1" highVersionID="1" numOuts="4" numFns="16" productID="SD18A_1.01" comment="SD18A with firmware 1.01" maxInputVolts="30V" maxMotorCurrent="1A" maxTotalCurrent="1A" connector="Next18">
+      <model model="SD18A (firmware 1.01+)" replacementModel="SD18A (firmware 1.12+)" replacementFamily="query:Sound Decoders (2020)" lowVersionID="54" highVersionID="54" numOuts="4" numFns="16" productID="SD18A_1.01" comment="SD18A with firmware 1.01" maxInputVolts="30V" maxMotorCurrent="1A" maxTotalCurrent="1A" connector="Next18">
         <output name="1" label="Front|Light" maxcurrent="150mA"/>
         <output name="2" label="Rear|Light" maxcurrent="150mA"/>
         <output name="3" label="AUX|1" maxcurrent="300mA"/>
@@ -60,6 +60,7 @@
         </protocols>
       </model>
       <model model="SD18A (firmware 1.02+)" replacementModel="SD18A (firmware 1.12+)" replacementFamily="query:Sound Decoders (2020)" lowVersionID="74" highVersionID="74" numOuts="4" numFns="16" productID="SD18A_1.02" comment="SD18A with July 2014 firmware" maxInputVolts="30V" maxMotorCurrent="1A" maxTotalCurrent="1A" connector="Next18">
+        <versionCV lowVersionID="84" highVersionID="84" comment="firmware 1.02.084"/>
         <output name="1" label="Front|Light" maxcurrent="150mA"/>
         <output name="2" label="Rear|Light" maxcurrent="150mA"/>
         <output name="3" label="AUX|1" maxcurrent="300mA"/>
@@ -94,6 +95,7 @@
         </protocols>
       </model>
     <model model="SD18A (firmware 1.04+)" replacementModel="SD18A (firmware 1.12+)" replacementFamily="query:Sound Decoders (2020)" lowVersionID="055" highVersionID="055" numOuts="6" numFns="16" productID="SD18A_1.04" comment="SD18A with May 2015 firmware" maxInputVolts="30V" maxMotorCurrent="1A" maxTotalCurrent="1A" connector="Next18">
+      <versionCV lowVersionID="115" highVersionID="115" comment="firmware 1.05.115 has no dedicated definition; this is the nearest earlier CV set"/>
         <output name="1" label="Front|Light" maxcurrent="150mA"/>
         <output name="2" label="Rear|Light" maxcurrent="150mA"/>
         <output name="3" label="AUX|1" maxcurrent="300mA"/>

--- a/xml/decoders/Doehler_Haass_sd_SD21A.xml
+++ b/xml/decoders/Doehler_Haass_sd_SD21A.xml
@@ -12,6 +12,8 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" showEmptyPanes="no" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
+  <version version="4" author="Pierre Billon, pierre.bln@me.com" lastUpdated="20260727"/>
+  <!--  Firmware 1.01 identified by CV7=54 (was 1, which is 1.00); firmware 1.02.084 and 1.05.115 now identified  -->
   <version version="3.1" author="Pierre Billon, pierre.bln@me.com" lastUpdated="20210416"/>
   <!--  Added update paths to newest fw 1.12.050 -->
   <version version="3" author="Pierre Billon, pierre.bln@me.com" lastUpdated="20151014"/>

--- a/xml/decoders/Doehler_Haass_sd_SD21A.xml
+++ b/xml/decoders/Doehler_Haass_sd_SD21A.xml
@@ -27,7 +27,7 @@
   -->
   <decoder>
     <family name="Combo sound decoders" mfg="Doehler und Haass">
-      <model model="SD21A (firmware 1.01+)" replacementModel="SD21A-4 (firmware 1.12+)" replacementFamily="query:Sound Decoders (2020)" lowVersionID="1" highVersionID="1" numOuts="6" numFns="16" productID="SD21A_1.01" comment="SD21A with firmware 1.01" maxInputVolts="30V" maxMotorCurrent="2A" maxTotalCurrent="2A">
+      <model model="SD21A (firmware 1.01+)" replacementModel="SD21A-4 (firmware 1.12+)" replacementFamily="query:Sound Decoders (2020)" lowVersionID="54" highVersionID="54" numOuts="6" numFns="16" productID="SD21A_1.01" comment="SD21A with firmware 1.01" maxInputVolts="30V" maxMotorCurrent="2A" maxTotalCurrent="2A">
         <output name="1" label="Front|Light" maxcurrent="150mA"/>
         <output name="2" label="Rear|Light" maxcurrent="150mA"/>
         <output name="3" label="AUX|1" maxcurrent="300mA"/>
@@ -44,6 +44,7 @@
         </protocols>
       </model>
       <model model="SD21A (firmware 1.02+)" replacementModel="SD21A-4 (firmware 1.12+)" replacementFamily="query:Sound Decoders (2020)" lowVersionID="74" highVersionID="74" numOuts="6" numFns="16" productID="SD21A_1.02" comment="SD21A with July 2014 firmware" maxInputVolts="30V" maxMotorCurrent="2A" maxTotalCurrent="2A">
+        <versionCV lowVersionID="84" highVersionID="84" comment="firmware 1.02.084"/>
         <output name="1" label="Front|Light" maxcurrent="150mA"/>
         <output name="2" label="Rear|Light" maxcurrent="150mA"/>
         <output name="3" label="AUX|1" maxcurrent="300mA"/>
@@ -76,6 +77,7 @@
         </protocols>
       </model>
     <model model="SD21A (firmware 1.04+)" replacementModel="SD21A-4 (firmware 1.12+)" replacementFamily="query:Sound Decoders (2020)" lowVersionID="055" highVersionID="055" numOuts="6" numFns="16" productID="SD21A_1.04" comment="SD21A with May 2015 firmware" maxInputVolts="30V" maxMotorCurrent="2A" maxTotalCurrent="2A">
+      <versionCV lowVersionID="115" highVersionID="115" comment="firmware 1.05.115 has no dedicated definition; this is the nearest earlier CV set"/>
         <output name="1" label="Front|Light" maxcurrent="150mA"/>
         <output name="2" label="Rear|Light" maxcurrent="150mA"/>
         <output name="3" label="AUX|1" maxcurrent="300mA"/>

--- a/xml/decoders/Doehler_Haass_susi_sd_fw1.14_SH05-10A.xml
+++ b/xml/decoders/Doehler_Haass_susi_sd_fw1.14_SH05-10A.xml
@@ -19,7 +19,7 @@
         -->
   <decoder>
     <family name="SUSI sound modules (2020)" mfg="Doehler und Haass">
-      <model model="SH05A (firmware 1.14.050+)" replacementModel="SH05A (firmware 1.15.112+)" replacementFamily="query:SUSI sound modules (2022)" lowVersionID="50" highVersionID="50" numOuts="2" numFns="30" productID="50" comment="SH10A with firmware 1.14 or later" maxInputVolts="30V" connector="SUSI">
+      <model model="SH05A (firmware 1.14.050+)" replacementModel="SH05A (firmware 1.15.112+)" replacementFamily="query:SUSI sound modules (2022)" lowVersionID="50" highVersionID="50" numOuts="2" numFns="30" productID="50" comment="SH05A with firmware 1.14 or later" maxInputVolts="30V" connector="SUSI">
         <output name="1" label="AUX|1" maxcurrent="20mA"/>
         <output name="2" label="AUX|2" maxcurrent="20mA"/>
         <size length="14.3" width="9.3" height="2.9" units="mm"/>

--- a/xml/decoders/Doehler_Haass_susi_sd_fw1.14_SH05-10A.xml
+++ b/xml/decoders/Doehler_Haass_susi_sd_fw1.14_SH05-10A.xml
@@ -12,6 +12,8 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" showEmptyPanes="no" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
+  <version version="2" author="Pierre Billon, pierre.bln@me.com" lastUpdated="20260727"/>
+  <!--  Corrected the SH05A model comment  -->
   <version version="1.1" author="Ronald Kuhn, ronald@wirkuhns.de" lastUpdated="20230731"/>
   <!--  Added update paths to newest fw 1.15.112 -->
   <version version="1" author="Pierre Billon, pierre.bln@me.com" lastUpdated="20210312"/>

--- a/xml/decoders/doehler_haass/Pane_function_swapping.xml
+++ b/xml/decoders/doehler_haass/Pane_function_swapping.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <?xml-stylesheet type="text/xsl" href="../XSLT/decoder.xsl"?>
+<!-- version 2 - 2026-07-27 - PB - add CV137 bit 6, apply swappings to SUSI F1-F12 -->
 <!-- version 1 - Ronald Kuhn - initial version -->
 <pane xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
   <name>Function Swapping</name>
@@ -105,6 +106,18 @@
           <text xml:lang="de">    33 - 46 = Soundablauf 3 - 16</text>
         </label>
       </column>
+    </row>
+    <row>
+      <!-- CV137 bit 6 extends these swappings to the SUSI functions. New in sound decoder
+           firmware 1.13.112, so gated on the variable existing rather than on a family name. -->
+      <group>
+        <qualifier>
+          <variableref>Adopt function swapping for SUSI</variableref>
+          <relation>exists</relation>
+            <value>1</value>
+        </qualifier>
+        <display item="Adopt function swapping for SUSI" format="checkbox"/>
+      </group>
     </row>
   </column>
 </pane>

--- a/xml/decoders/doehler_haass/Pane_railcom.xml
+++ b/xml/decoders/doehler_haass/Pane_railcom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <?xml-stylesheet type="text/xsl" href="../XSLT/decoder.xsl"?>
+<!-- version 6 - 2026-07-27 - PB - add CV28 bit 2, the NMRA form of the dynamic channel setting -->
 <!-- version 5 - 2019-07-28 - ALM - Moved Railcom BiDi to section with qualifier / Divider as enum -->
 <!-- version 4 - 2016-12-14 - RK - add options for fw 3.06, 3.07  -->
 <!-- version 3 - 2015-03-05 - PB - Now using grid  -->
@@ -35,6 +36,18 @@
       </griditem>
       <griditem gridx="0" gridy="4" anchor="LINE_END">
         <display item="Railcom Dynamic Channel" format="checkbox"/>
+        <!-- CV28 bit 2 does the same job as CV144 bit 0 above, to the NMRA standard.
+             New in sound decoder firmware 1.13.112, so gated on the variable existing
+             rather than on a family name: any later firmware that includes
+             doehler_haass/SD_cv28_bit2_fw1.13.xml picks it up without editing this pane. -->
+        <group>
+          <qualifier>
+            <variableref>Railcom dynamic channel (CV28)</variableref>
+            <relation>exists</relation>
+            <value>1</value>
+          </qualifier>
+          <display item="Railcom dynamic channel (CV28)" format="checkbox"/>
+        </group>
       </griditem>
       <griditem gridx="1" gridy="2" anchor="LINE_END">
        <row>

--- a/xml/decoders/doehler_haass/Pane_railcom.xml
+++ b/xml/decoders/doehler_haass/Pane_railcom.xml
@@ -36,19 +36,21 @@
       </griditem>
       <griditem gridx="0" gridy="4" anchor="LINE_END">
         <display item="Railcom Dynamic Channel" format="checkbox"/>
-        <!-- CV28 bit 2 does the same job as CV144 bit 0 above, to the NMRA standard.
-             New in sound decoder firmware 1.13.112, so gated on the variable existing
-             rather than on a family name: any later firmware that includes
-             doehler_haass/SD_cv28_bit2_fw1.13.xml picks it up without editing this pane. -->
-        <group>
-          <qualifier>
-            <variableref>Railcom dynamic channel (CV28)</variableref>
-            <relation>exists</relation>
-            <value>1</value>
-          </qualifier>
-          <display item="Railcom dynamic channel (CV28)" format="checkbox"/>
-        </group>
       </griditem>
+      <!-- CV28 bit 2 does the same job as CV144 bit 0 above, to the NMRA standard, so it sits
+           on the line below it. New in sound decoder firmware 1.13.112, so gated on the variable
+           existing rather than on a family name: any later firmware that includes
+           doehler_haass/SD_cv28_bit2_fw1.13.xml picks it up without editing this pane. -->
+      <group>
+        <qualifier>
+          <variableref>Railcom dynamic channel (CV28)</variableref>
+          <relation>exists</relation>
+          <value>1</value>
+        </qualifier>
+        <griditem gridx="0" gridy="5" anchor="LINE_END">
+          <display item="Railcom dynamic channel (CV28)" format="checkbox"/>
+        </griditem>
+      </group>
       <griditem gridx="1" gridy="2" anchor="LINE_END">
        <row>
         <display item="Multiplicator for speed fedback"/>

--- a/xml/decoders/doehler_haass/SD_cv125-133.xml
+++ b/xml/decoders/doehler_haass/SD_cv125-133.xml
@@ -28,6 +28,12 @@
   </authorgroup>
   <revhistory xmlns="http://docbook.org/ns/docbook">
     <revision>
+      <revnumber>2</revnumber>
+      <date>2026-07-27</date>
+      <authorinitials>PB</authorinitials>
+      <revremark>CV131, CV132 and CV133 defaults corrected to F8, F4 and F9; English labels added; tooltips and CV133 translations corrected</revremark>
+    </revision>
+    <revision>
       <revnumber>1</revnumber>
       <date>2015-10-14</date>
       <authorinitials>PB</authorinitials>

--- a/xml/decoders/doehler_haass/SD_cv125-133.xml
+++ b/xml/decoders/doehler_haass/SD_cv125-133.xml
@@ -307,23 +307,26 @@
     <label xml:lang="de">AUX 6 Timer für Ausschalten</label>
     <label xml:lang="ca">Temps d'apagar autimàtic de F6</label>
   </variable>
-  <variable item="Function for dimmed lights" CV="131" default="1" tooltip="CV131: 0=>Off, 1-28=>F1-F8, 29=>F0" exclude="SD18A_1.00,SD18A_1.01,SD21A_1.01,SD18A_1.02,SD21A_1.02,SD18A_1.03,SD21A_1.03">
+  <variable item="Function for dimmed lights" CV="131" default="8" tooltip="CV131: 0=>Off, 1-28=>F1-F28, 29=>F0" exclude="SD18A_1.00,SD18A_1.01,SD21A_1.01,SD18A_1.02,SD21A_1.02,SD18A_1.03,SD21A_1.03">
 		<xi:include href="http://jmri.org/xml/decoders/doehler_haass/Susi-SD_enum-map.xml"/>
+		<label>Function mapping low beam light</label>
 		<label xml:lang="fr">Fonction pour feux réduits</label>
 		<label xml:lang="de">Funktionszuordnung Abblendlicht</label>
 		<label xml:lang="ca">Funció per a llum feble</label>
   </variable>
-  <variable item="Function for shunting speed" CV="132" default="1" tooltip="CV132: 0=>Off, 1-28=>F1-F8, 29=>F0" exclude="SD18A_1.00,SD18A_1.01,SD21A_1.01,SD18A_1.02,SD21A_1.02,SD18A_1.03,SD21A_1.03">
+  <variable item="Function for shunting speed" CV="132" default="4" tooltip="CV132: 0=>Off, 1-28=>F1-F28, 29=>F0" exclude="SD18A_1.00,SD18A_1.01,SD21A_1.01,SD18A_1.02,SD21A_1.02,SD18A_1.03,SD21A_1.03">
 		<xi:include href="http://jmri.org/xml/decoders/doehler_haass/Susi-SD_enum-map.xml"/>
+		<label>Function mapping shunting gear</label>
 		<label xml:lang="fr">Fonction pour marche réduite</label>
 		<label xml:lang="de">Funktionszuordnung Rangiergang</label>
 		<label xml:lang="ca">Funció per a marxa de maniobres</label>
   </variable>
-  <variable item="Function to deactivate start delay" CV="133" default="1" tooltip="CV133: 0=>Off, 1-28=>F1-F8, 29=>F0" exclude="SD18A_1.00,SD18A_1.01,SD21A_1.01,SD18A_1.02,SD21A_1.02,SD18A_1.03,SD21A_1.03">
+  <variable item="Function to deactivate start delay" CV="133" default="9" tooltip="CV133: switches off the acceleration and deceleration rates (CV3/CV4). 0=>Off, 1-28=>F1-F28, 29=>F0" exclude="SD18A_1.00,SD18A_1.01,SD21A_1.01,SD18A_1.02,SD21A_1.02,SD18A_1.03,SD21A_1.03">
 		<xi:include href="http://jmri.org/xml/decoders/doehler_haass/Susi-SD_enum-map.xml"/>
-		<label xml:lang="fr">Fonction pour désactiver délai de départ</label>
-		<label xml:lang="de">Funktionszuordnung Verzögerung ausschalten</label>
-		<label xml:lang="ca">Funció per a desactivar el retard en arrencar</label>
+		<label>Function mapping deceleration off</label>
+		<label xml:lang="fr">Fonction pour désactiver les temporisations</label>
+		<label xml:lang="de">Funktionszuordnung Verzögerungen ausschalten</label>
+		<label xml:lang="ca">Funció per desactivar les temporitzacions</label>
   </variable>
 
 </variables>

--- a/xml/decoders/doehler_haass/SD_cv137_bit6_fw1.13.xml
+++ b/xml/decoders/doehler_haass/SD_cv137_bit6_fw1.13.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet type="text/xsl" href="../XSLT/decoder.xsl"?>
+<!-- Copyright (C) JMRI 2001, 2005, 2007, 2-009, 2010 All rights reserved -->
+<!--                                                                        -->
+<!-- JMRI is free software; you can redistribute it and/or modify it under  -->
+<!-- the terms of version 2 of the GNU General Public License as published  -->
+<!-- by the Free Software Foundation. See the "COPYING" file for a copy     -->
+<!-- of this license.                                                       -->
+<!--                                                                        -->
+<!-- JMRI is distributed in the hope that it will be useful, but WITHOUT    -->
+<!-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or  -->
+<!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
+<!-- for more details.                                                      -->
+<variables xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
+  <copyright xmlns="http://docbook.org/ns/docbook">
+    <year>2026</year>
+    <holder>JMRI</holder>
+  </copyright>
+  <authorgroup xmlns="http://docbook.org/ns/docbook">
+    <author>
+      <personname>
+        <firstname>Pierre</firstname>
+        <surname>Billon</surname>
+      </personname>
+    </author>
+  </authorgroup>
+  <revhistory xmlns="http://docbook.org/ns/docbook">
+    <revision>
+      <revnumber>1</revnumber>
+      <date>2026-07-27</date>
+      <authorinitials>PB</authorinitials>
+      <revremark>Creation. CV137 bit 6, introduced in sound decoder firmware 1.13.112.</revremark>
+    </revision>
+  </revhistory>
+  <variable CV="137" item="Adopt function swapping for SUSI" mask="XVXXXXXX">
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+    <label>Adopt function interchanges (CV401ff.) for SUSI F1-F12</label>
+    <label xml:lang="fr">Appliquer les permutations de fonction (CV401ss.) aux SUSI F1-F12</label>
+    <label xml:lang="de">Funktionsvertauschungen (CV401ff.) für SUSI F1-F12 übernehmen</label>
+    <tooltip>bit 6 - since firmware 1.13.112. Requires CV137 bit 0 = 0 (SUSI on ZCLK/ZDAT).</tooltip>
+    <tooltip xml:lang="fr">bit 6 - depuis le firmware 1.13.112. Nécessite CV137 bit 0 = 0 (SUSI sur ZCLK/ZDAT).</tooltip>
+    <tooltip xml:lang="de">Bit 6 - seit Firmware 1.13.112. Nur bei CV137 Bit 0 = 0 (SUSI an ZCLK und ZDAT).</tooltip>
+  </variable>
+</variables>

--- a/xml/decoders/doehler_haass/SD_cv137_bits4-5.xml
+++ b/xml/decoders/doehler_haass/SD_cv137_bits4-5.xml
@@ -39,7 +39,7 @@
     <label xml:lang="de">Erweiterte Funktionszuordnung</label>
     <label xml:lang="ca">Mapejat estés</label>
   </variable>
-  <variable item="SUSI ouptuts mapping" CV="137" mask="XXVXXXXX" tooltip="CV137 bit 5" exclude="SD18A_1.00,SD18A_1.01,SD21A_1.01,SD18A_1.02,SD21A_1.02,SD18A_1.03,SD21A_1.03">
+  <variable item="SUSI outputs mapping" CV="137" mask="XXVXXXXX" tooltip="CV137 bit 5" exclude="SD18A_1.00,SD18A_1.01,SD21A_1.01,SD18A_1.02,SD21A_1.02,SD18A_1.03,SD21A_1.03">
     <enumVal>
       <enumChoice choice="ZCLK and ZDAT as AUX 3 and AUX 4" value="0">
         <choice>ZCLK and ZDAT as AUX 3 and AUX 4</choice>
@@ -54,7 +54,7 @@
         <choice xml:lang="ca">ZCLK i ZDAT com AUX 3 und AUX 4</choice>
       </enumChoice>
     </enumVal>
-    <label>SUSI ouptuts mapping</label>
+    <label>SUSI outputs mapping</label>
     <label xml:lang="fr">Mapping sorties SUSI</label>
     <label xml:lang="de">SUSI Ausgänge Mapping</label>
     <label xml:lang="ca">Mapejat de sortides SUSI</label>

--- a/xml/decoders/doehler_haass/SD_cv137_bits4-5.xml
+++ b/xml/decoders/doehler_haass/SD_cv137_bits4-5.xml
@@ -26,6 +26,12 @@
   </authorgroup>
   <revhistory xmlns="http://docbook.org/ns/docbook">
     <revision>
+      <revnumber>2</revnumber>
+      <date>2026-07-27</date>
+      <authorinitials>PB</authorinitials>
+      <revremark>Corrected a misspelt item name and label</revremark>
+    </revision>
+    <revision>
       <revnumber>1</revnumber>
       <date>2015-10-15</date>
       <authorinitials>PB</authorinitials>

--- a/xml/decoders/doehler_haass/SD_cv28_bit2_fw1.13.xml
+++ b/xml/decoders/doehler_haass/SD_cv28_bit2_fw1.13.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet type="text/xsl" href="../XSLT/decoder.xsl"?>
+<!-- Copyright (C) JMRI 2001, 2005, 2007, 2-009, 2010 All rights reserved -->
+<!--                                                                        -->
+<!-- JMRI is free software; you can redistribute it and/or modify it under  -->
+<!-- the terms of version 2 of the GNU General Public License as published  -->
+<!-- by the Free Software Foundation. See the "COPYING" file for a copy     -->
+<!-- of this license.                                                       -->
+<!--                                                                        -->
+<!-- JMRI is distributed in the hope that it will be useful, but WITHOUT    -->
+<!-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or  -->
+<!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
+<!-- for more details.                                                      -->
+<variables xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
+  <copyright xmlns="http://docbook.org/ns/docbook">
+    <year>2026</year>
+    <holder>JMRI</holder>
+  </copyright>
+  <authorgroup xmlns="http://docbook.org/ns/docbook">
+    <author>
+      <personname>
+        <firstname>Pierre</firstname>
+        <surname>Billon</surname>
+      </personname>
+    </author>
+  </authorgroup>
+  <revhistory xmlns="http://docbook.org/ns/docbook">
+    <revision>
+      <revnumber>1</revnumber>
+      <date>2026-07-27</date>
+      <authorinitials>PB</authorinitials>
+      <revremark>Creation. CV28 bit 2, introduced in sound decoder firmware 1.13.112.</revremark>
+    </revision>
+  </revhistory>
+  <variable CV="28" item="Railcom dynamic channel (CV28)" mask="XXXXXVXX">
+    <xi:include href="http://jmri.org/xml/decoders/parts/enum-disabledEnabled.xml"/>
+    <label>Dynamic channel use (NMRA, CV28)</label>
+    <label xml:lang="fr">Utilisation dynamique du canal (NMRA, CV28)</label>
+    <label xml:lang="de">Dynamische Kanalnutzung (normgerecht, CV28)</label>
+    <tooltip>bit 2 - since firmware 1.13.112. Two CVs control this one function: this NMRA-standard bit, and the older D&amp;H "Railcom Dynamic Channel" (CV144 bit 0), which D&amp;H still support. Setting either one activates dynamic channel use.</tooltip>
+    <tooltip xml:lang="fr">bit 2 - depuis le firmware 1.13.112. Deux CV commandent cette même fonction : ce bit normalisé NMRA, et l'ancien "Railcom Dynamic Channel" D&amp;H (CV144 bit 0), toujours géré par D&amp;H. Activer l'un ou l'autre suffit.</tooltip>
+    <tooltip xml:lang="de">Bit 2 - seit Firmware 1.13.112. Zwei CV steuern dieselbe Funktion: dieses normgerechte NMRA-Bit und das ältere D&amp;H "Railcom Dynamic Channel" (CV144 Bit 0), das D&amp;H weiterhin unterstützen. Es genügt, eines von beiden zu setzen.</tooltip>
+  </variable>
+</variables>

--- a/xml/decoders/doehler_haass/SD_cv28_bit2_fw1.13.xml
+++ b/xml/decoders/doehler_haass/SD_cv28_bit2_fw1.13.xml
@@ -34,9 +34,9 @@
   </revhistory>
   <variable CV="28" item="Railcom dynamic channel (CV28)" mask="XXXXXVXX">
     <xi:include href="http://jmri.org/xml/decoders/parts/enum-disabledEnabled.xml"/>
-    <label>Dynamic channel use (NMRA, CV28)</label>
-    <label xml:lang="fr">Utilisation dynamique du canal (NMRA, CV28)</label>
-    <label xml:lang="de">Dynamische Kanalnutzung (normgerecht, CV28)</label>
+    <label>Dynamic Channel (NMRA, CV28)</label>
+    <label xml:lang="fr">Canal dynamique (NMRA, CV28)</label>
+    <label xml:lang="de">Dynamische Kanalnutzung (NMRA, CV28)</label>
     <tooltip>bit 2 - since firmware 1.13.112. Two CVs control this one function: this NMRA-standard bit, and the older D&amp;H "Railcom Dynamic Channel" (CV144 bit 0), which D&amp;H still support. Setting either one activates dynamic channel use.</tooltip>
     <tooltip xml:lang="fr">bit 2 - depuis le firmware 1.13.112. Deux CV commandent cette même fonction : ce bit normalisé NMRA, et l'ancien "Railcom Dynamic Channel" D&amp;H (CV144 bit 0), toujours géré par D&amp;H. Activer l'un ou l'autre suffit.</tooltip>
     <tooltip xml:lang="de">Bit 2 - seit Firmware 1.13.112. Zwei CV steuern dieselbe Funktion: dieses normgerechte NMRA-Bit und das ältere D&amp;H "Railcom Dynamic Channel" (CV144 Bit 0), das D&amp;H weiterhin unterstützen. Es genügt, eines von beiden zu setzen.</tooltip>

--- a/xml/decoders/doehler_haass/SD_cv360-362_960-962.xml
+++ b/xml/decoders/doehler_haass/SD_cv360-362_960-962.xml
@@ -95,7 +95,7 @@
   </variable>
   <!-- END SIMILAR CV -->
   <!-- BEGIN SIMILAR CV for sound decoders (SD18A, SD21A...) and modules (SH10A...). Mind the exclude parameter -->
-  <variable label="Threshold ZVS" CV="361" tooltip="CV361 (0-14)" default="9" item="Sound Option 21" exclude="SUSI sound modules,SUSI sound modules (2020),SUSI sound modules (2022)">
+  <variable label="Threshold ZVS" CV="361" tooltip="CV361 (0-14)" default="7" item="Sound Option 21" exclude="SUSI sound modules,SUSI sound modules (2020),SUSI sound modules (2022)">
   <decVal min="0" max="14"/>
   <label xml:lang="fr">Seuil ZVS</label>
   <label xml:lang="de">Schwellenwert ZVS</label>

--- a/xml/decoders/doehler_haass/SD_cv360-362_960-962.xml
+++ b/xml/decoders/doehler_haass/SD_cv360-362_960-962.xml
@@ -38,6 +38,12 @@
   </authorgroup>
   <revhistory xmlns="http://docbook.org/ns/docbook">
     <revision>
+      <revnumber>8</revnumber>
+      <date>2026-07-27</date>
+      <authorinitials>PB</authorinitials>
+      <revremark>CV361 and CV961 defaults corrected to 7</revremark>
+    </revision>
+    <revision>
       <revnumber>7</revnumber>
       <date>2023-07-22</date>
       <authorinitials>RK</authorinitials>

--- a/xml/decoders/doehler_haass/SD_cv360-362_960-962.xml
+++ b/xml/decoders/doehler_haass/SD_cv360-362_960-962.xml
@@ -101,7 +101,7 @@
   <label xml:lang="de">Schwellenwert ZVS</label>
   <label xml:lang="ca">Límit ZVS</label>
    </variable>
-  <variable label="Threshold ZVS" CV="961" tooltip="CV961 (0-14)" default="9" item="Sound Option 21" exclude="Combo sound decoders,Sound Decoders (2016),Sound Decoders (2018),Sound Decoders (2020),Sound Decoders (2022),SH10A_1.00">
+  <variable label="Threshold ZVS" CV="961" tooltip="CV961 (0-14)" default="7" item="Sound Option 21" exclude="Combo sound decoders,Sound Decoders (2016),Sound Decoders (2018),Sound Decoders (2020),Sound Decoders (2022),SH10A_1.00">
   <decVal min="0" max="14"/>
   <label xml:lang="fr">Seuil ZVS</label>
   <label xml:lang="de">Schwellenwert ZVS</label>

--- a/xml/decoders/doehler_haass/SD_cv364-373_964-973.xml
+++ b/xml/decoders/doehler_haass/SD_cv364-373_964-973.xml
@@ -38,6 +38,12 @@
   </authorgroup>
   <revhistory xmlns="http://docbook.org/ns/docbook">
     <revision>
+      <revnumber>8</revnumber>
+      <date>2026-07-27</date>
+      <authorinitials>PB</authorinitials>
+      <revremark>Added the missing English label on CV367 bit 2</revremark>
+    </revision>
+    <revision>
       <revnumber>7</revnumber>
       <date>2023-07-22</date>
       <authorinitials>RK</authorinitials>

--- a/xml/decoders/doehler_haass/SD_cv364-373_964-973.xml
+++ b/xml/decoders/doehler_haass/SD_cv364-373_964-973.xml
@@ -152,6 +152,7 @@
   <!-- Added - Fw 1.04+ for Sound decoders only (irrelevant for SUSI modules)-->
   <variable item="Forward random sounds to SUSI" CV="367" tooltip="CV367 bit 2" mask="XXXXXVXX" default="0" exclude="SUSI sound modules,SUSI sound modules (2020),SUSI sound modules (2022),SD18A_1.00,SD18A_1.01,SD21A_1.01,SD18A_1.02,SD21A_1.02,SD18A_1.03,SD21A_1.03">
     <xi:include href="http://jmri.org/xml/decoders/parts/enum-disabledEnabled.xml"/>
+    <label>Forward random sounds to SUSI</label>
     <label xml:lang="fr">Passer les sons aléatoires à SUSI</label>
     <label xml:lang="de">Zufallsgeräusche an SUSI weiterleiten</label>
     <label xml:lang="ca">Passar sons aleatoris a Susi</label>

--- a/xml/decoders/doehler_haass/cv135-136_144_railcom_fw3.06.xml
+++ b/xml/decoders/doehler_haass/cv135-136_144_railcom_fw3.06.xml
@@ -38,6 +38,12 @@
   </authorgroup>
   <revhistory xmlns="http://docbook.org/ns/docbook">
     <revision>
+      <revnumber>5</revnumber>
+      <date>2026-07-27</date>
+      <authorinitials>PB</authorinitials>
+      <revremark>Added the missing French label on CV144 bit 0</revremark>
+    </revision>
+    <revision>
       <revnumber>4</revnumber>
       <date>2019-07-28</date>
       <authorinitials>ALM</authorinitials>
@@ -89,6 +95,7 @@
   <variable item="Railcom Dynamic Channel" CV="144" mask="XXXXXXXV" tooltip="CV144 Bit 0">
     <xi:include href="http://jmri.org/xml/decoders/parts/enum-disabledEnabled.xml"/>
     <label>Dynamic Channel (BiDi)</label>
+    <label xml:lang="fr">Canal dynamique (BiDi)</label>
     <label xml:lang="de">Dynamische Kanalnutzung (BiDi)</label>
     <label xml:lang="ca">Canal Dinàmic (BiDi)</label>
   </variable>


### PR DESCRIPTION
Completes firmware 1.13 for the D&H sound decoders and corrects
long-standing defects.

Firmware 1.14 is deliberately excluded — D&H's CV page lists it, but there
is no downloadable firmware, no changelog and no CV7 value, so it cannot
be defined at this point.