### PR TITLE
DP tabbing fix

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -487,6 +487,7 @@
             <li>Add the ability to export a backup of a single Roster Group.</li>
             <li>You can now program, save and load DS64 output addresses and routes in a roster entry using DecoderPro.</li>
             <li>Fixed a bug which caused importing a decoder on Windows to fail.</li>
+            <li>Fixed a bug which would sometimes show empty tabs when it shouldn't.</li>
         </ul>
 
    <h3>Dispatcher</h3>

--- a/java/src/jmri/jmrit/symbolicprog/tabbedframe/PaneProgFrame.java
+++ b/java/src/jmri/jmrit/symbolicprog/tabbedframe/PaneProgFrame.java
@@ -1717,12 +1717,14 @@ abstract public class PaneProgFrame extends JmriJFrame
                     // how to handle the tab depends on whether it has contents and option setting
                     int index;
                     if (enableEmpty || !p.cvList.isEmpty() || !p.varList.isEmpty()) {
+                        log.debug("'{}' pane of 1st type at index {}", name, tabPane.indexOfTab(name));
                         // Was there a race condition here with qualified panes?
                         // QualifiedVarTest attempts to invoke that, but haven't it with the following code
                         index = tabPane.indexOfTab(name);
                         tabPane.setComponentAt(tabPane.indexOfTab(name), p);  // always add if not empty
                         tabPane.setToolTipTextAt(tabPane.indexOfTab(name), p.getToolTipText());
                     } else if (isShowingEmptyPanes()) {
+                        log.debug("'{}' pane of 2nd type", name);
                         // here empty, but showing anyway as disabled
                         index = tabPane.indexOfTab(name);
                         tabPane.setComponentAt(tabPane.indexOfTab(name), p);
@@ -1730,10 +1732,12 @@ abstract public class PaneProgFrame extends JmriJFrame
                                 Bundle.getMessage("TipTabEmptyNoCategory"));
                         tabPane.setEnabledAt(tabPane.indexOfTab(name), true); // need to enable the pane so user can see message
                     } else {
+                        log.debug("'{}' pane of 3rd type", name);
                         // here not showing tab at all
                         index = -1;
-                        log.trace("deleted {} tab here", name);
-                        tabPane.removeTabAt(tabPane.indexOfTab(name));
+                        log.trace("deleted {} tab here at index {}", name, tabPane.indexOfTab(name));
+                        // tabPane.removeTabAt(..) does not work here with DetachableTabbedPane
+                        tabPane.remove(tabPane.indexOfTab(name));
                     }
 
                     // remember it for programming

--- a/java/src/jmri/util/org/mitre/jawb/swing/DetachableTabbedPane.java
+++ b/java/src/jmri/util/org/mitre/jawb/swing/DetachableTabbedPane.java
@@ -393,11 +393,13 @@ public class DetachableTabbedPane extends JTabbedPane {
   public void remove (Component comp) {
     Detachable detachable = panelToDetMap.get (comp);
     if (detachable != null)
+      log.trace("panelToDetMap of {} found {} with {}", comp, detachable, detachable.component);
       remove (detachable);
     else
       super.remove(comp);
   }
   private void remove (Detachable d) {
+    log.trace("remove Detachable {} Component {}", d, d.component);
     if (d != null) {
       panelToDetMap.remove (d.component);
       shiftDetachables (false, d);

--- a/java/src/jmri/util/org/mitre/jawb/swing/DetachableTabbedPane.java
+++ b/java/src/jmri/util/org/mitre/jawb/swing/DetachableTabbedPane.java
@@ -392,14 +392,14 @@ public class DetachableTabbedPane extends JTabbedPane {
   @Override
   public void remove (Component comp) {
     Detachable detachable = panelToDetMap.get (comp);
-    if (detachable != null)
+    if (detachable != null) {
       log.trace("panelToDetMap of {} found {} with {}", comp, detachable, detachable.component);
       remove (detachable);
-    else
+    } else {
       super.remove(comp);
+    }
   }
   private void remove (Detachable d) {
-    log.trace("remove Detachable {} Component {}", d, d.component);
     if (d != null) {
       panelToDetMap.remove (d.component);
       shiftDetachables (false, d);


### PR DESCRIPTION
When some DP tabs are not shown and the user opens a tab before it's fully loaded, sometimes an "invisible" tab would be erroneously shown.  This PR fixes that and adds a little debugging logging.