### PR TITLE
Fix the "Current Config file" path in "Help -> File Locations"

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -146,7 +146,7 @@
         <pathelement location="${libdir}/openlcb.jar"/>
         <pathelement location="${libdir}/jlfgr-1_0.jar"/>
         <pathelement location="${libdir}/joal.jar"/>
-        
+
         <pathelement location="${libdir}/jython-standalone-2.7.4.jar"/>
 
         <!-- Logging -->
@@ -491,7 +491,7 @@
 
     <!-- check build system requirements, not for user use -->
     <!-- Used in the warnings and warnings-check targets -->
-    <target name="check-ant-requirements"> 
+    <target name="check-ant-requirements">
       <antversion property="ant-version-ok" atleast="1.10.6"/>
       <antversion property="ant-version-actual"/>
       <fail unless="ant-version-ok" message="Minimum ant version required is 1.10.6, this is ${ant-version-actual}"/>
@@ -748,7 +748,7 @@
         <attribute name="javac.classpath" default="compile.class.path"/>
         <attribute name="is.test" default=""/>
         <sequential>
-        
+
             <!-- Set property only if it's a test build AND metadata is missing -->
             <!-- Test build - JUnitAppender uses a Log4J Plugin, saves unused argument warning in non-test builds -->
             <!-- metadata missing - Graalvm does not trigger for incremental builds, saves unused argument warning -->
@@ -1310,7 +1310,7 @@
             depends="debug, copyfiles">
         <antcall target="-run-jmri-application">
             <param name="application.classname" value="apps.DecoderPro.DecoderPro"/>
-            <param name="antargline" value="DecoderProConfig2.xml"/>
+            <param name="antargline" value="DecoderProConfig2.properties"/>
         </antcall>
     </target>
 
@@ -1319,7 +1319,7 @@
             depends="debug, copyfiles">
         <antcall target="-run-jmri-application">
             <param name="application.classname" value="apps.gui3.lccpro.LccPro"/>
-            <param name="antargline" value="LccProConfig.xml"/>
+            <param name="antargline" value="LccProConfig.properties"/>
         </antcall>
     </target>
 
@@ -1328,7 +1328,7 @@
             depends="debug, copyfiles">
         <antcall target="-run-jmri-application">
             <param name="application.classname" value="apps.gui3.dp3.DecoderPro3"/>
-            <param name="antargline" value="DecoderProConfig3.xml"/>
+            <param name="antargline" value="DecoderProConfig3.properties"/>
         </antcall>
     </target>
 
@@ -1337,7 +1337,7 @@
             depends="debug">
         <antcall target="-run-jmri-application">
             <param name="application.classname" value="apps.PanelPro.PanelPro"/>
-            <param name="antargline" value="PanelProConfig2.xml"/>
+            <param name="antargline" value="PanelProConfig2.properties"/>
         </antcall>
     </target>
 
@@ -1346,7 +1346,7 @@
             depends="debug">
         <antcall target="-run-jmri-application">
             <param name="application.classname" value="apps.SoundPro.SoundPro"/>
-            <param name="antargline" value="SoundProConfig2.xml"/>
+            <param name="antargline" value="SoundProConfig2.properties"/>
         </antcall>
     </target>
 
@@ -1371,7 +1371,7 @@
             description="build and run build and run InstallTest app">
         <antcall target="-run-jmri-application">
             <param name="application.classname" value="apps.InstallTest.InstallTest"/>
-            <param name="antargline" value="InstallTestConfig2.xml"/>
+            <param name="antargline" value="InstallTestConfig2.properties"/>
         </antcall>
     </target>
 
@@ -1388,7 +1388,7 @@
             description="build and run build and run JmriFaceless app">
         <antcall target="-run-jmri-application">
             <param name="application.classname" value="apps.JmriFaceless"/>
-            <param name="antargline" value="JmriFacelessConfig3.xml"/>
+            <param name="antargline" value="JmriFacelessConfig3.properties"/>
         </antcall>
     </target>
 
@@ -2161,7 +2161,7 @@
             <!-- <link href="https://docs.oracle.com/cd/E17802_01/products/products/javacomm/reference/api/" /> redirection issue as of 2024-09-16 -->
 
             <link href="https://fazecast.github.io/jSerialComm/javadoc" />
