### PR TITLE
Dispatcher System: do not invert first-registration facing direction

### DIFF
--- a/jython/DispatcherSystem/MoveTrain.py
+++ b/jython/DispatcherSystem/MoveTrain.py
@@ -1756,10 +1756,10 @@ class NewTrainMaster(jmri.jmrit.automat.AbstractAutomaton):
             result = self.od.customQuestionMessage2str(msg, title, "forward", "reverse")
             if self.od.CLOSED_OPTION == True:
                 OptionDialog().displayMessage("Sorry Can't Cancel at this point")
-        if result == "reverse":
-            train_direction = "forward"
-        else:
-            train_direction = "reverse"
+        # First registration: stored direction is throttle polarity for this
+        # move (the dialog answer). Do not invert here; last-moved is updated
+        # after a completed hop in set_direction(). See GitHub issue 15407.
+        train_direction = result
 
         # if in_siding:
         #     if result == "reverse":
@@ -2307,12 +2307,6 @@ class createandshowGUI(TableModelListener):
             train_direction = self.model.data[row][direction]
             train_length = self.model.data[row][length]
             train_speed_factor = self.model.data[row][speed_factor]
-
-            result = train_direction
-            if result == "forward":
-                train_direction = "reverse"
-            else:
-                train_direction = "forward"
             if self.logLevel > 3: print "train_name", train_name,"train_direction", train_direction
 
             if train_name != "" and train_name != None and block_name != "" and block_name != None:
@@ -2543,12 +2537,7 @@ class MyTableModel (DefaultTableModel):
                 current_speed_factor_str = engine.getComment()
                 train = trains[train_name]
                 result = train["direction"]
-                # print "train[direction] loading to put in dropdown", result
-                if result == "forward":
-                    train_direction = "reverse"
-                else:
-                    train_direction = "forward"
-                # print "train", train, train_direction
+                train_direction = result
             items_to_put_in_dropdown.append([train_name,block_name,train_direction, False, train_length, current_speed_factor ])
 
         # print "items_to_put_in_dropdown", items_to_put_in_dropdown


### PR DESCRIPTION
Fixes #15407 (if first-setup polarity is the intended rule).

## Summary
- Dispatcher System (jython) `MoveTrain.py`: store the Setup Train facing dialog as throttle polarity for the first move.
- Stop swapping in `set_train_direction`, `save_action`, and `populate_existing`.
- Leave `set_direction()` (last-moved after a hop) unchanged.

## Why
Clicking **forward** currently stores `"reverse"`, so `call_dispatch` loads `*_rvs.xml` (`runInReverse=yes`) while the transit section list is still Forward. The locomotive backs on a forward route.

This invert came in with #14365 / `b0b1627` (*store direction last moved*). There is no last move on first registration, and the dialog wording reads as polarity for this move.

## Test plan
- [ ] First Setup Train in Section: click **forward**, confirm stored direction is `"forward"` and the first dispatch uses `*_fwd.xml` (`runInReverse=no`).
- [ ] Click **reverse** → `*_rvs.xml`.
- [ ] Save/reload Setup Train table: dropdown still matches the click.
- [ ] After a completed hop, later moves still follow `set_direction()` last-moved.

Not in this PR: Layout Editor END_BUMPER facing slots; Java Dispatcher; other HART overlays.


Made with [Cursor](https://cursor.com)