### PR TITLE
fix current value in display

### DIFF
--- a/java/src/jmri/jmrix/bidib/BiDiBPowerManager.java
+++ b/java/src/jmri/jmrix/bidib/BiDiBPowerManager.java
@@ -184,6 +184,7 @@ public class BiDiBPowerManager implements PowerManager {
             public void speed(byte[] address, int messageNum, AddressData addressData, int speed) {
                 //Node node = tc.getFirstCommandStationNode();
                 //log.trace("speed: node UID: {}, node addr: {}, msg node addr: {}, address: {}, speed: {}", node.getUniqueId(), node.getAddr(), address, addressData, speed);
+                log.trace("speed: msg node addr: {}, address: {}, speed: {}", address, addressData, speed);
                 //if (NodeUtils.isAddressEqual(node.getAddr(), address)) {
                     //log.debug("SPEED was signalled, node addr: {}, speed: {}, loco: {}", node.getAddr(), speed, addressData);
                 //}

--- a/java/src/jmri/jmrix/bidib/swing/mon/BiDiBMonPane.java
+++ b/java/src/jmri/jmrix/bidib/swing/mon/BiDiBMonPane.java
@@ -201,7 +201,7 @@ public class BiDiBMonPane extends jmri.jmrix.AbstractMonPane implements BiDiBPan
             case BidibLibrary.MSG_BOOST_DIAGNOSTIC:
             {
                 BoostDiagnosticResponse m = (BoostDiagnosticResponse)message;
-                line = "Voltage: " + m.getVoltage() + " mV, Current: " + m.getCurrent() + " mA, Temperature: " + m.getTemperature() + " °C";
+                line = "Voltage: " + m.getVoltage() + " mV, Current: " + m.getCurrent().getCurrent() + " mA, Temperature: " + m.getTemperature() + " °C";
             }
                 break;
             case BidibLibrary.MSG_BOOST_STAT:


### PR DESCRIPTION
Small bug fix: due to a change in the jbidibc library, the current was not displayed correctly.

Additionally add a trace-log when receiving a real speed message (from RailCom). There doesn't seem to be any use for it anyway in JMRI.