-            
+
             <link href="https://www.javadoc.io/doc/org.openlcb/openlcb/0.7.37/" />
 
             <!-- <link href="https://static.javadoc.io/com.github.purejavacomm/purejavacomm/1.0.1.RELEASE/" packagelistLoc="lib/purejavacomm-1.0.1-package-list"/>  redirected to next line -->

--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -89,7 +89,7 @@
 
         <h4>LocoNet</h4>
             <ul>
-                <li>SlotMonitor update: 
+                <li>SlotMonitor update:
                 <ul>
                     <li>Add ability to hide / move columns. N.B. if you open 2 or more SlotMonitors this is only effective on the first one.</li>
                     <li>If Extended purge time is enabled in the Command Station the Slow scan for slots is extended.</li>
@@ -687,6 +687,6 @@
     <h3>Miscellaneous</h3>
         <a id="Misc" name="Misc"></a>
         <ul>
-            <li></li>
+            <li>Fix the <strong>Current Config file</strong> path in <strong>Help &rArr; File Locations</strong>.</li>
         </ul>
 

--- a/java/src/apps/Apps.java
+++ b/java/src/apps/Apps.java
@@ -114,10 +114,6 @@ public class Apps extends JPanel implements PropertyChangeListener, WindowListen
         log.trace("about to try getStartingProfile");
         try {
             ProfileManagerDialog.getStartingProfile(sp);
-            // Manually setting the configFilename property since calling
-            // Apps.setConfigFilename() does not reset the system property
-            configFilename = FileUtil.getProfilePath() + Profile.CONFIG_FILENAME;
-            System.setProperty("org.jmri.Apps.configFilename", Profile.CONFIG_FILENAME);
             Profile profile = ProfileManager.getDefault().getActiveProfile();
             if (profile != null) {
                 log.info("Starting with profile {}", profile.getId());

--- a/java/src/apps/AppsBase.java
+++ b/java/src/apps/AppsBase.java
@@ -165,9 +165,6 @@ public abstract class AppsBase {
         try {
             // GUI should use ProfileManagerDialog.getStartingProfile here
             if (ProfileManager.getStartingProfile() != null) {
-                // Manually setting the configFilename property since calling
-                // Apps.setConfigFilename() does not reset the system property
-                System.setProperty("org.jmri.Apps.configFilename", Profile.CONFIG_FILENAME);
                 Profile profile = ProfileManager.getDefault().getActiveProfile();
                 if (profile != null) {
                     log.info("Starting with profile {}", profile.getId());

--- a/java/src/apps/DecoderPro/DecoderPro.java
+++ b/java/src/apps/DecoderPro/DecoderPro.java
@@ -149,7 +149,7 @@ public class DecoderPro extends Apps {
 
         Apps.setStartupInfo("DecoderPro");
 
-        setConfigFilename("DecoderProConfig2.xml", args);
+        setConfigFilename("DecoderProConfig2.properties", args);
         DecoderPro dp = new DecoderPro();
         JmriJFrame f = new JmriJFrame(jmri.Application.getApplicationName());
         createFrame(dp, f);

--- a/java/src/apps/DispatcherPro/DispatcherPro.java
+++ b/java/src/apps/DispatcherPro/DispatcherPro.java
@@ -122,7 +122,7 @@ public class DispatcherPro extends Apps {
 
         Apps.setStartupInfo("DispatcherPro");
 
-        setConfigFilename("DispatcherProConfig2.xml", args);
+        setConfigFilename("DispatcherProConfig2.properties", args);
         DispatcherPro dp = new DispatcherPro();
         JmriJFrame f = new JmriJFrame(jmri.Application.getApplicationName());
         createFrame(dp, f);

--- a/java/src/apps/InstallTest/InstallTest.java
+++ b/java/src/apps/InstallTest/InstallTest.java
@@ -114,7 +114,7 @@ public class InstallTest extends Apps {
 
         Apps.setStartupInfo("InstallTest");
 
-        setConfigFilename("InstallTestConfig2.xml", args);
+        setConfigFilename("InstallTestConfig2.properties", args);
         InstallTest it = new InstallTest();
         JmriJFrame f = new JmriJFrame(jmri.Application.getApplicationName());
         createFrame(it, f);

--- a/java/src/apps/PanelPro/PanelPro.java
+++ b/java/src/apps/PanelPro/PanelPro.java
@@ -118,7 +118,7 @@ public class PanelPro extends Apps {
 
         Apps.setStartupInfo("PanelPro");
 
-        setConfigFilename("PanelProConfig2.xml", args);
+        setConfigFilename("PanelProConfig2.properties", args);
         PanelPro p = new PanelPro();
         JmriJFrame f = new JmriJFrame(jmri.Application.getApplicationName());
         createFrame(p, f);

--- a/java/src/apps/SampleMinimalProgram.java
+++ b/java/src/apps/SampleMinimalProgram.java
@@ -81,7 +81,7 @@ public class SampleMinimalProgram {
 
         // Load from preference file, by default the DecoderPro
         // one so you can use DecoderPro to load the preferences values.
-        //    setConfigFilename("DecoderProConfig2.xml", args);
+        //    setConfigFilename("DecoderProConfig2.properties", args);
         //    loadFile();
         // load directly via code
         codeConfig(args);

--- a/java/src/apps/SoundPro/SoundPro.java
+++ b/java/src/apps/SoundPro/SoundPro.java
@@ -126,7 +126,7 @@ public class SoundPro extends Apps {
 
         Apps.setStartupInfo("SoundPro");
 
-        setConfigFilename("SoundProConfig2.xml", args);
+        setConfigFilename("SoundProConfig2.properties", args);
         SoundPro sp = new SoundPro();
         JmriJFrame f = new JmriJFrame(jmri.Application.getApplicationName());
         createFrame(sp, f);

--- a/java/src/apps/gui3/Apps3.java
+++ b/java/src/apps/gui3/Apps3.java
@@ -94,13 +94,13 @@ public abstract class Apps3 extends AppsBase {
     protected boolean wizardLaunchCheck() {
         return false;
     }
-    
+
     public void launchFirstTimeStartupWizard() {
         FirstTimeStartUpWizardAction prefsAction = new FirstTimeStartUpWizardAction("Start Up Wizard");
         prefsAction.setApp(this);
         prefsAction.actionPerformed(null);
     }
-    
+
     /**
      * For compatability with adding in buttons to the toolbar using the
      * existing createbuttonmodel
@@ -159,7 +159,7 @@ public abstract class Apps3 extends AppsBase {
                 }
             }
         }, eventMask);
-        
+
         // A Shutdown manager handles the quiting of the application
         mainFrame.setDefaultCloseOperation(WindowConstants.DO_NOTHING_ON_CLOSE);
         displayMainFrame(mainFrame.getMaximumSize());
@@ -320,9 +320,6 @@ public abstract class Apps3 extends AppsBase {
         }
         try {
             ProfileManagerDialog.getStartingProfile(sp);
-            // Manually setting the configFilename property since calling
-            // Apps.setConfigFilename() does not reset the system property
-            System.setProperty("org.jmri.Apps.configFilename", Profile.CONFIG_FILENAME);
             Profile profile = ProfileManager.getDefault().getActiveProfile();
             if (profile != null) {
                 log.info("Starting with profile {}", profile.getId());

--- a/java/src/apps/gui3/dp3/DecoderPro3.java
+++ b/java/src/apps/gui3/dp3/DecoderPro3.java
@@ -97,7 +97,7 @@ public class DecoderPro3 extends apps.gui3.Apps3 {
 
     public static void preInit(String[] args) {
         apps.gui3.Apps3.preInit(applicationName);
-        apps.gui3.Apps3.setConfigFilename("DecoderProConfig3.xml", args);
+        apps.gui3.Apps3.setConfigFilename("DecoderProConfig3.properties", args);
     }
 
     /**

--- a/java/src/apps/gui3/lccpro/LccPro.java
+++ b/java/src/apps/gui3/lccpro/LccPro.java
@@ -98,7 +98,7 @@ public class LccPro extends Apps3 {
                         return "Next you need to configure your LCC connection.\n\nThen select the serial port or enter in the IP address of the device";
                     }
                 };
-            }      
+            }
         };
         prefsAction.setApp(this);
         prefsAction.actionPerformed(null);
@@ -136,7 +136,7 @@ public class LccPro extends Apps3 {
 
     public static void preInit(String[] args) {
         apps.gui3.Apps3.preInit(applicationName);
-        apps.gui3.Apps3.setConfigFilename("LccProConfig.xml", args);
+        apps.gui3.Apps3.setConfigFilename("LccProConfig.properties", args);
     }
 
     /**

--- a/java/src/jmri/jmrit/XmlFileLocationAction.java
+++ b/java/src/jmri/jmrit/XmlFileLocationAction.java
@@ -144,7 +144,7 @@ public class XmlFileLocationAction extends AbstractAction {
         if (!new File(configName).isAbsolute()) {
             // must be relative, but we want it to
             // be relative to the preferences directory
-            configName = FileUtil.getProfilePath() + configName;
+            configName = FileUtil.getPreferencesPath() + configName;
         }
 
         StringBuilder s = new StringBuilder();

--- a/scripts/AppScriptTemplate
+++ b/scripts/AppScriptTemplate
@@ -504,7 +504,7 @@ CP="${CP}.:classes:target/classes:jmri.jar"
 # add contents of lib
 CP="${CP}:$( ls -m ${LIBDIR}/*.jar | tr -d ' \n' | tr ',' ':' )"
 
-# add contents of the user settings / lib directory, if anything 
+# add contents of the user settings / lib directory, if anything
 mkdir -p ${settingsdir}/lib
 if [ ! -z "$(ls -A ${settingsdir}/lib)" ]; then
     CP="${CP}:$( ls -m ${settingsdir}/lib/*.jar | tr -d ' \n' | tr ',' ':' )"
@@ -541,7 +541,7 @@ if [ "$APPNAME" != "$DEFAULT_APP_NAME" -o -n "${CONFIGNAME}" ] ; then
     if [ -z "${CONFIGNAME}" ] ; then
         CONFIGNAME=$( echo $APPNAME | tr -d '[:space:]' | tr -d '=' )
     fi
-    CONFIGFILE="-Dorg.jmri.Apps.configFilename=${CONFIGNAME}Config.xml"
+    CONFIGFILE="-Dorg.jmri.Apps.configFilename=${CONFIGNAME}Config.properties"
     [ -n "${DEBUG}" ] && echo "CONFIGFILE: '${CONFIGFILE}'" | tee -a ${launcher_log}
 fi
 
@@ -603,10 +603,10 @@ RESTART_CODE=100
 EXIT_STATUS=${RESTART_CODE}
 
 while [ "${EXIT_STATUS}" -eq "${RESTART_CODE}" ] ; do
- 
+
     trap 'kill -TERM $PID' TERM INT
     trap 'kill -HUP $PID' HUP
-    
+
     if [ "$OS" = "macosx" ] ; then
         "${JAVACMD}" "${DOCK_OPTIONS[@]}" ${OPTIONS} ${ALTPORTS} ${CONFIGFILE} -cp "${CP}" "${CLASSNAME}" ${ARGS} &
         PID=$!
@@ -614,7 +614,7 @@ while [ "${EXIT_STATUS}" -eq "${RESTART_CODE}" ] ; do
         "${JAVACMD}" ${OPTIONS} ${ALTPORTS} ${CONFIGFILE} -cp "${CP}" "${CLASSNAME}" ${ARGS} &
         PID=$!
     fi
-    
+
     wait $PID
     trap - TERM INT HUP
     wait $PID


### PR DESCRIPTION
The current reference to **ProfileConfig.xml** is not valid.

<img width="505" height="45" alt="help-current" src="https://github.com/user-attachments/assets/d20d7d7a-684f-4c33-a07b-1b84bae89836" />

This reference was valid from JMRI 3.8 until JMRI 4.4.  

The profile structure was implemented at JMRI 3.8.  The existing configuration information was migrated to ProfileConfig.xml from the original config file, such as PanelProConfig2.xml.  The "app" startup process was changed to use a config properties file, such as PanelProConfig2.properties, which refers to the profile which contains the ProfileConfig.xml file.

JMRI 4.4 changed the profile process to support shared profiles.  The contents of ProfileConfig.xml were migrated to the profile/profile.xml and profile/profile.properties structure with node specific copies in a "node identity" directory.  This directory also contains the user-interface.xml file.


