### PR TITLE
WIP - Make LayoutBlock throw ConcurrentModificationException consistent

### DIFF
--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutBlock.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutBlock.java
@@ -16,6 +16,7 @@ import jmri.implementation.AbstractNamedBean;
 import jmri.jmrit.beantable.beanedit.*;
 import jmri.jmrit.roster.RosterEntry;
 import jmri.swing.NamedBeanComboBox;
+import jmri.util.ListLogger;
 import jmri.util.MathUtil;
 import jmri.util.swing.JmriColorChooser;
 import jmri.util.swing.JmriJOptionPane;
@@ -70,11 +71,11 @@ import org.slf4j.MDC;
  */
 public class LayoutBlock extends AbstractNamedBean implements PropertyChangeListener {
 
-    private static final List<Integer> updateReferences = new ArrayList<>(500);
+    private static final List<Integer> updateReferences = new ListLogger<>(new ArrayList<>(500));
 
     // might want to use the jmri ordered HashMap, so that we can add at the top
     // and remove at the bottom.
-    private final List<Integer> actedUponUpdates = new ArrayList<>(500);
+    private final List<Integer> actedUponUpdates = new ListLogger<>(new ArrayList<>(500));
 
     @Deprecated (since="5.11.2",forRemoval=true) // please use the SLF4J categories.
     public void enableDeleteRouteLog() {
@@ -2110,7 +2111,7 @@ public class LayoutBlock extends AbstractNamedBean implements PropertyChangeList
                     // could still hold a valid through path.
                     for (int i = neighbours.size() - 1; i > -1; i--) {
                         // Need to ignore if the dest block is our neighour in this instance
-                        if ((neighbours.get(i).getBlock() != destBlock) && (neighbours.get(i).getBlock() != nextHop) 
+                        if ((neighbours.get(i).getBlock() != destBlock) && (neighbours.get(i).getBlock() != nextHop)
                             && validThroughPath(notifyingblk, neighbours.get(i).getBlock())) {
                             Block neighblock = neighbours.get(i).getBlock();
 
@@ -2264,7 +2265,7 @@ public class LayoutBlock extends AbstractNamedBean implements PropertyChangeList
             addRouteLog.debug("Block {} is a traverser block. Skipping through path generation in addThroughPath(Adjacencies).", getDisplayName());
             return; // Do not create through paths for a traverser
         }
-        
+
         Block newAdj = adj.getBlock();
         int packetFlow = adj.getPacketFlow();
 

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutBlock.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutBlock.java
@@ -71,7 +71,7 @@ import org.slf4j.MDC;
  */
 public class LayoutBlock extends AbstractNamedBean implements PropertyChangeListener {
 
-    private static final int UPDATE_REFERENCE_SIZE_MAX = 500;
+    private static final int UPDATE_REFERENCE_SIZE_MAX = 4;  // Very small for testing
     private static final int UPDATE_REFERENCE_SIZE_HALF_MAX = UPDATE_REFERENCE_SIZE_MAX / 2;
 
     private static final List<Integer> updateReferences = new ListLogger<>(new ArrayList<>(500));

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutBlock.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutBlock.java
@@ -71,6 +71,9 @@ import org.slf4j.MDC;
  */
 public class LayoutBlock extends AbstractNamedBean implements PropertyChangeListener {
 
+    private static final int UPDATE_REFERENCE_SIZE_MAX = 500;
+    private static final int UPDATE_REFERENCE_SIZE_HALF_MAX = UPDATE_REFERENCE_SIZE_MAX / 2;
+
     private static final List<Integer> updateReferences = new ListLogger<>(new ArrayList<>(500));
 
     // might want to use the jmri ordered HashMap, so that we can add at the top
@@ -2613,9 +2616,9 @@ public class LayoutBlock extends AbstractNamedBean implements PropertyChangeList
          thus making sure if the packet gets back to us we do knowing with it.*/
         actedUponUpdates.add(lastID);
 
-        if (updateReferences.size() > 500) {
+        if (updateReferences.size() > UPDATE_REFERENCE_SIZE_MAX) {
             // log.info("flush update references");
-            updateReferences.subList(0, 250).clear();
+            updateReferences.subList(0, UPDATE_REFERENCE_SIZE_HALF_MAX).clear();
         }
 
         if (actedUponUpdates.size() > 500) {

--- a/java/src/jmri/util/ListLogger.java
+++ b/java/src/jmri/util/ListLogger.java
@@ -19,7 +19,6 @@ public class ListLogger<E extends Object> implements List<E> {
     private static final boolean LOG_WHERE = false;
 
     private final List<E> list;
-    private volatile boolean listAddedTo = false;
 
     public ListLogger(List<E> list) {
         this(list, true);
@@ -69,7 +68,6 @@ public class ListLogger<E extends Object> implements List<E> {
     @Override
     public boolean add(E element) {
         log("add(element) called");
-        listAddedTo = true;
         return list.add(element);
     }
 
@@ -86,14 +84,12 @@ public class ListLogger<E extends Object> implements List<E> {
     @Override
     public boolean addAll(Collection<? extends E> c) {
         log("addAll(c) called");
-        listAddedTo = true;
         return list.addAll(c);
     }
 
     @Override
     public boolean addAll(int index, Collection<? extends E> c) {
         log("addAll(index, c) called");
-        listAddedTo = true;
         return list.addAll(index, c);
     }
 
@@ -111,9 +107,7 @@ public class ListLogger<E extends Object> implements List<E> {
     public void clear() {
         try {
             log("clear() called. Start wait.");
-            listAddedTo = false;
             Thread.sleep(2000);
-            if (listAddedTo) throw new ConcurrentModificationException("List added to during clear()");
             list.clear();
         } catch (InterruptedException e) {
             log.warn("Interrupted during sleep");
@@ -133,7 +127,6 @@ public class ListLogger<E extends Object> implements List<E> {
     @Override
     public void add(int index, E element) {
         log("add(index, element) called");
-        listAddedTo = true;
         list.add(index, element);
     }
 

--- a/java/src/jmri/util/ListLogger.java
+++ b/java/src/jmri/util/ListLogger.java
@@ -21,7 +21,11 @@ public class ListLogger<E extends Object> implements List<E> {
     private final List<E> list;
 
     public ListLogger(List<E> list) {
-        log("ListLogger created");
+        this(list, true);
+    }
+
+    public ListLogger(List<E> list, boolean logCreation) {
+        if (logCreation) log("ListLogger created");
         this.list = list;
     }
 
@@ -149,7 +153,7 @@ public class ListLogger<E extends Object> implements List<E> {
     @Override
     public List<E> subList(int fromIndex, int toIndex) {
         log("subList() called");
-        return list.subList(fromIndex, toIndex);
+        return new ListLogger(list.subList(fromIndex, toIndex), false);
     }
 
     private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(ListLogger.class);

--- a/java/src/jmri/util/ListLogger.java
+++ b/java/src/jmri/util/ListLogger.java
@@ -58,6 +58,8 @@ public class ListLogger<E extends Object> implements List<E> {
 
     @Override
     public boolean add(E element) {
+        log.warn("add(element) called");
+        if (LOG_WHERE) LoggingUtil.shortenStacktrace(new Exception()).printStackTrace();
         return list.add(element);
     }
 
@@ -73,11 +75,15 @@ public class ListLogger<E extends Object> implements List<E> {
 
     @Override
     public boolean addAll(Collection<? extends E> c) {
+        log.warn("addAll(c) called");
+        if (LOG_WHERE) LoggingUtil.shortenStacktrace(new Exception()).printStackTrace();
         return list.addAll(c);
     }
 
     @Override
     public boolean addAll(int index, Collection<? extends E> c) {
+        log.warn("addAll(index, c) called");
+        if (LOG_WHERE) LoggingUtil.shortenStacktrace(new Exception()).printStackTrace();
         return list.addAll(index, c);
     }
 
@@ -110,6 +116,8 @@ public class ListLogger<E extends Object> implements List<E> {
 
     @Override
     public void add(int index, E element) {
+        log.warn("add(index, element) called");
+        if (LOG_WHERE) LoggingUtil.shortenStacktrace(new Exception()).printStackTrace();
         list.add(index, element);
     }
 

--- a/java/src/jmri/util/ListLogger.java
+++ b/java/src/jmri/util/ListLogger.java
@@ -15,6 +15,7 @@ public class ListLogger<E extends Object> implements List<E> {
      * Log where it's called?
      */
     private static final boolean LOG = true;
+//    private static final boolean LOG = false;
     private static final boolean LOG_WHERE = false;
 
     private final List<E> list;

--- a/java/src/jmri/util/ListLogger.java
+++ b/java/src/jmri/util/ListLogger.java
@@ -14,20 +14,24 @@ public class ListLogger<E extends Object> implements List<E> {
     /**
      * Log where it's called?
      */
+    private static final boolean LOG = true;
     private static final boolean LOG_WHERE = false;
 
     private final List<E> list;
 
     public ListLogger(List<E> list) {
-        log.warn("ListLogger created");
-        if (LOG_WHERE) LoggingUtil.shortenStacktrace(new Exception()).printStackTrace();
+        log("ListLogger created");
         this.list = list;
+    }
+
+    private void log(String message) {
+        if (LOG) log.warn(message);
+        if (LOG_WHERE) LoggingUtil.shortenStacktrace(new Exception()).printStackTrace();
     }
 
     @Override
     public int size() {
-        log.warn("size() called");
-        if (LOG_WHERE) LoggingUtil.shortenStacktrace(new Exception()).printStackTrace();
+        log("size() called");
         return list.size();
     }
 
@@ -58,8 +62,7 @@ public class ListLogger<E extends Object> implements List<E> {
 
     @Override
     public boolean add(E element) {
-        log.warn("add(element) called");
-        if (LOG_WHERE) LoggingUtil.shortenStacktrace(new Exception()).printStackTrace();
+        log("add(element) called");
         return list.add(element);
     }
 
@@ -75,15 +78,13 @@ public class ListLogger<E extends Object> implements List<E> {
 
     @Override
     public boolean addAll(Collection<? extends E> c) {
-        log.warn("addAll(c) called");
-        if (LOG_WHERE) LoggingUtil.shortenStacktrace(new Exception()).printStackTrace();
+        log("addAll(c) called");
         return list.addAll(c);
     }
 
     @Override
     public boolean addAll(int index, Collection<? extends E> c) {
-        log.warn("addAll(index, c) called");
-        if (LOG_WHERE) LoggingUtil.shortenStacktrace(new Exception()).printStackTrace();
+        log("addAll(index, c) called");
         return list.addAll(index, c);
     }
 
@@ -99,8 +100,7 @@ public class ListLogger<E extends Object> implements List<E> {
 
     @Override
     public void clear() {
-        log.warn("clear() called");
-        if (LOG_WHERE) LoggingUtil.shortenStacktrace(new Exception()).printStackTrace();
+        log("clear() called");
         list.clear();
     }
 
@@ -116,8 +116,7 @@ public class ListLogger<E extends Object> implements List<E> {
 
     @Override
     public void add(int index, E element) {
-        log.warn("add(index, element) called");
-        if (LOG_WHERE) LoggingUtil.shortenStacktrace(new Exception()).printStackTrace();
+        log("add(index, element) called");
         list.add(index, element);
     }
 
@@ -148,8 +147,7 @@ public class ListLogger<E extends Object> implements List<E> {
 
     @Override
     public List<E> subList(int fromIndex, int toIndex) {
-        log.warn("subList() called");
-        if (LOG_WHERE) LoggingUtil.shortenStacktrace(new Exception()).printStackTrace();
+        log("subList() called");
         return list.subList(fromIndex, toIndex);
     }
 

--- a/java/src/jmri/util/ListLogger.java
+++ b/java/src/jmri/util/ListLogger.java
@@ -14,7 +14,7 @@ public class ListLogger<E extends Object> implements List<E> {
     /**
      * Should we sleep?
      */
-    private static final boolean DO_SLEEP = false;
+    private static final boolean SLEEP = false;
 
     /**
      * Should we log the calls?
@@ -116,7 +116,7 @@ public class ListLogger<E extends Object> implements List<E> {
     public void clear() {
         try {
             log("clear() called. Start wait.");
-            if (DO_SLEEP) Thread.sleep(2000);
+            if (SLEEP) Thread.sleep(2000);
             list.clear();
         } catch (InterruptedException e) {
             log.warn("Interrupted during sleep");

--- a/java/src/jmri/util/ListLogger.java
+++ b/java/src/jmri/util/ListLogger.java
@@ -1,0 +1,149 @@
+package jmri.util;
+
+import java.util.*;
+
+/**
+ * A list that loggs some of its calls.
+ *
+ * @param <E> the type of elements in this list
+ *
+ * @author Daniel Bergqvist (C) 2026
+ */
+public class ListLogger<E extends Object> implements List<E> {
+
+    /**
+     * Log where it's called?
+     */
+    private static final boolean LOG_WHERE = false;
+
+    private final List<E> list;
+
+    public ListLogger(List<E> list) {
+        log.warn("ListLogger created");
+        if (LOG_WHERE) LoggingUtil.shortenStacktrace(new Exception()).printStackTrace();
+        this.list = list;
+    }
+
+    @Override
+    public int size() {
+        log.warn("size() called");
+        if (LOG_WHERE) LoggingUtil.shortenStacktrace(new Exception()).printStackTrace();
+        return list.size();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return list.isEmpty();
+    }
+
+    @Override
+    public boolean contains(Object o) {
+        return list.contains(o);
+    }
+
+    @Override
+    public Iterator<E> iterator() {
+        return list.iterator();
+    }
+
+    @Override
+    public Object[] toArray() {
+        return list.toArray();
+    }
+
+    @Override
+    public <T extends Object> T[] toArray(T[] a) {
+        return list.toArray(a);
+    }
+
+    @Override
+    public boolean add(E element) {
+        return list.add(element);
+    }
+
+    @Override
+    public boolean remove(Object o) {
+        return list.remove(o);
+    }
+
+    @Override
+    public boolean containsAll(Collection<?> c) {
+        return list.containsAll(c);
+    }
+
+    @Override
+    public boolean addAll(Collection<? extends E> c) {
+        return list.addAll(c);
+    }
+
+    @Override
+    public boolean addAll(int index, Collection<? extends E> c) {
+        return list.addAll(index, c);
+    }
+
+    @Override
+    public boolean removeAll(Collection<?> c) {
+        return list.removeAll(c);
+    }
+
+    @Override
+    public boolean retainAll(Collection<?> c) {
+        return list.retainAll(c);
+    }
+
+    @Override
+    public void clear() {
+        log.warn("clear() called");
+        if (LOG_WHERE) LoggingUtil.shortenStacktrace(new Exception()).printStackTrace();
+        list.clear();
+    }
+
+    @Override
+    public E get(int index) {
+        return list.get(index);
+    }
+
+    @Override
+    public E set(int index, E element) {
+        return list.set(index, element);
+    }
+
+    @Override
+    public void add(int index, E element) {
+        list.add(index, element);
+    }
+
+    @Override
+    public E remove(int index) {
+        return list.remove(index);
+    }
+
+    @Override
+    public int indexOf(Object o) {
+        return list.indexOf(o);
+    }
+
+    @Override
+    public int lastIndexOf(Object o) {
+        return list.lastIndexOf(o);
+    }
+
+    @Override
+    public ListIterator<E> listIterator() {
+        return list.listIterator();
+    }
+
+    @Override
+    public ListIterator<E> listIterator(int index) {
+        return list.listIterator(index);
+    }
+
+    @Override
+    public List<E> subList(int fromIndex, int toIndex) {
+        log.warn("subList() called");
+        if (LOG_WHERE) LoggingUtil.shortenStacktrace(new Exception()).printStackTrace();
+        return list.subList(fromIndex, toIndex);
+    }
+
+    private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(ListLogger.class);
+}

--- a/java/src/jmri/util/ListLogger.java
+++ b/java/src/jmri/util/ListLogger.java
@@ -12,11 +12,20 @@ import java.util.*;
 public class ListLogger<E extends Object> implements List<E> {
 
     /**
-     * Log where it's called?
+     * Should we sleep?
+     */
+    private static final boolean DO_SLEEP = false;
+
+    /**
+     * Should we log the calls?
      */
     private static final boolean LOG = true;
-//    private static final boolean LOG = false;
+
+    /**
+     * Log where it's called?
+     */
     private static final boolean LOG_WHERE = false;
+
 
     private final List<E> list;
 
@@ -107,7 +116,7 @@ public class ListLogger<E extends Object> implements List<E> {
     public void clear() {
         try {
             log("clear() called. Start wait.");
-            Thread.sleep(2000);
+            if (DO_SLEEP) Thread.sleep(2000);
             list.clear();
         } catch (InterruptedException e) {
             log.warn("Interrupted during sleep");

--- a/java/src/jmri/util/ListLogger.java
+++ b/java/src/jmri/util/ListLogger.java
@@ -19,6 +19,7 @@ public class ListLogger<E extends Object> implements List<E> {
     private static final boolean LOG_WHERE = false;
 
     private final List<E> list;
+    private volatile boolean listAddedTo = false;
 
     public ListLogger(List<E> list) {
         this(list, true);
@@ -68,6 +69,7 @@ public class ListLogger<E extends Object> implements List<E> {
     @Override
     public boolean add(E element) {
         log("add(element) called");
+        listAddedTo = true;
         return list.add(element);
     }
 
@@ -84,12 +86,14 @@ public class ListLogger<E extends Object> implements List<E> {
     @Override
     public boolean addAll(Collection<? extends E> c) {
         log("addAll(c) called");
+        listAddedTo = true;
         return list.addAll(c);
     }
 
     @Override
     public boolean addAll(int index, Collection<? extends E> c) {
         log("addAll(index, c) called");
+        listAddedTo = true;
         return list.addAll(index, c);
     }
 
@@ -105,8 +109,15 @@ public class ListLogger<E extends Object> implements List<E> {
 
     @Override
     public void clear() {
-        log("clear() called");
-        list.clear();
+        try {
+            log("clear() called. Start wait.");
+            listAddedTo = false;
+            Thread.sleep(2000);
+            if (listAddedTo) throw new ConcurrentModificationException("List added to during clear()");
+            list.clear();
+        } catch (InterruptedException e) {
+            log.warn("Interrupted during sleep");
+        }
     }
 
     @Override
@@ -122,6 +133,7 @@ public class ListLogger<E extends Object> implements List<E> {
     @Override
     public void add(int index, E element) {
         log("add(index, element) called");
+        listAddedTo = true;
         list.add(index, element);
     }
 


### PR DESCRIPTION
See: https://jmri-developers.groups.io/g/jmri/message/12770

This PR does a couple of minor changes to LayoutBlock to get the CME consistent at line 2617 / 2621 with a very small panel file.

[My entire profile to test this](https://github.com/user-attachments/files/31156722/LayoutBlock.jmri.zip). It has a panel file, [Daniel.xml](https://github.com/user-attachments/files/31156970/Daniel.xml), and a jython script, [SetSensor.py](https://github.com/user-attachments/files/31156976/SetSensor.py).

To get the CME consistent, I have:
- Created the new class ListLogger that decorates a List.
- Made the `updateReferences` list in LayoutBlock a ListLogger
- Set the max size very small (4 instead of 500).
- Made `ListLogger.clear()` delay a long time (2 seconds)
- When JMRI starts, it first loads a panel and then runs a script that sets a sensor for a block on the GUI thread.

To get the CME, set `ListLogger.SLEEP` to true. If it's false, as it is now, there is no sleep and therefore no CME.