### PR TITLE
Repaint only the affected area on Sensor icon state change

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -591,6 +591,10 @@
    <h3>Panel Editor</h3>
         <a id="PE" name="PE"></a>
         <ul>
+            <li>Sensor and MultiSensor icons now repaint only their own area of the panel
+                when their sensor changes state, instead of the whole window, reducing CPU
+                use on panels receiving frequent sensor events. The repainted area follows
+                the panel zoom level.</li>
             <li></li>
         </ul>
 

--- a/java/src/jmri/jmrit/display/Editor.java
+++ b/java/src/jmri/jmrit/display/Editor.java
@@ -489,6 +489,36 @@ public abstract class Editor extends JmriJFrameWithPermissions
         setScrollbarScale(ratio);
     }
 
+    /**
+     * Repaint a limited area of the target panel.
+     * <p>
+     * The rectangle is given in panel (unscaled) coordinates, e.g. the bounds
+     * of a child of the target panel: children are laid out in unscaled
+     * coordinates while painting is scaled by the paint scale, so the dirty
+     * region is scaled here. The region is grown by a pixel on each side to
+     * cover rounding and antialiasing.
+     * <p>
+     * Use this instead of a full {@code repaint()} of the Editor frame when
+     * the changed area is known, e.g. to show a state change of a single
+     * icon. Safe to call from any thread, as it only posts a dirty region.
+     *
+     * @param rect area to repaint, in unscaled target panel coordinates
+     */
+    public void repaintTargetPanel(@Nonnull Rectangle rect) {
+        JLayeredPane panel = _targetPanel;
+        if (panel == null) { // too early in construction, fall back to a full repaint
+            repaint();
+            return;
+        }
+        double scale = _paintScale;
+        int x = (int) Math.floor(rect.x * scale) - 1;
+        int y = (int) Math.floor(rect.y * scale) - 1;
+        // +2 for the margin pixels, +1 for the flooring of x and y
+        int width = (int) Math.ceil(rect.width * scale) + 3;
+        int height = (int) Math.ceil(rect.height * scale) + 3;
+        panel.repaint(x, y, width, height);
+    }
+
     private ToolTipTimer _tooltipTimer;
 
     protected void setToolTip(ToolTip tt) {

--- a/java/src/jmri/jmrit/display/MultiSensorIcon.java
+++ b/java/src/jmri/jmrit/display/MultiSensorIcon.java
@@ -1,5 +1,6 @@
 package jmri.jmrit.display;
 
+import java.awt.Rectangle;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.util.ArrayList;
@@ -172,8 +173,10 @@ public class MultiSensorIcon extends PositionableLabel implements java.beans.Pro
                     prop, sen.getKnownState(), e.getOldValue(), e.getNewValue());
         }
         if (e.getPropertyName().equals("KnownState")) {
+            Rectangle dirty = getBounds();
             displayState();
-            _editor.repaint();
+            dirty.add(getBounds()); // union with the new bounds, in case displayState resized this icon
+            _editor.repaintTargetPanel(dirty);
         }
     }
 

--- a/java/src/jmri/jmrit/display/SensorIcon.java
+++ b/java/src/jmri/jmrit/display/SensorIcon.java
@@ -1,6 +1,7 @@
 package jmri.jmrit.display;
 
 import java.awt.Color;
+import java.awt.Rectangle;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.util.Collection;
@@ -295,8 +296,10 @@ public class SensorIcon extends PositionableIcon implements java.beans.PropertyC
         log.debug("property change: {}", e);
         if (e.getPropertyName().equals("KnownState")) {
             int now = ((Integer) e.getNewValue());
+            Rectangle dirty = getBounds();
             displayState(now);
-            _editor.repaint();
+            dirty.add(getBounds()); // union with the new bounds, in case displayState resized this icon
+            _editor.repaintTargetPanel(dirty);
         }
     }
 

