### PR TITLE
Improve speed and reliability of importing an exported roster

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -548,7 +548,8 @@
     <h3>Roster</h3>
         <a id="Roster" name="Roster"></a>
         <ul>
-            <li></li>
+            <li>Importing a roster backup file (Import Complete Roster)
+                has been made faster and more reliable.</li>
         </ul>
 
     <h3>Routes</h3>

--- a/java/src/jmri/jmrit/roster/FullBackupImportAction.java
+++ b/java/src/jmri/jmrit/roster/FullBackupImportAction.java
@@ -163,7 +163,13 @@ public class FullBackupImportAction extends ImportRosterItemAction {
         } catch (IOException ex) {
             log.error("Unable to read {}", filename, ex);
         } finally {
+            log.info("Writing roster index at end");
+            Roster.getDefault().writeRoster();
+            // use the new roster
+            Roster.getDefault().reloadRosterFile();
+
             ThreadingUtil.runOnGUIEventually(() -> {dialog.finish();});
+
             if (inputfile != null) {
                 try {
                     inputfile.close(); // zipper.close() is meaningless, see above, but this will do
@@ -277,8 +283,6 @@ public class FullBackupImportAction extends ImportRosterItemAction {
             loadEntryFromElement(lroot);
             addToEntryToRoster();
 
-            // use the new roster
-            Roster.getDefault().reloadRosterFile();
         } catch (org.jdom2.JDOMException ex) {
             log.error("Unable to parse entry", ex);
         }
@@ -286,5 +290,14 @@ public class FullBackupImportAction extends ImportRosterItemAction {
         return true;
     }
     
+    @Override
+    void addToEntryToRoster() {
+        // add the new entry to the roster
+        Roster.getDefault().addEntry(mToEntry);
+        // unlike the superclass method, this does not 
+        // write the full Roster until the end of the full import
+        // to improve speed.  
+    }
+
     private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(FullBackupImportAction.class);
 }


### PR DESCRIPTION
This defers writing of the roster index to the end of the bulk import, instead of doing it after each roster entry is imported.