### PR TITLE
Mirror of the Sensor Table fix for turnouts

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -697,6 +697,11 @@
     <h3>Turnouts, Lights, Sensors and other elements</h3>
         <a id="TLae" name="TLae"></a>
         <ul>
+            <li>Fixed high CPU use of the Turnout Table when the "graphic state" preference
+                is enabled: painting a state icon no longer resizes the row, which kept the
+                table repainting itself continuously once all turnouts were in a known state.
+                Rows are now also tall enough for the icons while turnouts are still in the
+                Unknown state.</li>
             <li></li>
         </ul>
 

--- a/java/src/jmri/jmrit/beantable/turnout/TurnoutTableDataModel.java
+++ b/java/src/jmri/jmrit/beantable/turnout/TurnoutTableDataModel.java
@@ -1,5 +1,9 @@
 package jmri.jmrit.beantable.turnout;
 
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Image;
+import java.awt.Rectangle;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.MouseAdapter;
@@ -616,6 +620,13 @@ public class TurnoutTableDataModel extends BeanTableDataModel<Turnout>{
         // and then set user prefs
         super.configureTable(tbl);
 
+        if (_graphicState) {
+            // make the rows tall enough for the state icons, once and outside of the
+            // renderer; must come after super.configureTable, which sets the row
+            // height for the buttons
+            tbl.setRowHeight(Math.max(tbl.getRowHeight(), ImageIconRenderer.getIconRowHeight()));
+        }
+
         columnModel.getColumnByModelIndex(FORGETCOL).setHeaderValue(null);
         columnModel.getColumnByModelIndex(QUERYCOL).setHeaderValue(null);
 
@@ -672,8 +683,8 @@ public class TurnoutTableDataModel extends BeanTableDataModel<Turnout>{
         // add extras, override BeanTableDataModel
         log.debug("Turnout configValueColumn (I am {})", super.toString());
         if (_graphicState) { // load icons, only once
-            table.setDefaultEditor(JLabel.class, new ImageIconRenderer()); // editor
-            table.setDefaultRenderer(JLabel.class, new ImageIconRenderer()); // item class copied from SwitchboardEditor panel
+            table.setDefaultEditor(JLabel.class, new ImageIconRenderer(closedText, thrownText)); // editor
+            table.setDefaultRenderer(JLabel.class, new ImageIconRenderer(closedText, thrownText)); // item class copied from SwitchboardEditor panel
         } else {
             super.configValueColumn(table); // classic text style state indication
         }
@@ -878,72 +889,36 @@ public class TurnoutTableDataModel extends BeanTableDataModel<Turnout>{
      * Renderer and Editor are identical, as the cell contents
      * are not actually edited, only used to toggle state using
      * {@link #clickOn(Turnout)}.
-     *
+     * <p>
+     * A single label is reused for every cell and the icons are loaded once
+     * per JVM, so rendering a cell allocates nothing. The label ignores
+     * revalidate/repaint requests and the row height is set once in
+     * {@link #configureTable}: painting a cell must never schedule more
+     * painting, or the table repaints itself forever.
      */
-    class ImageIconRenderer extends AbstractCellEditor implements TableCellEditor, TableCellRenderer {
+    static class ImageIconRenderer extends AbstractCellEditor implements TableCellEditor, TableCellRenderer {
 
-        protected JLabel label;
-        protected String rootPath = "resources/icons/misc/switchboard/"; // also used in display.switchboardEditor
-        protected char beanTypeChar = 'T'; // for Turnout
-        protected String onIconPath = rootPath + beanTypeChar + "-on-s.png";
-        protected String offIconPath = rootPath + beanTypeChar + "-off-s.png";
-        protected BufferedImage onImage;
-        protected BufferedImage offImage;
-        protected ImageIcon onIcon;
-        protected ImageIcon offIcon;
-        protected int iconHeight = -1;
+        private static final String ROOT_PATH = "resources/icons/misc/switchboard/"; // also used in display.switchboardEditor
+        private static final char BEAN_TYPE_CHAR = 'T'; // for Turnout
+        private static final String ON_ICON_PATH = ROOT_PATH + BEAN_TYPE_CHAR + "-on-s.png";
+        private static final String OFF_ICON_PATH = ROOT_PATH + BEAN_TYPE_CHAR + "-off-s.png";
+        private static ImageIcon onIcon = null;
+        private static ImageIcon offIcon = null;
+        private static int iconHeight = -1;
 
-        @Override
-        public java.awt.Component getTableCellRendererComponent(
-                JTable table, Object value, boolean isSelected,
-                boolean hasFocus, int row, int column) {
-            log.debug("Renderer Item = {}, State = {}", row, value);
-            if (iconHeight < 0) { // load resources only first time, either for renderer or editor
-                loadIcons();
-                log.debug("icons loaded");
-            }
-            return updateLabel((String) value, row, table);
-        }
+        private final StateLabel label = new StateLabel();
+        private final Color defaultForeground = label.getForeground();
+        private final String closedText;
+        private final String thrownText;
+        private final String unknownText = Bundle.getMessage("BeanStateUnknown");
+        private final String inconsistentText = Bundle.getMessage("BeanStateInconsistent");
+        private int row = -1; // row of the cell last rendered or edited
 
-        @Override
-        public java.awt.Component getTableCellEditorComponent(
-                JTable table, Object value, boolean isSelected,
-                int row, int column) {
-            log.debug("Renderer Item = {}, State = {}", row, value);
-            if (iconHeight < 0) { // load resources only first time, either for renderer or editor
-                loadIcons();
-                log.debug("icons loaded");
-            }
-            return updateLabel((String) value, row, table);
-        }
-
-        public JLabel updateLabel(String value, int row, JTable table) {
-            if (iconHeight > 0) { // if necessary, increase row height;
-                table.setRowHeight(row, Math.max(table.getRowHeight(), iconHeight - 5));
-            }
-            if (value.equals(closedText) && onIcon != null) {
-                label = new JLabel(onIcon);
-                label.setVerticalAlignment(JLabel.BOTTOM);
-                log.debug("onIcon set");
-            } else if (value.equals(thrownText) && offIcon != null) {
-                label = new JLabel(offIcon);
-                label.setVerticalAlignment(JLabel.BOTTOM);
-                log.debug("offIcon set");
-            } else if (value.equals(Bundle.getMessage("BeanStateInconsistent"))) {
-                label = new JLabel("X", JLabel.CENTER); // centered text alignment
-                label.setForeground(java.awt.Color.red);
-                log.debug("Turnout state inconsistent");
-                iconHeight = 0;
-            } else if (value.equals(Bundle.getMessage("BeanStateUnknown"))) {
-                label = new JLabel("?", JLabel.CENTER); // centered text alignment
-                log.debug("Turnout state unknown");
-                iconHeight = 0;
-            } else { // failed to load icon
-                label = new JLabel(value, JLabel.CENTER); // centered text alignment
-                log.warn("Error reading icons for TurnoutTable");
-                iconHeight = 0;
-            }
-            label.setToolTipText(value);
+        ImageIconRenderer(String closedText, String thrownText) {
+            this.closedText = closedText;
+            this.thrownText = thrownText;
+            label.setHorizontalAlignment(JLabel.CENTER);
+            // must stay the only anonymous class in ImageIconRenderer, see jmri.ArchitectureTest
             label.addMouseListener(new MouseAdapter() {
                 @Override
                 public final void mousePressed(MouseEvent evt) {
@@ -951,6 +926,65 @@ public class TurnoutTableDataModel extends BeanTableDataModel<Turnout>{
                     stopCellEditing();
                 }
             });
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public Component getTableCellRendererComponent(
+                JTable table, Object value, boolean isSelected,
+                boolean hasFocus, int row, int column) {
+            log.debug("Renderer Item = {}, State = {}", row, value);
+            return updateLabel((String) value, row);
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public Component getTableCellEditorComponent(
+                JTable table, Object value, boolean isSelected,
+                int row, int column) {
+            log.debug("Editor Item = {}, State = {}", row, value);
+            return updateLabel((String) value, row);
+        }
+
+        protected JLabel updateLabel(String value, int row) {
+            this.row = row;
+            if (iconHeight < 0) { // load resources only first time, either for renderer or editor
+                loadIcons();
+                log.debug("icons loaded");
+            }
+            label.setForeground(defaultForeground); // reset a foreground left over from an INCONSISTENT cell
+            if (value.equals(closedText) && onIcon != null) {
+                label.setIcon(onIcon);
+                label.setText(null);
+                label.setVerticalAlignment(JLabel.BOTTOM);
+                log.debug("onIcon set");
+            } else if (value.equals(thrownText) && offIcon != null) {
+                label.setIcon(offIcon);
+                label.setText(null);
+                label.setVerticalAlignment(JLabel.BOTTOM);
+                log.debug("offIcon set");
+            } else if (value.equals(inconsistentText)) {
+                label.setIcon(null);
+                label.setText("X");
+                label.setForeground(Color.red);
+                label.setVerticalAlignment(JLabel.CENTER);
+                log.debug("Turnout state inconsistent");
+            } else if (value.equals(unknownText)) {
+                label.setIcon(null);
+                label.setText("?");
+                label.setVerticalAlignment(JLabel.CENTER);
+                log.debug("Turnout state unknown");
+            } else { // failed to load icon
+                label.setIcon(null);
+                label.setText(value);
+                label.setVerticalAlignment(JLabel.CENTER);
+                log.warn("Error reading icons for TurnoutTable");
+            }
+            label.setToolTipText(value);
             return label;
         }
 
@@ -961,27 +995,92 @@ public class TurnoutTableDataModel extends BeanTableDataModel<Turnout>{
         }
 
         /**
-         * Read and buffer graphics. Only called once for this table.
+         * Get the row height needed to fit the state icons, loading them if
+         * required. Used by {@link #configureTable} to size the rows once,
+         * outside of the render path.
          *
-         * @see #getTableCellEditorComponent(JTable, Object, boolean,
-         * int, int)
+         * @return required row height in pixels, 0 if the icons could not be read
          */
-        protected void loadIcons() {
+        static int getIconRowHeight() {
+            if (iconHeight < 0) {
+                loadIcons();
+            }
+            return Math.max(iconHeight - 5, 0);
+        }
+
+        /**
+         * Read and buffer graphics. Only called once per JVM, the icons are
+         * shared by all instances of this renderer.
+         */
+        private static synchronized void loadIcons() {
+            if (iconHeight >= 0) { // another instance already loaded the icons
+                return;
+            }
+            BufferedImage onImage = null;
+            BufferedImage offImage = null;
             try {
-                onImage = ImageIO.read(new File(onIconPath));
-                offImage = ImageIO.read(new File(offIconPath));
+                onImage = ImageIO.read(new File(ON_ICON_PATH));
+                offImage = ImageIO.read(new File(OFF_ICON_PATH));
             } catch (IOException ex) {
-                log.error("error reading image from {} or {}", onIconPath, offIconPath, ex);
+                log.error("error reading image from {} or {}", ON_ICON_PATH, OFF_ICON_PATH, ex);
+            }
+            if (onImage == null || offImage == null) { // ImageIO.read returns null for an unreadable file
+                log.error("error reading image from {} or {}", ON_ICON_PATH, OFF_ICON_PATH);
+                iconHeight = 0; // give up: render states as text, don't retry for every cell
+                return;
             }
             log.debug("Success reading images");
             int imageWidth = onImage.getWidth();
             int imageHeight = onImage.getHeight();
             // scale icons 50% to fit in table rows
-            java.awt.Image smallOnImage = onImage.getScaledInstance(imageWidth / 2, imageHeight / 2, java.awt.Image.SCALE_DEFAULT);
-            java.awt.Image smallOffImage = offImage.getScaledInstance(imageWidth / 2, imageHeight / 2, java.awt.Image.SCALE_DEFAULT);
+            Image smallOnImage = onImage.getScaledInstance(imageWidth / 2, imageHeight / 2, Image.SCALE_DEFAULT);
+            Image smallOffImage = offImage.getScaledInstance(imageWidth / 2, imageHeight / 2, Image.SCALE_DEFAULT);
             onIcon = new ImageIcon(smallOnImage);
             offIcon = new ImageIcon(smallOffImage);
             iconHeight = onIcon.getIconHeight();
+        }
+
+        /**
+         * Label that ignores revalidate and repaint requests.
+         * <p>
+         * The rendered component stays a child of the table's
+         * CellRendererPane after painting, so a plain JLabel schedules a new
+         * repaint of the whole table each time its icon or text changes
+         * during a paint cycle. Same overrides as DefaultTableCellRenderer,
+         * except firePropertyChange, which BasicLabelUI needs to keep its
+         * view up to date.
+         */
+        private static class StateLabel extends JLabel {
+
+            @Override
+            public void revalidate() {
+                // ignored, see class comment
+            }
+
+            @Override
+            public void repaint() {
+                // ignored, see class comment
+            }
+
+            @Override
+            public void repaint(long tm) {
+                // ignored, see class comment
+            }
+
+            @Override
+            public void repaint(int x, int y, int width, int height) {
+                // ignored, see class comment
+            }
+
+            @Override
+            public void repaint(long tm, int x, int y, int width, int height) {
+                // ignored, see class comment
+            }
+
+            @Override
+            public void repaint(Rectangle r) {
+                // ignored, see class comment
+            }
         }
 
     } // end of ImageIconRenderer class

--- a/java/test/jmri/jmrit/beantable/turnout/TurnoutTableDataModelTest.java
+++ b/java/test/jmri/jmrit/beantable/turnout/TurnoutTableDataModelTest.java
@@ -1,11 +1,28 @@
 package jmri.jmrit.beantable.turnout;
 
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.event.MouseEvent;
+import java.awt.event.MouseListener;
+
+import javax.swing.JLabel;
+import javax.swing.JTable;
+import javax.swing.table.TableCellRenderer;
+import javax.swing.table.TableModel;
+
+import jmri.InstanceManager;
 import jmri.Turnout;
+import jmri.TurnoutManager;
 import jmri.util.JUnitUtil;
+import jmri.util.gui.GuiLafPreferencesManager;
+import jmri.util.swing.XTableColumnModel;
 
 import org.junit.jupiter.api.*;
 import org.junit.Assert;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 
 /**
  *
@@ -57,6 +74,133 @@ public class TurnoutTableDataModelTest extends jmri.jmrit.beantable.AbstractBean
         assertEquals("Column19 - QUERYCOL",Bundle.getMessage("StateQueryHeader"),
             t.getColumnName(TurnoutTableDataModel.QUERYCOL));
 
+    }
+
+    /**
+     * JTable which counts calls to the per-row setRowHeight. The graphic state
+     * renderer must never call it: setRowHeight(int, int) unconditionally
+     * schedules a repaint of the whole table, so calling it while rendering a
+     * cell keeps the table repainting itself forever.
+     */
+    private static class CountingJTable extends JTable {
+
+        int rowHeightCalls = 0;
+
+        CountingJTable(TableModel m) {
+            super(m);
+        }
+
+        @Override
+        public void setRowHeight(int row, int rowHeight) {
+            rowHeightCalls++;
+            super.setRowHeight(row, rowHeight);
+        }
+    }
+
+    private TurnoutTableDataModel createGraphicStateModel() {
+        InstanceManager.getDefault(GuiLafPreferencesManager.class).setGraphicTableState(true);
+        // the model reads the preference in its constructor, so create a fresh one
+        return new TurnoutTableDataModel();
+    }
+
+    @Test
+    public void testGraphicRendererDoesNotResizeRows() {
+        TurnoutManager mgr = InstanceManager.getDefault(TurnoutManager.class);
+        for (int i = 1; i <= 10; i++) {
+            Turnout to = mgr.provideTurnout("IT" + i);
+            to.setCommandedState((i % 2 == 0) ? Turnout.THROWN : Turnout.CLOSED);
+        }
+        TurnoutTableDataModel model = createGraphicStateModel();
+        CountingJTable table = new CountingJTable(model);
+        model.configValueColumn(table);
+        TableCellRenderer r = table.getDefaultRenderer(JLabel.class);
+        assertNotNull("graphic state renderer installed", r);
+        table.rowHeightCalls = 0;
+        for (int pass = 0; pass < 5; pass++) {
+            for (int row = 0; row < table.getRowCount(); row++) {
+                Component c = r.getTableCellRendererComponent(table,
+                        table.getValueAt(row, TurnoutTableDataModel.VALUECOL),
+                        false, false, row, TurnoutTableDataModel.VALUECOL);
+                assertNotNull("renderer returns a component", c);
+            }
+        }
+        assertEquals("rendering must not set row heights", 0, table.rowHeightCalls);
+        model.dispose();
+    }
+
+    @Test
+    public void testGraphicRendererReusesComponent() {
+        TurnoutManager mgr = InstanceManager.getDefault(TurnoutManager.class);
+        mgr.provideTurnout("IT1").setCommandedState(Turnout.CLOSED);
+        mgr.provideTurnout("IT2").setCommandedState(Turnout.THROWN);
+        TurnoutTableDataModel model = createGraphicStateModel();
+        JTable table = new JTable(model);
+        model.configValueColumn(table);
+        TableCellRenderer r = table.getDefaultRenderer(JLabel.class);
+        Component first = r.getTableCellRendererComponent(table,
+                table.getValueAt(0, TurnoutTableDataModel.VALUECOL),
+                false, false, 0, TurnoutTableDataModel.VALUECOL);
+        Component second = r.getTableCellRendererComponent(table,
+                table.getValueAt(1, TurnoutTableDataModel.VALUECOL),
+                false, false, 1, TurnoutTableDataModel.VALUECOL);
+        assertSame("renderer reuses a single component", first, second);
+        model.dispose();
+    }
+
+    @Test
+    public void testGraphicRowHeightSetByConfigureTable() {
+        InstanceManager.getDefault(TurnoutManager.class).provideTurnout("IT1");
+        TurnoutTableDataModel model = createGraphicStateModel();
+        CountingJTable table = new CountingJTable(model);
+        table.setColumnModel(new XTableColumnModel());
+        table.createDefaultColumnsFromModel();
+        model.configureTable(table);
+        assertTrue("icons read so a row height is available",
+                TurnoutTableDataModel.ImageIconRenderer.getIconRowHeight() > 0);
+        assertTrue("row height fits the state icons",
+                table.getRowHeight() >= TurnoutTableDataModel.ImageIconRenderer.getIconRowHeight());
+        model.dispose();
+    }
+
+    @Test
+    public void testGraphicRendererForegroundReset() {
+        TurnoutTableDataModel model = createGraphicStateModel();
+        JTable table = new JTable(model);
+        model.configValueColumn(table);
+        TableCellRenderer r = table.getDefaultRenderer(JLabel.class);
+        JLabel label = (JLabel) r.getTableCellRendererComponent(table,
+                InstanceManager.getDefault(TurnoutManager.class).getClosedText(),
+                false, false, 0, TurnoutTableDataModel.VALUECOL);
+        Color defaultForeground = label.getForeground();
+        label = (JLabel) r.getTableCellRendererComponent(table,
+                Bundle.getMessage("BeanStateInconsistent"), false, false, 0, TurnoutTableDataModel.VALUECOL);
+        assertEquals("inconsistent state shown in red", Color.red, label.getForeground());
+        assertEquals("tool tip follows the state", Bundle.getMessage("BeanStateInconsistent"), label.getToolTipText());
+        label = (JLabel) r.getTableCellRendererComponent(table,
+                InstanceManager.getDefault(TurnoutManager.class).getClosedText(),
+                false, false, 0, TurnoutTableDataModel.VALUECOL);
+        assertEquals("foreground reset after an inconsistent cell", defaultForeground, label.getForeground());
+        model.dispose();
+    }
+
+    @Test
+    public void testGraphicEditorClickTogglesTurnout() {
+        Turnout to = InstanceManager.getDefault(TurnoutManager.class).provideTurnout("IT1");
+        to.setCommandedState(Turnout.CLOSED);
+        TurnoutTableDataModel model = createGraphicStateModel();
+        JTable table = new JTable(model);
+        model.configValueColumn(table);
+        assertTrue("cell goes into edit mode",
+                table.editCellAt(0, TurnoutTableDataModel.VALUECOL));
+        Component editor = table.getEditorComponent();
+        assertNotNull("editor component in place", editor);
+        MouseEvent evt = new MouseEvent(editor, MouseEvent.MOUSE_PRESSED,
+                System.currentTimeMillis(), 0, 1, 1, 1, false);
+        for (MouseListener ml : editor.getMouseListeners()) {
+            ml.mousePressed(evt);
+        }
+        assertEquals("turnout toggled by clicking the cell", Turnout.THROWN, to.getCommandedState());
+        model.dispose();
     }
 
     @BeforeEach


### PR DESCRIPTION
The graphic state renderer called JTable.setRowHeight(row, ...) from getTableCellRendererComponent, and that method unconditionally schedules a full-table repaint. Each painted cell scheduled another paint pass, saturating the EDT once every turnout reached a known state. Row height is now set once in configureTable, icons are loaded once per JVM, and a single reused label ignores revalidate/repaint while rendering.