### PR TITLE
Fix high CPU use in Sensor Table

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -697,6 +697,11 @@
     <h3>Turnouts, Lights, Sensors and other elements</h3>
         <a id="TLae" name="TLae"></a>
         <ul>
+            <li>Fixed high CPU use of the Sensor Table when the "graphic state" preference
+                is enabled: painting a state icon no longer resizes the row, which kept the
+                table repainting itself continuously once all sensors were in a known state.
+                Rows are now also tall enough for the icons while sensors are still in the
+                Unknown state.</li>
             <li></li>
         </ul>
 

--- a/java/src/jmri/jmrit/beantable/sensor/SensorTableDataModel.java
+++ b/java/src/jmri/jmrit/beantable/sensor/SensorTableDataModel.java
@@ -4,6 +4,7 @@ import jmri.util.gui.GuiLafPreferencesManager;
 import java.awt.Color;
 import java.awt.Component;
 import java.awt.Image;
+import java.awt.Rectangle;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.awt.image.BufferedImage;
@@ -451,19 +452,42 @@ public class SensorTableDataModel extends BeanTableDataModel<Sensor> {
      * Visualize state in table as a graphic, customized for Sensors (2 states).
      * Renderer and Editor are identical, as the cell contents are not actually
      * edited, only used to toggle state using {@link #clickOn}.
+     * <p>
+     * A single label is reused for every cell and the icons are loaded once
+     * per JVM, so rendering a cell allocates nothing. The label ignores
+     * revalidate/repaint requests and the row height is set once in
+     * {@link #configureTable}: painting a cell must never schedule more
+     * painting, or the table repaints itself forever.
      */
     static class ImageIconRenderer extends AbstractCellEditor implements TableCellEditor, TableCellRenderer {
 
-        protected JLabel label;
-        protected String rootPath = "resources/icons/misc/switchboard/"; // also used in display.switchboardEditor
-        protected char beanTypeChar = 'S'; // for Sensor
-        protected String onIconPath = rootPath + beanTypeChar + "-on-s.png";
-        protected String offIconPath = rootPath + beanTypeChar + "-off-s.png";
-        protected BufferedImage onImage;
-        protected BufferedImage offImage;
-        protected ImageIcon onIcon;
-        protected ImageIcon offIcon;
-        protected int iconHeight = -1;
+        private static final String ROOT_PATH = "resources/icons/misc/switchboard/"; // also used in display.switchboardEditor
+        private static final char BEAN_TYPE_CHAR = 'S'; // for Sensor
+        private static final String ON_ICON_PATH = ROOT_PATH + BEAN_TYPE_CHAR + "-on-s.png";
+        private static final String OFF_ICON_PATH = ROOT_PATH + BEAN_TYPE_CHAR + "-off-s.png";
+        private static ImageIcon onIcon = null;
+        private static ImageIcon offIcon = null;
+        private static int iconHeight = -1;
+
+        private final StateLabel label = new StateLabel();
+        private final Color defaultForeground = label.getForeground();
+        private final String activeText = Bundle.getMessage("SensorStateActive");
+        private final String inactiveText = Bundle.getMessage("SensorStateInactive");
+        private final String unknownText = Bundle.getMessage("BeanStateUnknown");
+        private final String inconsistentText = Bundle.getMessage("BeanStateInconsistent");
+        private int row = -1; // row of the cell last rendered or edited
+
+        ImageIconRenderer() {
+            label.setHorizontalAlignment(JLabel.CENTER);
+            // must stay the only anonymous class in ImageIconRenderer, see jmri.ArchitectureTest
+            label.addMouseListener(new MouseAdapter() {
+                @Override
+                public final void mousePressed(MouseEvent evt) {
+                    log.debug("Clicked on icon in row {}", row);
+                    stopCellEditing();
+                }
+            });
+        }
 
         /**
          * {@inheritDoc}
@@ -473,11 +497,7 @@ public class SensorTableDataModel extends BeanTableDataModel<Sensor> {
                 JTable table, Object value, boolean isSelected,
                 boolean hasFocus, int row, int column) {
             log.debug("Renderer Item = {}, State = {}", row, value);
-            if (iconHeight < 0) { // load resources only first time, either for renderer or editor
-                loadIcons();
-                log.debug("icons loaded");
-            }
-            return updateLabel((String) value, row, table);
+            return updateLabel((String) value, row);
         }
 
         /**
@@ -487,48 +507,45 @@ public class SensorTableDataModel extends BeanTableDataModel<Sensor> {
         public Component getTableCellEditorComponent(
                 JTable table, Object value, boolean isSelected,
                 int row, int column) {
-            log.debug("Renderer Item = {}, State = {}", row, value);
+            log.debug("Editor Item = {}, State = {}", row, value);
+            return updateLabel((String) value, row);
+        }
+
+        protected JLabel updateLabel(String value, int row) {
+            this.row = row;
             if (iconHeight < 0) { // load resources only first time, either for renderer or editor
                 loadIcons();
                 log.debug("icons loaded");
             }
-            return updateLabel((String) value, row, table);
-        }
-
-        public JLabel updateLabel(String value, int row, JTable table) {
-            if (iconHeight > 0) { // if necessary, increase row height;
-                table.setRowHeight(row, Math.max(table.getRowHeight(), iconHeight - 5)); // adjust table row height for Sensor icon
-            }
-            if (value.equals(Bundle.getMessage("SensorStateInactive")) && offIcon != null) {
-                label = new JLabel(offIcon);
+            label.setForeground(defaultForeground); // reset a foreground left over from an INCONSISTENT cell
+            if (value.equals(inactiveText) && offIcon != null) {
+                label.setIcon(offIcon);
+                label.setText(null);
                 label.setVerticalAlignment(JLabel.BOTTOM);
                 log.debug("offIcon set");
-            } else if (value.equals(Bundle.getMessage("SensorStateActive")) && onIcon != null) {
-                label = new JLabel(onIcon);
+            } else if (value.equals(activeText) && onIcon != null) {
+                label.setIcon(onIcon);
+                label.setText(null);
                 label.setVerticalAlignment(JLabel.BOTTOM);
                 log.debug("onIcon set");
-            } else if (value.equals(Bundle.getMessage("BeanStateInconsistent"))) {
-                label = new JLabel("X", JLabel.CENTER); // centered text alignment
+            } else if (value.equals(inconsistentText)) {
+                label.setIcon(null);
+                label.setText("X");
                 label.setForeground(Color.red);
+                label.setVerticalAlignment(JLabel.CENTER);
                 log.debug("Sensor state inconsistent");
-                iconHeight = 0;
-            } else if (value.equals(Bundle.getMessage("BeanStateUnknown"))) {
-                label = new JLabel("?", JLabel.CENTER); // centered text alignment
+            } else if (value.equals(unknownText)) {
+                label.setIcon(null);
+                label.setText("?");
+                label.setVerticalAlignment(JLabel.CENTER);
                 log.debug("Sensor state unknown");
-                iconHeight = 0;
             } else { // failed to load icon
-                label = new JLabel(value, JLabel.CENTER); // centered text alignment
+                label.setIcon(null);
+                label.setText(value);
+                label.setVerticalAlignment(JLabel.CENTER);
                 log.warn("Error reading icons for SensorTable");
-                iconHeight = 0;
             }
             label.setToolTipText(value);
-            label.addMouseListener(new MouseAdapter() {
-                @Override
-                public final void mousePressed(MouseEvent evt) {
-                    log.debug("Clicked on icon in row {}", row);
-                    stopCellEditing();
-                }
-            });
             return label;
         }
 
@@ -542,16 +559,39 @@ public class SensorTableDataModel extends BeanTableDataModel<Sensor> {
         }
 
         /**
-         * Read and buffer graphics. Only called once for this table.
+         * Get the row height needed to fit the state icons, loading them if
+         * required. Used by {@link #configureTable} to size the rows once,
+         * outside of the render path.
          *
-         * @see #getTableCellEditorComponent(JTable, Object, boolean, int, int)
+         * @return required row height in pixels, 0 if the icons could not be read
          */
-        protected void loadIcons() {
+        static int getIconRowHeight() {
+            if (iconHeight < 0) {
+                loadIcons();
+            }
+            return Math.max(iconHeight - 5, 0);
+        }
+
+        /**
+         * Read and buffer graphics. Only called once per JVM, the icons are
+         * shared by all instances of this renderer.
+         */
+        private static synchronized void loadIcons() {
+            if (iconHeight >= 0) { // another instance already loaded the icons
+                return;
+            }
+            BufferedImage onImage = null;
+            BufferedImage offImage = null;
             try {
-                onImage = ImageIO.read(new File(onIconPath));
-                offImage = ImageIO.read(new File(offIconPath));
+                onImage = ImageIO.read(new File(ON_ICON_PATH));
+                offImage = ImageIO.read(new File(OFF_ICON_PATH));
             } catch (IOException ex) {
-                log.error("error reading image from {} or {}", onIconPath, offIconPath, ex);
+                log.error("error reading image from {} or {}", ON_ICON_PATH, OFF_ICON_PATH, ex);
+            }
+            if (onImage == null || offImage == null) { // ImageIO.read returns null for an unreadable file
+                log.error("error reading image from {} or {}", ON_ICON_PATH, OFF_ICON_PATH);
+                iconHeight = 0; // give up: render states as text, don't retry for every cell
+                return;
             }
             log.debug("Success reading images");
             int imageWidth = onImage.getWidth();
@@ -564,6 +604,49 @@ public class SensorTableDataModel extends BeanTableDataModel<Sensor> {
             iconHeight = onIcon.getIconHeight();
         }
 
+        /**
+         * Label that ignores revalidate and repaint requests.
+         * <p>
+         * The rendered component stays a child of the table's
+         * CellRendererPane after painting, so a plain JLabel schedules a new
+         * repaint of the whole table each time its icon or text changes
+         * during a paint cycle. Same overrides as DefaultTableCellRenderer,
+         * except firePropertyChange, which BasicLabelUI needs to keep its
+         * view up to date.
+         */
+        private static class StateLabel extends JLabel {
+
+            @Override
+            public void revalidate() {
+                // ignored, see class comment
+            }
+
+            @Override
+            public void repaint() {
+                // ignored, see class comment
+            }
+
+            @Override
+            public void repaint(long tm) {
+                // ignored, see class comment
+            }
+
+            @Override
+            public void repaint(int x, int y, int width, int height) {
+                // ignored, see class comment
+            }
+
+            @Override
+            public void repaint(long tm, int x, int y, int width, int height) {
+                // ignored, see class comment
+            }
+
+            @Override
+            public void repaint(Rectangle r) {
+                // ignored, see class comment
+            }
+        }
+
     } // end of ImageIconRenderer class
 
     /**
@@ -572,6 +655,12 @@ public class SensorTableDataModel extends BeanTableDataModel<Sensor> {
     @Override
     public void configureTable(JTable table) {
         super.configureTable(table);
+        if (_graphicState) {
+            // make the rows tall enough for the state icons, once and outside of the
+            // renderer; must come after super.configureTable, which sets the row
+            // height for the buttons
+            table.setRowHeight(Math.max(table.getRowHeight(), ImageIconRenderer.getIconRowHeight()));
+        }
         XTableColumnModel columnModel = (XTableColumnModel) table.getColumnModel();
         columnModel.getColumnByModelIndex(FORGETCOL).setHeaderValue(null);
         columnModel.getColumnByModelIndex(QUERYCOL).setHeaderValue(null);

--- a/java/test/jmri/jmrit/beantable/sensor/SensorTableDataModelTest.java
+++ b/java/test/jmri/jmrit/beantable/sensor/SensorTableDataModelTest.java
@@ -1,14 +1,31 @@
 package jmri.jmrit.beantable.sensor;
 
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.event.MouseEvent;
+import java.awt.event.MouseListener;
+
 import javax.swing.JButton;
 import javax.swing.JComboBox;
+import javax.swing.JLabel;
+import javax.swing.JTable;
+import javax.swing.table.TableCellRenderer;
+import javax.swing.table.TableModel;
 
+import jmri.InstanceManager;
+import jmri.JmriException;
 import jmri.Sensor;
+import jmri.SensorManager;
 import jmri.util.JUnitUtil;
+import jmri.util.gui.GuiLafPreferencesManager;
+import jmri.util.swing.XTableColumnModel;
 
 import org.junit.jupiter.api.*;
 import org.junit.Assert;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 
 /**
  *
@@ -56,6 +73,131 @@ public class SensorTableDataModelTest extends jmri.jmrit.beantable.AbstractBeanT
         assertEquals("PULLUPCOL ",JComboBox.class,t.getColumnClass(SensorTableDataModel.PULLUPCOL) );
         assertEquals("FORGETCOL ",JButton.class,t.getColumnClass(SensorTableDataModel.FORGETCOL) );
         assertEquals("QUERYCOL ",JButton.class,t.getColumnClass(SensorTableDataModel.QUERYCOL) );
+    }
+
+    /**
+     * JTable which counts calls to the per-row setRowHeight. The graphic state
+     * renderer must never call it: setRowHeight(int, int) unconditionally
+     * schedules a repaint of the whole table, so calling it while rendering a
+     * cell keeps the table repainting itself forever.
+     */
+    private static class CountingJTable extends JTable {
+
+        int rowHeightCalls = 0;
+
+        CountingJTable(TableModel m) {
+            super(m);
+        }
+
+        @Override
+        public void setRowHeight(int row, int rowHeight) {
+            rowHeightCalls++;
+            super.setRowHeight(row, rowHeight);
+        }
+    }
+
+    private SensorTableDataModel createGraphicStateModel() {
+        InstanceManager.getDefault(GuiLafPreferencesManager.class).setGraphicTableState(true);
+        // the model reads the preference in its constructor, so create a fresh one
+        return new SensorTableDataModel();
+    }
+
+    @Test
+    public void testGraphicRendererDoesNotResizeRows() throws JmriException {
+        SensorManager mgr = InstanceManager.getDefault(SensorManager.class);
+        for (int i = 1; i <= 10; i++) {
+            Sensor s = mgr.provideSensor("IS" + i);
+            s.setKnownState((i % 2 == 0) ? Sensor.ACTIVE : Sensor.INACTIVE);
+        }
+        SensorTableDataModel model = createGraphicStateModel();
+        CountingJTable table = new CountingJTable(model);
+        model.configValueColumn(table);
+        TableCellRenderer r = table.getDefaultRenderer(JLabel.class);
+        assertNotNull("graphic state renderer installed", r);
+        table.rowHeightCalls = 0;
+        for (int pass = 0; pass < 5; pass++) {
+            for (int row = 0; row < table.getRowCount(); row++) {
+                Component c = r.getTableCellRendererComponent(table,
+                        table.getValueAt(row, SensorTableDataModel.VALUECOL),
+                        false, false, row, SensorTableDataModel.VALUECOL);
+                assertNotNull("renderer returns a component", c);
+            }
+        }
+        assertEquals("rendering must not set row heights", 0, table.rowHeightCalls);
+        model.dispose();
+    }
+
+    @Test
+    public void testGraphicRendererReusesComponent() throws JmriException {
+        SensorManager mgr = InstanceManager.getDefault(SensorManager.class);
+        mgr.provideSensor("IS1").setKnownState(Sensor.ACTIVE);
+        mgr.provideSensor("IS2").setKnownState(Sensor.INACTIVE);
+        SensorTableDataModel model = createGraphicStateModel();
+        JTable table = new JTable(model);
+        model.configValueColumn(table);
+        TableCellRenderer r = table.getDefaultRenderer(JLabel.class);
+        Component first = r.getTableCellRendererComponent(table,
+                table.getValueAt(0, SensorTableDataModel.VALUECOL),
+                false, false, 0, SensorTableDataModel.VALUECOL);
+        Component second = r.getTableCellRendererComponent(table,
+                table.getValueAt(1, SensorTableDataModel.VALUECOL),
+                false, false, 1, SensorTableDataModel.VALUECOL);
+        assertSame("renderer reuses a single component", first, second);
+        model.dispose();
+    }
+
+    @Test
+    public void testGraphicRowHeightSetByConfigureTable() {
+        InstanceManager.getDefault(SensorManager.class).provideSensor("IS1");
+        SensorTableDataModel model = createGraphicStateModel();
+        CountingJTable table = new CountingJTable(model);
+        table.setColumnModel(new XTableColumnModel());
+        table.createDefaultColumnsFromModel();
+        model.configureTable(table);
+        assertTrue("icons read so a row height is available",
+                SensorTableDataModel.ImageIconRenderer.getIconRowHeight() > 0);
+        assertTrue("row height fits the state icons",
+                table.getRowHeight() >= SensorTableDataModel.ImageIconRenderer.getIconRowHeight());
+        model.dispose();
+    }
+
+    @Test
+    public void testGraphicRendererForegroundReset() {
+        SensorTableDataModel model = createGraphicStateModel();
+        JTable table = new JTable(model);
+        model.configValueColumn(table);
+        TableCellRenderer r = table.getDefaultRenderer(JLabel.class);
+        JLabel label = (JLabel) r.getTableCellRendererComponent(table,
+                Bundle.getMessage("SensorStateActive"), false, false, 0, SensorTableDataModel.VALUECOL);
+        Color defaultForeground = label.getForeground();
+        label = (JLabel) r.getTableCellRendererComponent(table,
+                Bundle.getMessage("BeanStateInconsistent"), false, false, 0, SensorTableDataModel.VALUECOL);
+        assertEquals("inconsistent state shown in red", Color.red, label.getForeground());
+        assertEquals("tool tip follows the state", Bundle.getMessage("BeanStateInconsistent"), label.getToolTipText());
+        label = (JLabel) r.getTableCellRendererComponent(table,
+                Bundle.getMessage("SensorStateActive"), false, false, 0, SensorTableDataModel.VALUECOL);
+        assertEquals("foreground reset after an inconsistent cell", defaultForeground, label.getForeground());
+        model.dispose();
+    }
+
+    @Test
+    public void testGraphicEditorClickTogglesSensor() throws JmriException {
+        Sensor s = InstanceManager.getDefault(SensorManager.class).provideSensor("IS1");
+        s.setKnownState(Sensor.INACTIVE);
+        SensorTableDataModel model = createGraphicStateModel();
+        JTable table = new JTable(model);
+        model.configValueColumn(table);
+        assertTrue("cell goes into edit mode",
+                table.editCellAt(0, SensorTableDataModel.VALUECOL));
+        Component editor = table.getEditorComponent();
+        assertNotNull("editor component in place", editor);
+        MouseEvent evt = new MouseEvent(editor, MouseEvent.MOUSE_PRESSED,
+                System.currentTimeMillis(), 0, 1, 1, 1, false);
+        for (MouseListener ml : editor.getMouseListeners()) {
+            ml.mousePressed(evt);
+        }
+        assertEquals("sensor toggled by clicking the cell", Sensor.ACTIVE, s.getKnownState());
+        model.dispose();
     }
 
     @BeforeEach


### PR DESCRIPTION
Hello, tracking perf issue as I am running on a raspberry PI with limited capacity, I hope this helps.

The graphic state renderer called JTable.setRowHeight(row, ...) from each paint cycle, unconditionally scheduling a full-table repaint. This created a self-sustaining loop once every sensors reached a known state.

Fix: icons loaded once per JVM, row height set once in configureTable, single reused label ignores revalidate/repaint. CPU reduced ~8x (8.1% → 1.1% user, EDT samples 1172 → 89).

- Test reproduction: open Sensor Table (graphic state on), wait for all sensors known, observe CPU should be flat (not climbing) 
- Regression tests added: CountingJTable, component reuse, foreground reset, click toggle
