### PR TITLE
Create a reference schema for the Speed Profile preferences

### DIFF
--- a/xml/schema/speedprofiler.xsd
+++ b/xml/schema/speedprofiler.xsd
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="schema2xhtml.xsl" type="text/xsl"?>
+
+<!-- XML Schema for the JMRI Speed Profile tool                             -->
+
+<!-- This schema is part of JMRI. Copyright 2026.                           -->
+<!--                                                                        -->
+<!-- JMRI is free software; you can redistribute it and/or modify it under  -->
+<!-- the terms of version 2 of the GNU General Public License as published  -->
+<!-- by the Free Software Foundation. See the "COPYING" file for a copy     -->
+<!-- of this license.                                                       -->
+<!--                                                                        -->
+<!-- JMRI is distributed in the hope that it will be useful, but WITHOUT    -->
+<!-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or  -->
+<!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
+<!-- for more details.                                                      -->
+
+<xs:schema xmlns:xs  ="http://www.w3.org/2001/XMLSchema"
+           xmlns:xsi ="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns:docbook="http://docbook.org/ns/docbook"
+           xmlns:jmri="http://jmri.org/xml/schema/JMRIschema"
+           xsi:schemaLocation="
+                http://jmri.org/xml/schema/JMRIschema http://jmri.org/xml/schema/JMRIschema.xsd
+                http://docbook.org/ns/docbook http://jmri.org/xml/schema/docbook/docbook.xsd
+            "
+           >
+
+  <xs:include schemaLocation="http://jmri.org/xml/schema/types/general.xsd"/>
+  <xs:import namespace='http://docbook.org/ns/docbook' schemaLocation='http://jmri.org/xml/schema/docbook/docbook.xsd'/>
+
+  <xs:element name="speedprofiler-config">
+
+    <xs:annotation>
+      <xs:documentation>
+        This is the schema representing SpeedProfile information.
+        Since the "speedprofiler-config" XML is embedded in the "profile.xml" file,
+        this schema defintion is for reference.
+        To validate the content, copy the XML and create a temporary standalone XML file.
+      </xs:documentation>
+      <xs:appinfo>
+        <jmri:usingclass configurexml="false">jmri.jmrit.roster.swing.speedprofile.SpeedProfilePanel</jmri:usingclass>
+      </xs:appinfo>
+    </xs:annotation>
+
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element type="configurationType" name="configuration" minOccurs="0" maxOccurs="1"/>
+        <xs:element type="sensorsType" name="sensors" minOccurs="0" maxOccurs="1"/>
+        <xs:element type="stepsType" name="steps" minOccurs="0" maxOccurs="1"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:complexType name="configurationType">
+    <xs:sequence>
+      <xs:element name="length" type="xs:float" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="createMissingSensors" type="trueFalseType" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="lengthUnit" type="lengthUnitType" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="sensordelay" type="xs:float" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:simpleType name="lengthUnitType">
+      <xs:restriction base="xs:string">
+          <xs:pattern value="MM|IN"/>
+      </xs:restriction>
+  </xs:simpleType>
+
+  <xs:complexType name="sensorsType">
+    <xs:annotation><xs:documentation>
+      Sensor table with up to 3 sensor entries
+    </xs:documentation></xs:annotation>
+    <xs:sequence>
+      <xs:element type="sensorType" name="sensor" minOccurs="0" maxOccurs="3"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="sensorType">
+    <xs:annotation><xs:documentation>
+      The "sensorname" refers to the Java variable than contains a sensor system or user name.
+      The "sensorvalue" is the system or user name for the sensor.
+    </xs:documentation></xs:annotation>
+    <xs:sequence>
+      <xs:element name="sensorname" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="sensorvalue" type="xs:string" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="stepsType">
+    <xs:sequence>
+      <xs:element name="speedStepFrom" type="speedStepType" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="speedStepTo" type="speedStepType" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="speedStepIncr" type="xs:integer" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:simpleType name="speedStepType">
+      <xs:restriction base="xs:integer">
+       <xs:minInclusive value = "0"/>
+       <xs:maxInclusive value = "128"/>
+      </xs:restriction>
+  </xs:simpleType>
+
+</xs:schema>


### PR DESCRIPTION
The Speed Profile tool preferences are embedded in the `profile.xml` file instead of a typical xml file.

If needed, a temporary xml file can be created to use `speedprofiler.xsd` for validation.

`SpeedProfilePanel` is currently using `speedometer-3-9-3.xsd` as a placeholder for the embedded XML content.  Ideally the new schema would be used but doing so makes the existing saved preferences invisible.

It is possible to validate `profile.xml` as of 5.17.2.  However, the validation is not recursive so the embedded schema reference is not used.