--- a/java/test/jmri/jmrit/display/EditorRepaintTargetPanelTest.java
+++ b/java/test/jmri/jmrit/display/EditorRepaintTargetPanelTest.java
@@ -1,0 +1,84 @@
+package jmri.jmrit.display;
+
+import java.awt.Rectangle;
+
+import javax.swing.JLayeredPane;
+
+import jmri.util.JUnitUtil;
+import jmri.util.junit.annotations.DisabledIfHeadless;
+
+import org.junit.jupiter.api.*;
+
+/**
+ * Tests scaling in {@link Editor#repaintTargetPanel(Rectangle)}.
+ * <p>
+ * Child components of the target panel are laid out in unscaled coordinates
+ * while painting is scaled by the paint scale, so the dirty region posted for
+ * a child's bounds must be scaled to land on the pixels actually painted.
+ *
+ * @author Adrien Virolleaud Copyright (C) 2026
+ */
+@DisabledIfHeadless
+public class EditorRepaintTargetPanelTest {
+
+    /**
+     * Layered pane recording the dirty region posted by repaintTargetPanel.
+     */
+    private static class RecordingPane extends JLayeredPane {
+
+        Rectangle lastDirty = null;
+
+        @Override
+        public void repaint(int x, int y, int width, int height) {
+            lastDirty = new Rectangle(x, y, width, height);
+            super.repaint(x, y, width, height);
+        }
+    }
+
+    private EditorScaffold editor = null;
+    private RecordingPane pane = null;
+
+    @Test
+    public void testRepaintAtScale1() {
+        editor.repaintTargetPanel(new Rectangle(10, 20, 30, 40));
+        Rectangle dirty = pane.lastDirty;
+        Assertions.assertNotNull( dirty, "dirty region posted");
+        Assertions.assertTrue( dirty.contains(new Rectangle(10, 20, 30, 40)),
+                "dirty region covers the rectangle");
+        Assertions.assertTrue( dirty.width <= 30 + 6 && dirty.height <= 40 + 6,
+                "dirty region stays close to the rectangle");
+    }
+
+    @Test
+    public void testRepaintAtScale2() {
+        editor.setPaintScale(2.0);
+        editor.repaintTargetPanel(new Rectangle(10, 20, 30, 40));
+        Rectangle dirty = pane.lastDirty;
+        Assertions.assertNotNull( dirty, "dirty region posted");
+        Assertions.assertTrue( dirty.contains(new Rectangle(20, 40, 60, 80)),
+                "dirty region covers the rectangle scaled by the paint scale");
+        Assertions.assertTrue( dirty.width <= 60 + 6 && dirty.height <= 80 + 6,
+                "dirty region stays close to the scaled rectangle");
+    }
+
+    @BeforeEach
+    public void setUp() {
+        JUnitUtil.setUp();
+        JUnitUtil.resetProfileManager();
+        editor = new EditorScaffold();
+        pane = new RecordingPane();
+        editor.setTargetPanel(pane, editor);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        if (editor != null) {
+            JUnitUtil.dispose(editor);
+            editor = null;
+        }
+        pane = null;
+        JUnitUtil.resetWindows(false, false);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
+        JUnitUtil.tearDown();
+    }
+}

--- a/java/test/jmri/jmrit/display/EditorScaffold.java
+++ b/java/test/jmri/jmrit/display/EditorScaffold.java
@@ -32,6 +32,18 @@ public class EditorScaffold extends Editor {
         this(name, true, true);
     }
 
+    /**
+     * The last rectangle passed to {@link #repaintTargetPanel(java.awt.Rectangle)},
+     * in unscaled target panel coordinates, for test verification.
+     */
+    public java.awt.Rectangle lastRepaintRect = null;
+
+    @Override
+    public void repaintTargetPanel(java.awt.Rectangle rect) {
+        lastRepaintRect = new java.awt.Rectangle(rect);
+        super.repaintTargetPanel(rect);
+    }
+
     /*
      * ********************* Abstract Methods ***********************
      */

--- a/java/test/jmri/jmrit/display/SensorIconTest.java
+++ b/java/test/jmri/jmrit/display/SensorIconTest.java
@@ -1,7 +1,9 @@
 package jmri.jmrit.display;
 
 import java.awt.Component;
+import java.awt.Rectangle;
 
+import jmri.JmriException;
 import jmri.Sensor;
 import jmri.util.junit.annotations.DisabledIfHeadless;
 import jmri.util.swing.JmriMouseEvent;
@@ -81,6 +83,21 @@ public class SensorIconTest extends PositionableIconTest {
         p.doMouseReleased(event);
         
         Assertions.assertEquals(Sensor.INACTIVE, s.getCommandedState());
+    }
+
+    @Test
+    @DisabledIfHeadless
+    public void testStateChangeRepaintsBoundedArea() throws JmriException {
+        si.setBounds(12, 17, 20, 30);
+        EditorScaffold scaffold = (EditorScaffold) editor;
+        scaffold.lastRepaintRect = null;
+
+        s.setKnownState(Sensor.ACTIVE);
+
+        Assertions.assertNotNull( scaffold.lastRepaintRect,
+                "state change posts a bounded repaint instead of repainting the frame");
+        Assertions.assertTrue( scaffold.lastRepaintRect.contains(new Rectangle(12, 17, 20, 30)),
+                "dirty area covers the icon bounds");
     }
 
     Sensor s;


### PR DESCRIPTION
Another look at panels performance, in my case I always have panel editor open

SensorIcon and MultiSensorIcon called Editor.repaint() on every KnownState
event. Editor is a JFrame, so a single sensor changing state repainted the
whole window, including the menu bar, tool bar and scroll bars.

They now post a dirty region covering the icon only, through a new
Editor.repaintTargetPanel(Rectangle). Child components of the target panel
are laid out in unscaled coordinates while painting is scaled by the paint
scale, so the rectangle is scaled there and grown by a pixel for rounding
and antialiasing; the icon bounds before and after displayState() are
unioned, because a text mode sensor can shrink and Component.reshape only
repaints the parent when the size changes.

TurnoutIcon and LightIcon have the opposite defect, relying on a sibling
object to trigger the redraw, and should adopt the same helper later.