### PR TITLE
Do not skip Layout Block routing when reading block values fails

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -482,6 +482,9 @@
                 occupancy change: a redraw now repaints the drawing area only, instead of
                 the whole window including its menu bar, tool bar and scroll bars, and a
                 partial repaint no longer redraws the whole visible track plan.</li>
+            <li>An unexpected error while restoring the saved block values no longer leaves
+                Layout Block routing uninitialized, and is now reported in the log instead
+                of passing unnoticed.</li>
             <li></li>
         </ul>
 

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutBlockManager.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutBlockManager.java
@@ -264,6 +264,10 @@ public class LayoutBlockManager extends AbstractManager<LayoutBlock> implements 
             log.error("JDOM Exception when retreiving block values", jde);
         } catch (java.io.IOException ioe) {
             log.error("I/O Exception when retreiving block values", ioe);
+        } catch (RuntimeException re) {
+            // restoring the saved block values is not worth losing the routing
+            // initialization below, which would otherwise be skipped silently
+            log.error("Exception when retreiving block values", re);
         }
 
         //special tests for getFacingSignalHead method - comment out next three lines unless using LayoutEditorTests


### PR DESCRIPTION
initializeLayoutBlockPaths() guards readBlockValues() against JDOMException and IOException only. Any RuntimeException therefore escapes the method, skipping both the initialized flag and initializeLayoutBlockRouting(), so block routing is never set up and nothing in the log says why.

readBlockValues() can raise one. It reads the value attribute without the null check it applies to systemname, so a block element saved without a value is enough; and it calls Block.setValue(), which notifies panel icons and therefore runs listener code outside its control.

Catch RuntimeException as well and log it, so a failure to restore the saved block values costs the block values only, not the routing.

Setting initialized in a finally block would be the other option, but that would assert an initialization that did not happen.