### PR TITLE
WIP - Show classpath and packages

### DIFF
--- a/java/src/jmri/jmrix/can/CanSystemConnectionMemo.java
+++ b/java/src/jmri/jmrix/can/CanSystemConnectionMemo.java
@@ -63,7 +63,7 @@ public class CanSystemConnectionMemo extends DefaultSystemConnectionMemo impleme
     protected boolean _supportsCVHints = false; // Support for CV read hint values
     private boolean _multipleThrottles = true;  // Support for multiple throttles
     private boolean _powerOnArst = true;        // Turn power on if ARST opcode received
-    
+
     jmri.jmrix.swing.ComponentFactory cf = null;
 
     protected TrafficController tm;
@@ -169,6 +169,24 @@ public class CanSystemConnectionMemo extends DefaultSystemConnectionMemo impleme
                     manager = new jmri.jmrix.can.cbus.CbusConfigurationManager(this);
                     break;
                 case ConfigurationManager.OPENLCB:
+
+                    String cp = System.getProperty("java.class.path");
+                    String[] cpSorted = cp.split(":");
+                    java.util.Arrays.sort(cpSorted);
+                    for (var s : cpSorted) {
+                        System.out.format("Classpath: %s%n", s);
+                    }
+//                    System.out.format("Version: %s%n", org.openlcb.Version.libVersion());
+
+                    var packages = ClassLoader.getSystemClassLoader().getDefinedPackages();
+                    java.util.Arrays.sort(packages, (Package t1, Package t2) -> t1.getName().compareTo(t2.getName()));
+                    for (var p : packages) {
+                        System.out.format("Package: %s%n", p.getName());
+                    }
+
+                    System.exit(0);
+
+                    System.out.format("Daniel: Version: %s%n", org.openlcb.Version.libVersion());
                     manager = new jmri.jmrix.openlcb.OlcbConfigurationManager(this);
                     break;
                 case ConfigurationManager.RAWCAN:

--- a/java/test/jmri/jmrix/openlcb/CheckOpenLcbJarVersion.java
+++ b/java/test/jmri/jmrix/openlcb/CheckOpenLcbJarVersion.java
@@ -1,0 +1,44 @@
+package jmri.jmrix.openlcb;
+
+import java.util.*;
+
+import jmri.util.JUnitUtil;
+
+import org.junit.jupiter.api.*;
+
+/**
+ * Check the version of the openlcb.jar file.
+ *
+ * @author Daniel Bergqvist (C) 2026
+ */
+public class CheckOpenLcbJarVersion {
+
+    @Test
+    public void testAddressOK() {
+
+        String cp = System.getProperty("java.class.path");
+        String[] cpSorted = cp.split(":");
+        Arrays.sort(cpSorted);
+        for (var s : cpSorted) {
+            System.out.format("Classpath: %s%n", s);
+        }
+        System.out.format("Version: %s%n", org.openlcb.Version.libVersion());
+
+        var packages = ClassLoader.getSystemClassLoader().getDefinedPackages();
+        Arrays.sort(packages, (Package t1, Package t2) -> t1.getName().compareTo(t2.getName()));
+        for (var p : packages) {
+            System.out.format("Package: %s%n", p.getName());
+        }
+    }
+
+    @BeforeEach
+    public void setUp() {
+        JUnitUtil.setUp();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        JUnitUtil.tearDown();
+    }
+
+}


### PR DESCRIPTION
See: https://jmri-developers.groups.io/g/jmri/message/12793

The classpath differ between when running JMRI and when running the tests. I have openlcb.jar on the classpath when running the tests, but not when running PanelPro.