### PR TITLE
Fix NullPointerException in MemoryIcon roster display

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -527,6 +527,10 @@
                 when their sensor changes state, instead of the whole window, reducing CPU
                 use on panels receiving frequent sensor events. The repainted area follows
                 the panel zoom level.</li>
+            <li>Fixed a NullPointerException in a Memory icon displaying a roster entry,
+                which could be thrown when the memory value changed while the icon was
+                being updated. The exception propagated out to the caller, so a script or
+                automaton writing to that memory could be stopped by it.</li>
             <li></li>
         </ul>
 

--- a/java/src/jmri/jmrit/display/MemoryIcon.java
+++ b/java/src/jmri/jmrit/display/MemoryIcon.java
@@ -456,8 +456,10 @@ public class MemoryIcon extends MemoryOrGVIcon implements java.beans.PropertyCha
             if (flipRosterIcon) {
                 flipIcon(NamedIcon.HORIZONTALFLIP);
             }
-            jmri.InstanceManager.throttleManagerInstance().attachListener(re.getDccLocoAddress(), this);
-            Object isForward = jmri.InstanceManager.throttleManagerInstance().getThrottleInfo(re.getDccLocoAddress(), jmri.Throttle.ISFORWARD);
+            // use the roster parameter, not the re field: displayState() can clear
+            // re from another thread between the assignment above and here
+            jmri.InstanceManager.throttleManagerInstance().attachListener(roster.getDccLocoAddress(), this);
+            Object isForward = jmri.InstanceManager.throttleManagerInstance().getThrottleInfo(roster.getDccLocoAddress(), jmri.Throttle.ISFORWARD);
             if (isForward != null) {
                 if (!(Boolean) isForward) {
                     flipIcon(NamedIcon.HORIZONTALFLIP);

--- a/java/test/jmri/jmrit/display/MemoryIconTest.java
+++ b/java/test/jmri/jmrit/display/MemoryIconTest.java
@@ -2,6 +2,7 @@ package jmri.jmrit.display;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.awt.Color;
@@ -178,6 +179,36 @@ public class MemoryIconTest extends PositionableTestBase {
 
         jf.setVisible(false);
         JUnitUtil.dispose(jf);
+    }
+
+    /**
+     * Showing a roster entry must not depend on the shared {@code re} field:
+     * displayState() clears it, so a second thread changing the memory value
+     * while updateIconFromRosterVal() runs used to cause a NullPointerException.
+     * The subclass below clears the field at that exact point, which makes the
+     * interleaving deterministic without needing a second thread.
+     */
+    @Test
+    public void testShowRosterEntryWhileFieldCleared() {
+        JUnitUtil.initDebugThrottleManager();
+
+        jmri.jmrit.roster.RosterEntry entry = new jmri.jmrit.roster.RosterEntry();
+        entry.setId("test loco");
+        entry.setDccAddress("42");
+        entry.setLongAddress(false);
+        entry.setIconPath("resources/icons/markers/loco-red.gif");
+
+        MemoryIcon icon = new MemoryIcon("MemoryTest2", editor) {
+            @Override
+            public void updateIcon(NamedIcon s) {
+                super.updateIcon(s);
+                re = null;  // as displayState() does, from another thread
+            }
+        };
+
+        // null means the icon was shown; a non-null return is the text fallback,
+        // which would not reach the code under test
+        assertNull(icon.updateIconFromRosterVal(entry), "roster icon was shown");
     }
 
     @Test


### PR DESCRIPTION
updateIconFromRosterVal() used its roster parameter to pick the icon, then re-read the shared re field to attach the throttle listener. displayState() clears re, so a memory value changing on another thread between the two made the call dereference null. Use the parameter throughout.

The exception propagated back out of the memory setter, so a script or automaton writing to that memory could be stopped by it.