### PR TITLE
Layout Editor repaint performance

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -475,6 +475,10 @@
     <h3>Layout Editor</h3>
         <a id="LE" name="LE"></a>
         <ul>
+            <li>Reduced CPU use when the layout is redrawn, for instance on every block
+                occupancy change: a redraw now repaints the drawing area only, instead of
+                the whole window including its menu bar, tool bar and scroll bars, and a
+                partial repaint no longer redraws the whole visible track plan.</li>
             <li></li>
         </ul>
 

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutEditor.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutEditor.java
@@ -3072,7 +3072,15 @@ public final class LayoutEditor extends PanelEditor implements MouseWheelListene
      */
     @Override
     public void redrawPanel() {
-        repaint();
+        JComponent targetPanel = getTargetPanel();
+        if (targetPanel != null) {
+            // repaint only the drawing area, not the whole frame with its
+            // menu bar, tool bar and scroll bars, none of which this changes
+            targetPanel.repaint();
+        } else {
+            // too early in construction to have a target panel yet
+            repaint();
+        }
     }
 
     /**

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutEditorComponent.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutEditorComponent.java
@@ -47,7 +47,13 @@ class LayoutEditorComponent extends JComponent {
                         if (!clipBounds.equals(g2.getClipBounds())) {
                             //log.debug("LEComponent.paint(); clipBounds: {}, oldClipBounds: {}",
                             //        clipBounds, g2.getClipBounds());
-                            g2.setClip(clipBounds);
+                            // intersect, never replace: clipBounds is the visible part of
+                            // the panel, used here to cull drawing, while the incoming clip
+                            // is the area Swing actually asked for. Replacing it would draw
+                            // track outside the dirty region, on top of higher level icons
+                            // that are not being repainted, as the target panel is a
+                            // JLayeredPane and so is not paint-optimized.
+                            g2.clip(clipBounds);
                         }
                     }
                 }

--- a/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorComponentTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorComponentTest.java
@@ -7,6 +7,10 @@ import org.junit.Assume;
 import jmri.util.JUnitUtil;
 
 import java.awt.GraphicsEnvironment;
+import java.awt.Graphics2D;
+import java.awt.Rectangle;
+import java.awt.geom.Rectangle2D;
+import java.awt.image.BufferedImage;
 
 /**
  *
@@ -20,6 +24,39 @@ public class LayoutEditorComponentTest {
         LayoutEditor le = new LayoutEditor("Layout Editor Component Test Layout");
         LayoutEditorComponent t = new LayoutEditorComponent(le);
         Assert.assertNotNull("exists", t);
+        JUnitUtil.dispose(le);
+    }
+
+    /**
+     * The clip held by the component is the visible part of the panel, used to
+     * cull drawing. It must be intersected with the clip Swing supplied, not
+     * substituted for it, so that a partial repaint stays partial.
+     */
+    @Test
+    public void testPaintStaysInsideRequestedClip() {
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
+        LayoutEditor le = new LayoutEditor("Layout Editor Component Clip Test Layout");
+        LayoutEditorComponent t = new LayoutEditorComponent(le);
+
+        // the visible area of the panel, as adjustClip() would set it
+        t.setClip(new Rectangle2D.Double(0, 0, 400, 400));
+
+        BufferedImage image = new BufferedImage(400, 400, BufferedImage.TYPE_INT_ARGB);
+        Graphics2D g2 = image.createGraphics();
+        try {
+            // the small area Swing asked to be repainted, e.g. one icon
+            Rectangle requested = new Rectangle(100, 100, 20, 20);
+            g2.setClip(requested);
+
+            t.paint(g2);
+
+            Rectangle after = g2.getClipBounds();
+            Assert.assertNotNull("clip still set after painting", after);
+            Assert.assertTrue("painting stayed inside the requested clip, was " + after,
+                    requested.contains(after));
+        } finally {
+            g2.dispose();
+        }
         JUnitUtil.dispose(le);
     }
 

--- a/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorTest.java
@@ -127,6 +127,30 @@ public class LayoutEditorTest extends AbstractEditorTestBase<LayoutEditor> {
         assertNotNull( f, "exists");
     }
 
+    /**
+     * redrawPanel() is called on every layout change, including every block
+     * occupancy change, so it must dirty the drawing area only and not the
+     * whole frame with its menu bar, tool bar and scroll bars.
+     */
+    @Test
+    public void testRedrawPanelDirtiesTargetPanelOnly() {
+        javax.swing.JComponent targetPanel = e.getTargetPanel();
+        assertNotNull( targetPanel, "target panel exists");
+
+        java.awt.Rectangle[] dirty = new java.awt.Rectangle[1];
+        // redrawPanel() and the check have to share one EDT task, otherwise a
+        // paint pass in between would have already cleared the dirty region
+        ThreadingUtil.runOnGUI( () -> {
+            javax.swing.RepaintManager rm = javax.swing.RepaintManager.currentManager(targetPanel);
+            rm.markCompletelyClean(targetPanel);
+            e.redrawPanel();
+            dirty[0] = rm.getDirtyRegion(targetPanel);
+        });
+
+        assertNotNull( dirty[0], "target panel has a dirty region");
+        assertFalse( dirty[0].isEmpty(), "target panel was marked dirty by redrawPanel");
+    }
+
     @Test
     @Override
     @Disabled("failing to set size on appveyor")


### PR DESCRIPTION
redrawPanel() is called from about ninety places, including every block occupancy change, and called repaint() on the LayoutEditor JFrame. That dirtied the whole window - menu bar, tool bar, scroll bars - for a change confined to the drawing area. It now repaints the target panel.

LayoutEditorComponent.paint() then replaced the incoming clip with g2.setClip(clipBounds), so any partial repaint still redrew the entire visible track plan, plus about ten uncalled passes over the track views.
clipBounds is the visible part of the panel, used to cull drawing, and belongs intersected with the clip Swing supplied, not substituted for it.

Intersecting also removes a latent painting bug: the target panel is a JLayeredPane and so is not paint-optimized, and drawing track outside the dirty region put it on top of higher level icons that were not being repainted.
