### PR TITLE
Xnet throttle stuck

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -115,7 +115,10 @@
 
         <h4>Lenz XPressNet</h4>
             <ul>
-                <li></li>
+                <li>Fixed an issue where a throttle could stop sending speed and
+                    function commands for its locomotive after receiving an
+                    unrecognized locomotive information response, requiring a
+                    JMRI restart to recover.</li>
             </ul>
 
         <h4>LocoNet</h4>

--- a/java/src/jmri/jmrix/lenz/XNetThrottle.java
+++ b/java/src/jmri/jmrix/lenz/XNetThrottle.java
@@ -40,6 +40,12 @@ public class XNetThrottle extends AbstractThrottle implements XNetListener {
 
     protected int requestState = THROTTLEIDLE;
 
+    // Consecutive retransmittable (busy/communication) error replies seen for
+    // the current outstanding request; guards against a stuck state machine
+    // when the command station keeps answering busy (see countRetransmittableError).
+    private int retransmittableErrorCount = 0;
+    private static final int MAX_RETRANSMITTABLE_ERRORS = 5;
+
     protected int address;
 
     // Get the number of valid functions from the software version number.
@@ -574,6 +580,7 @@ public class XNetThrottle extends AbstractThrottle implements XNetListener {
             } else if (l.isRetransmittableErrorMsg()) {
                 /* this is a communications error */
                 log.trace("Communications error occurred - message received was: {}", l);
+                countRetransmittableError();
             } else if (l.isUnsupportedError()) {
                 /* The Command Station does not support this command */
                 log.error("Unsupported Command Sent to command station");
@@ -714,10 +721,21 @@ public class XNetThrottle extends AbstractThrottle implements XNetListener {
                     // And then we want to request the Function Momentary Status
                     // for functions F13-F28
                     sendFunctionHighMomentaryStatusRequest();
+                } else {
+                    // The reply to the outstanding request has been consumed,
+                    // so no timeout will ever fire for it.  Without this
+                    // branch an unrecognized subtype leaves requestState stuck
+                    // (never returns to THROTTLEIDLE) and every command queued
+                    // afterwards is silently held back forever.
+                    log.debug("Unhandled LOCO_INFO_RESPONSE subtype {} while in THROTTLESTATSENT, resuming queue",
+                            l.getElement(1));
+                    requestState = THROTTLEIDLE;
+                    sendQueuedMessage();
                 }
             } else if (l.isRetransmittableErrorMsg()) {
                 /* this is a communications error */
                 log.trace("Communications error occurred - message received was: {}", l);
+                countRetransmittableError();
             } else if (l.isUnsupportedError()) {
                 /* The Command Station does not support this command */
                 log.error("Unsupported Command Sent to command station");
@@ -1062,6 +1080,9 @@ public class XNetThrottle extends AbstractThrottle implements XNetListener {
      * Send message from queue.
      */
     protected synchronized void sendQueuedMessage() {
+        // a new request is being started (or the previous one completed):
+        // clear the consecutive-busy guard counter.
+        retransmittableErrorCount = 0;
 
         RequestMessage msg;
         // check to see if the queue has a message in it, and if it does,
@@ -1082,6 +1103,23 @@ public class XNetThrottle extends AbstractThrottle implements XNetListener {
             log.debug("message queue empty");
             // if the queue is empty, set the state to idle.
             requestState = THROTTLEIDLE;
+        }
+    }
+
+    /**
+     * Count a retransmittable (busy/communication) error reply received while
+     * a request is outstanding.  The traffic controller retries the message
+     * itself, but if the command station keeps answering busy the retry/error
+     * cycle can repeat with requestState never returning to idle.  After
+     * MAX_RETRANSMITTABLE_ERRORS consecutive errors, reset the state machine
+     * and restart the queue so the throttle does not stay stuck forever.
+     */
+    private void countRetransmittableError() {
+        if (++retransmittableErrorCount >= MAX_RETRANSMITTABLE_ERRORS) {
+            log.warn("Throttle {}: {} consecutive busy/communication errors, resetting request state",
+                    getDccAddress(), retransmittableErrorCount);
+            requestState = THROTTLEIDLE;
+            sendQueuedMessage();
         }
     }
 

--- a/java/src/jmri/jmrix/lenz/XNetThrottle.java
+++ b/java/src/jmri/jmrix/lenz/XNetThrottle.java
@@ -40,12 +40,6 @@ public class XNetThrottle extends AbstractThrottle implements XNetListener {
 
     protected int requestState = THROTTLEIDLE;
 
-    // Consecutive retransmittable (busy/communication) error replies seen for
-    // the current outstanding request; guards against a stuck state machine
-    // when the command station keeps answering busy (see countRetransmittableError).
-    private int retransmittableErrorCount = 0;
-    private static final int MAX_RETRANSMITTABLE_ERRORS = 5;
-
     protected int address;
 
     // Get the number of valid functions from the software version number.
@@ -580,7 +574,6 @@ public class XNetThrottle extends AbstractThrottle implements XNetListener {
             } else if (l.isRetransmittableErrorMsg()) {
                 /* this is a communications error */
                 log.trace("Communications error occurred - message received was: {}", l);
-                countRetransmittableError();
             } else if (l.isUnsupportedError()) {
                 /* The Command Station does not support this command */
                 log.error("Unsupported Command Sent to command station");
@@ -735,7 +728,6 @@ public class XNetThrottle extends AbstractThrottle implements XNetListener {
             } else if (l.isRetransmittableErrorMsg()) {
                 /* this is a communications error */
                 log.trace("Communications error occurred - message received was: {}", l);
-                countRetransmittableError();
             } else if (l.isUnsupportedError()) {
                 /* The Command Station does not support this command */
                 log.error("Unsupported Command Sent to command station");
@@ -1080,9 +1072,6 @@ public class XNetThrottle extends AbstractThrottle implements XNetListener {
      * Send message from queue.
      */
     protected synchronized void sendQueuedMessage() {
-        // a new request is being started (or the previous one completed):
-        // clear the consecutive-busy guard counter.
-        retransmittableErrorCount = 0;
 
         RequestMessage msg;
         // check to see if the queue has a message in it, and if it does,
@@ -1103,23 +1092,6 @@ public class XNetThrottle extends AbstractThrottle implements XNetListener {
             log.debug("message queue empty");
             // if the queue is empty, set the state to idle.
             requestState = THROTTLEIDLE;
-        }
-    }
-
-    /**
-     * Count a retransmittable (busy/communication) error reply received while
-     * a request is outstanding.  The traffic controller retries the message
-     * itself, but if the command station keeps answering busy the retry/error
-     * cycle can repeat with requestState never returning to idle.  After
-     * MAX_RETRANSMITTABLE_ERRORS consecutive errors, reset the state machine
-     * and restart the queue so the throttle does not stay stuck forever.
-     */
-    private void countRetransmittableError() {
-        if (++retransmittableErrorCount >= MAX_RETRANSMITTABLE_ERRORS) {
-            log.warn("Throttle {}: {} consecutive busy/communication errors, resetting request state",
-                    getDccAddress(), retransmittableErrorCount);
-            requestState = THROTTLEIDLE;
-            sendQueuedMessage();
         }
     }
 

--- a/java/test/jmri/jmrix/lenz/XNetThrottleTest.java
+++ b/java/test/jmri/jmrix/lenz/XNetThrottleTest.java
@@ -501,8 +501,7 @@ public class XNetThrottleTest extends jmri.jmrix.AbstractThrottleTest {
      * A LOCO_INFO_RESPONSE (0xE3) carrying a sub-type the throttle does not
      * know about used to leave requestState stuck at THROTTLESTATSENT: the
      * reply was consumed, so no timeout ever fired, and every command queued
-     * afterwards was held back forever.  Observed on real hardware (LZV200)
-     * as "E3 60 00 00 83" in answer to a status request.
+     * afterwards was held back forever.
      */
     @Test
     public void testUnknownLocoInfoResponseSubtypeDoesNotStallQueue() {
@@ -534,46 +533,6 @@ public class XNetThrottleTest extends jmri.jmrix.AbstractThrottleTest {
             "Speed message sent after unrecognized LOCO_INFO_RESPONSE sub-type");
         assertEquals( XNetConstants.LOCO_SPEED_128, tc.outbound.elementAt(n).getElement(1),
             "Throttle Set Speed Message");
-        t.throttleDispose();
-    }
-
-    /**
-     * The command station answering "busy" (61 81 E3) is retransmitted by the
-     * traffic controller without any limit.  If the answer keeps being busy,
-     * requestState never returns to idle, so cap the number of consecutive
-     * retransmittable errors accepted for a single request.
-     */
-    @Test
-    public void testRepeatedCommandStationBusyDoesNotStallQueue() {
-        int n = tc.outbound.size();
-        XNetThrottle t = (XNetThrottle) instance;
-        initThrottle(t, n);
-        n = tc.outbound.size();
-
-        // send a speed command, which leaves the throttle in THROTTLESPEEDSENT.
-        t.setSpeedSetting(0.5f);
-        assertEquals( n + 1, tc.outbound.size(), "Throttle Set Speed Message sent");
-
-        // and queue a second command behind it; it can not go out while the
-        // first request is still outstanding.
-        n = tc.outbound.size();
-        t.setFunction(0, true);
-        assertEquals( n, tc.outbound.size(),
-            "Function message held while a request is outstanding");
-
-        // the command station answers busy over and over.
-        for (int i = 0; i < 5; i++) {
-            XNetReply m = new XNetReply();
-            m.setElement(0, XNetConstants.CS_INFO);
-            m.setElement(1, XNetConstants.CS_BUSY);
-            m.setElement(2, 0xE3);
-            t.message(m);
-        }
-
-        JUnitAppender.assertWarnMessage(
-            "Throttle 3: 5 consecutive busy/communication errors, resetting request state");
-        assertEquals( n + 1, tc.outbound.size(),
-            "Queued function message released after repeated busy answers");
         t.throttleDispose();
     }
 

--- a/java/test/jmri/jmrix/lenz/XNetThrottleTest.java
+++ b/java/test/jmri/jmrix/lenz/XNetThrottleTest.java
@@ -497,6 +497,86 @@ public class XNetThrottleTest extends jmri.jmrix.AbstractThrottleTest {
 
     }
 
+    /**
+     * A LOCO_INFO_RESPONSE (0xE3) carrying a sub-type the throttle does not
+     * know about used to leave requestState stuck at THROTTLESTATSENT: the
+     * reply was consumed, so no timeout ever fired, and every command queued
+     * afterwards was held back forever.  Observed on real hardware (LZV200)
+     * as "E3 60 00 00 83" in answer to a status request.
+     */
+    @Test
+    public void testUnknownLocoInfoResponseSubtypeDoesNotStallQueue() {
+        int n = tc.outbound.size();
+        XNetThrottle t = (XNetThrottle) instance;
+        initThrottle(t, n);
+        n = tc.outbound.size();
+
+        // request the status, which leaves the throttle in THROTTLESTATSENT.
+        t.sendStatusInformationRequest();
+        assertEquals( "E3 00 00 03 E0", tc.outbound.elementAt(n).toString(),
+            "Throttle Information Request Message");
+
+        // answer with an unrecognized LOCO_INFO_RESPONSE sub-type.
+        XNetReply m = new XNetReply();
+        m.setElement(0, XNetConstants.LOCO_INFO_RESPONSE);
+        m.setElement(1, 0x60);  // neither LOCO_NOT_AVAILABLE, LOCO_FUNCTION_STATUS
+        m.setElement(2, 0x00);  // nor LOCO_FUNCTION_STATUS_HIGH
+        m.setElement(3, 0x00);
+        m.setElement(4, 0x83);
+        t.message(m);
+
+        // the throttle has to be back to idle, so the next command reaches the
+        // traffic controller instead of piling up in the internal queue.
+        n = tc.outbound.size();
+        t.setSpeedSetting(0.5f);
+
+        assertEquals( n + 1, tc.outbound.size(),
+            "Speed message sent after unrecognized LOCO_INFO_RESPONSE sub-type");
+        assertEquals( XNetConstants.LOCO_SPEED_128, tc.outbound.elementAt(n).getElement(1),
+            "Throttle Set Speed Message");
+        t.throttleDispose();
+    }
+
+    /**
+     * The command station answering "busy" (61 81 E3) is retransmitted by the
+     * traffic controller without any limit.  If the answer keeps being busy,
+     * requestState never returns to idle, so cap the number of consecutive
+     * retransmittable errors accepted for a single request.
+     */
+    @Test
+    public void testRepeatedCommandStationBusyDoesNotStallQueue() {
+        int n = tc.outbound.size();
+        XNetThrottle t = (XNetThrottle) instance;
+        initThrottle(t, n);
+        n = tc.outbound.size();
+
+        // send a speed command, which leaves the throttle in THROTTLESPEEDSENT.
+        t.setSpeedSetting(0.5f);
+        assertEquals( n + 1, tc.outbound.size(), "Throttle Set Speed Message sent");
+
+        // and queue a second command behind it; it can not go out while the
+        // first request is still outstanding.
+        n = tc.outbound.size();
+        t.setFunction(0, true);
+        assertEquals( n, tc.outbound.size(),
+            "Function message held while a request is outstanding");
+
+        // the command station answers busy over and over.
+        for (int i = 0; i < 5; i++) {
+            XNetReply m = new XNetReply();
+            m.setElement(0, XNetConstants.CS_INFO);
+            m.setElement(1, XNetConstants.CS_BUSY);
+            m.setElement(2, 0xE3);
+            t.message(m);
+        }
+
+        JUnitAppender.assertWarnMessage(
+            "Throttle 3: 5 consecutive busy/communication errors, resetting request state");
+        assertEquals( n + 1, tc.outbound.size(),
+            "Queued function message released after repeated busy answers");
+        t.throttleDispose();
+    }
+
     @Test
     public void testSendFunctionStatusInformationRequest() {
         int n = tc.outbound.size();

--- a/java/test/jmri/jmrix/roco/z21/Z21XNetThrottleTest.java
+++ b/java/test/jmri/jmrix/roco/z21/Z21XNetThrottleTest.java
@@ -7,6 +7,7 @@ import jmri.jmrix.lenz.XNetInterfaceScaffold;
 import jmri.jmrix.lenz.XNetReply;
 import jmri.jmrix.lenz.XNetSystemConnectionMemo;
 import jmri.jmrix.lenz.XNetThrottle;
+import jmri.util.JUnitAppender;
 import jmri.util.JUnitUtil;
 
 import org.junit.jupiter.api.*;
@@ -249,6 +250,84 @@ public class Z21XNetThrottleTest extends jmri.jmrix.roco.RocoXNetThrottleTest {
         // n = tc.outbound.size();
         t.message(m);
         // which sets the status back state back to idle..
+    }
+
+    /**
+     * Z21 flavour of the parent test: the status request message and the
+     * commands queued behind it differ, but the stuck-state behaviour being
+     * checked is the one inherited from XNetThrottle.message(XNetReply).
+     */
+    @Override
+    @Test
+    @Timeout(1000)
+    public void testUnknownLocoInfoResponseSubtypeDoesNotStallQueue() {
+        int n = tc.outbound.size();
+        Z21XNetThrottle t = (Z21XNetThrottle) instance;
+        initThrottle(t, n);
+        n = tc.outbound.size();
+
+        // request the status, which leaves the throttle in THROTTLESTATSENT.
+        t.sendStatusInformationRequest();
+        assertEquals( "E3 F0 00 03 10", tc.outbound.elementAt(n).toString(),
+            "Throttle Information Request Message");
+
+        // answer with an unrecognized LOCO_INFO_RESPONSE sub-type, which the
+        // Z21 throttle hands over to the standard XpressNet handling.
+        XNetReply m = new XNetReply();
+        m.setElement(0, 0xE3);
+        m.setElement(1, 0x60);
+        m.setElement(2, 0x00);
+        m.setElement(3, 0x00);
+        m.setElement(4, 0x83);
+        t.message(m);
+
+        // the throttle has to be back to idle, so the next command reaches the
+        // traffic controller instead of piling up in the internal queue.
+        n = tc.outbound.size();
+        t.setSpeedSetting(0.5f);
+
+        assertEquals( n + 1, tc.outbound.size(),
+            "Speed message sent after unrecognized LOCO_INFO_RESPONSE sub-type");
+    }
+
+    /**
+     * Z21 flavour of the parent test.  Speed and function commands are queued
+     * with the THROTTLEIDLE state here, so the outstanding request used to
+     * hold the queue is a status request instead of a speed command.
+     */
+    @Override
+    @Test
+    @Timeout(1000)
+    public void testRepeatedCommandStationBusyDoesNotStallQueue() {
+        int n = tc.outbound.size();
+        Z21XNetThrottle t = (Z21XNetThrottle) instance;
+        initThrottle(t, n);
+        n = tc.outbound.size();
+
+        // send a status request, which leaves the throttle in THROTTLESTATSENT.
+        t.sendStatusInformationRequest();
+        assertEquals( n + 1, tc.outbound.size(), "Throttle Information Request Message sent");
+
+        // and queue a command behind it; it can not go out while the status
+        // request is still outstanding.
+        n = tc.outbound.size();
+        t.setSpeedSetting(0.5f);
+        assertEquals( n, tc.outbound.size(),
+            "Speed message held while a request is outstanding");
+
+        // the command station answers busy over and over.
+        for (int i = 0; i < 5; i++) {
+            XNetReply m = new XNetReply();
+            m.setElement(0, 0x61);
+            m.setElement(1, 0x81);
+            m.setElement(2, 0xE3);
+            t.message(m);
+        }
+
+        JUnitAppender.assertWarnMessage(
+            "Throttle 3: 5 consecutive busy/communication errors, resetting request state");
+        assertEquals( n + 1, tc.outbound.size(),
+            "Queued speed message released after repeated busy answers");
     }
 
     @Override

--- a/java/test/jmri/jmrix/roco/z21/Z21XNetThrottleTest.java
+++ b/java/test/jmri/jmrix/roco/z21/Z21XNetThrottleTest.java
@@ -7,7 +7,6 @@ import jmri.jmrix.lenz.XNetInterfaceScaffold;
 import jmri.jmrix.lenz.XNetReply;
 import jmri.jmrix.lenz.XNetSystemConnectionMemo;
 import jmri.jmrix.lenz.XNetThrottle;
-import jmri.util.JUnitAppender;
 import jmri.util.JUnitUtil;
 
 import org.junit.jupiter.api.*;
@@ -288,46 +287,6 @@ public class Z21XNetThrottleTest extends jmri.jmrix.roco.RocoXNetThrottleTest {
 
         assertEquals( n + 1, tc.outbound.size(),
             "Speed message sent after unrecognized LOCO_INFO_RESPONSE sub-type");
-    }
-
-    /**
-     * Z21 flavour of the parent test.  Speed and function commands are queued
-     * with the THROTTLEIDLE state here, so the outstanding request used to
-     * hold the queue is a status request instead of a speed command.
-     */
-    @Override
-    @Test
-    @Timeout(1000)
-    public void testRepeatedCommandStationBusyDoesNotStallQueue() {
-        int n = tc.outbound.size();
-        Z21XNetThrottle t = (Z21XNetThrottle) instance;
-        initThrottle(t, n);
-        n = tc.outbound.size();
-
-        // send a status request, which leaves the throttle in THROTTLESTATSENT.
-        t.sendStatusInformationRequest();
-        assertEquals( n + 1, tc.outbound.size(), "Throttle Information Request Message sent");
-
-        // and queue a command behind it; it can not go out while the status
-        // request is still outstanding.
-        n = tc.outbound.size();
-        t.setSpeedSetting(0.5f);
-        assertEquals( n, tc.outbound.size(),
-            "Speed message held while a request is outstanding");
-
-        // the command station answers busy over and over.
-        for (int i = 0; i < 5; i++) {
-            XNetReply m = new XNetReply();
-            m.setElement(0, 0x61);
-            m.setElement(1, 0x81);
-            m.setElement(2, 0xE3);
-            t.message(m);
-        }
-
-        JUnitAppender.assertWarnMessage(
-            "Throttle 3: 5 consecutive busy/communication errors, resetting request state");
-        assertEquals( n + 1, tc.outbound.size(),
-            "Queued speed message released after repeated busy answers");
     }
 
     @Override


### PR DESCRIPTION
This is a new attempt to fix an issue discussed here :
https://groups.io/g/jmriusers/topic/110573569#msg242409

I will be testing deeper next weekend with probably other changes to come.

Fix XNetThrottle stuck on unrecognized loco info response subtype

In message(XNetReply), the THROTTLESTATSENT branch handling LOCO_INFO_RESPONSE (0xE3) only tested element(1) against LOCO_NOT_AVAILABLE, LOCO_FUNCTION_STATUS and LOCO_FUNCTION_STATUS_HIGH, with no final else - unlike the sibling LOCO_INFO_* blocks. A reply with any other sub-type therefore never reset requestState to
THROTTLEIDLE, and since the reply had been consumed no timeout ever fired either, so every command queued afterwards stayed in requestList unsent until JMRI was restarted.

Add the missing else, mirroring the "unknown error" fallback used one level up: log the sub-type, reset the state and drain the queue.

Tests in XNetThrottleTest and Z21XNetThrottleTest fail without the fix.

In python script the following  sequence unlock a throttle without restart needed :
field_get(throttle, "requestList").clear()
call_protected(throttle, "sendQueuedMessage")
