### PR TITLE
Declare the E24 interface on the ESU and Zimo decoders that use it

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -280,6 +280,7 @@
 
         <h4>ESU</h4>
             <ul>
+                <li>LokSound 5 nano DCC now declares its E24 interface.</li>
                 <li></li>
             </ul>
 
@@ -435,6 +436,8 @@
 
         <h4>ZIMO</h4>
             <ul>
+                <li>MS540E24 now declares its E24 interface, and the MN140E24 definition is now
+                    available.</li>
                 <li></li>
             </ul>
 

--- a/xml/decoders/ESU_LokSound5.xml
+++ b/xml/decoders/ESU_LokSound5.xml
@@ -34,6 +34,7 @@
     <version author="Heiko Rosemann" version="8" lastUpdated="20230123"/>
     <version author="Michael Mosher" version="9" lastUpdated="20240321"/>
     <version author="Heiko Rosemann" version="10" lastUpdated="20240901"/>
+    <version author="Pierre Billon, pierre.bln@me.com" version="11" lastUpdated="20260727"/>
     <decoder>
         <family name="ESU LokSound 5" mfg="Electronic Solutions Ulm GmbH" lowVersionID="255" highVersionID="255">
             <model model="LokSound 5" maxFnNum="31" numOuts="20" maxMotorCurrent="1.5A" extFnsESU="V5" productID="33554582,33554679,33554650">
@@ -76,7 +77,7 @@
             <model show="no" model="LokSound 5 micro E24 DCC" replacementModel="LokSound 5 nano DCC" maxFnNum="31" numOuts="20" maxMotorCurrent="0.75A" extFnsESU="V5" productID="16777404">
                 <size length="21.0" width="10.6" height="4.0" units="mm"/>
             </model>
-            <model model="LokSound 5 nano DCC" maxFnNum="31" numOuts="20" maxMotorCurrent="0.75A" extFnsESU="V5" productID="16777404">
+            <model model="LokSound 5 nano DCC" maxFnNum="31" numOuts="20" maxMotorCurrent="0.75A" extFnsESU="V5" productID="16777404" connector="E24">
                 <size length="19.6" width="8.5" height="5.3" units="mm"/>
             </model>
             <model model="LokSound 5 nano DCC Next18" maxFnNum="31" numOuts="20" maxMotorCurrent="0.75A" extFnsESU="V5" productID="16777444">

--- a/xml/decoders/Zimo_MN_small_v4.xml
+++ b/xml/decoders/Zimo_MN_small_v4.xml
@@ -19,12 +19,12 @@
   <!-- v1.1  Ronald Kuhn. 2 May 2024, add new decoder   -->
 
   <version author="Ronald Kuhn" version="1.0" lastUpdated="2023/05/25"/>
+  <version author="Pierre Billon, pierre.bln@me.com" version="1.1" lastUpdated="2026/07/27"/>
 
   <decoder>
     <family name="MN Non-Sound (version 4+)" mfg="Zimo">
 
-<!-- not available yet (2024-05-02)
-      <model model="MN140E24 version 4+" lowVersionID="4" highVersionID="42" maxInputVolts="24V" maxMotorCurrent="0.7A, peak=1.5A" maxTotalCurrent="0.7A" formFactor="N" numOuts="8" numFns="14" productID="119">
+      <model model="MN140E24 version 4+" lowVersionID="4" highVersionID="42" maxInputVolts="24V" maxMotorCurrent="0.7A, peak=1.5A" maxTotalCurrent="0.7A" formFactor="N" numOuts="8" numFns="14" productID="119" connector="E24">
         <output name="1" label="Front Light">
           <label xml:lang="de">Lvor</label>
           <label xml:lang="cs">Přední světla</label>
@@ -59,7 +59,6 @@
         </output>
         <size length="14" width="8.7" height="2.3" units="mm"/>
       </model>
--->
       <model model="MN160 version 4+" lowVersionID="4" highVersionID="42" maxInputVolts="24V" maxMotorCurrent="0.5A, peak=1.0A" maxTotalCurrent="0.5A" formFactor="N" numOuts="6" numFns="14" productID="122">
         <output name="1" label="Front Light">
           <label xml:lang="de">Lvor</label>

--- a/xml/decoders/Zimo_MS_small_v4.xml
+++ b/xml/decoders/Zimo_MS_small_v4.xml
@@ -29,6 +29,7 @@
   <!-- v1.4,  added new decoder versions -->
 
   <version author="Nigel Cliffe" version="1.5" lastUpdated="2025/03/14"/>
+  <version author="Pierre Billon, pierre.bln@me.com" version="1.6" lastUpdated="2026/07/27"/>
   <!--  added Zimo Scripting variables, CV837, CV843, CV981-1019  new pane for Zimo Scripting,  added decoder MS591N18, and removed comments to enable MS540E4-->
   
   <decoder>
@@ -222,7 +223,7 @@
       </model>
 
 
-      <model model="MS540E24 version 4+" lowVersionID="4" highVersionID="42" maxInputVolts="35V" maxMotorCurrent="0.8A, peak=1.5A" maxTotalCurrent="0.8A" formFactor="HO" numOuts="12" numFns="14" productID="14">
+      <model model="MS540E24 version 4+" lowVersionID="4" highVersionID="42" maxInputVolts="35V" maxMotorCurrent="0.8A, peak=1.5A" maxTotalCurrent="0.8A" formFactor="HO" numOuts="12" numFns="14" productID="14" connector="E24">
         <output name="1" label="Front Light">
           <label xml:lang="de">Lvor</label>
           <label xml:lang="cs">Přední světla</label>


### PR DESCRIPTION
`E24` became a valid `connector` value in #15293. 
Definitions updated with it:
- ESU `LokSound 5 nano DCC`
- Zimo `MS540E24 version 4+`
- Zimo `MN140E24 version 4+`

**MN140E24 is also enabled by this PR.** It was commented out as
"not available yet (2024-05-02)"; the decoder has shipped since.

Not touched:
- `LokSound 5 micro E24 DCC` — `show="no"` with a `replacementModel`, so a
  connector on it would never be displayed.
