### PR TITLE
WIP - Add startup action: Wait for LogixNG Module

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -700,4 +700,8 @@
         <a id="Misc" name="Misc"></a>
         <ul>
             <li>Fix the <strong>Current Config file</strong> path in <strong>Help &rArr; File Locations</strong>.</li>
+            <li>The startup option <strong>Wait for LogixNG Module</strong> has been added.
+                It evaluates a LogixNG Digital Expression Module over and over again and
+                waits until the module returns true. This is useful if you need to wait
+                for some condition during the startup of JMRI.</li>
         </ul>

--- a/java/src/jmri/jmrit/logixng/LogixNG_Manager.java
+++ b/java/src/jmri/jmrit/logixng/LogixNG_Manager.java
@@ -311,6 +311,18 @@ public interface LogixNG_Manager extends Manager<LogixNG> {
             throws IllegalArgumentException;
 
     /**
+     * Evaluates a LogixNG Digital Expression Module.
+     * Note that the module must be a Digital Action Module.
+     * @param module      The module to be executed
+     * @param parameters  The parameters
+     * @return            The return value of the evaluation of the module
+     * @throws IllegalArgumentException If module or parameters is null or if module
+     *                    is not a DigitalExpressionModule.
+     */
+    boolean evaluateModule(Module module, Map<String, Object> parameters)
+            throws IllegalArgumentException;
+
+    /**
      * Get the female socket of the error handling module.
      * @return the socket.
      */

--- a/java/src/jmri/jmrit/logixng/implementation/DefaultConditionalNG.java
+++ b/java/src/jmri/jmrit/logixng/implementation/DefaultConditionalNG.java
@@ -1,6 +1,7 @@
 package jmri.jmrit.logixng.implementation;
 
 import java.util.*;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import javax.annotation.Nonnull;
 import javax.swing.JOptionPane;
@@ -163,17 +164,59 @@ public class DefaultConditionalNG extends AbstractBase
 
         LogixNG_Thread thread = LogixNG_Thread.getThread(LogixNG_Thread.DEFAULT_LOGIXNG_THREAD);
         ConditionalNG conditionalNG = new DefaultConditionalNG("IQC0000000", null);
-        InternalFemaleSocket socket = new InternalFemaleSocket(conditionalNG, module, parameters);
+        InternalFemaleActionSocket socket = new InternalFemaleActionSocket(conditionalNG, module, parameters);
         thread.runOnLogixNGEventually(() -> { internalExecute(conditionalNG, socket); });
     }
 
-    private static class InternalFemaleSocket extends DefaultFemaleDigitalActionSocket {
+    /**
+     * Executes a LogixNG Module.
+     * @param module      The module to be executed
+     * @param parameters  The parameters
+     * @return            The return value of the evaluation of the module
+     * @throws IllegalArgumentException when needed
+     */
+    public static boolean evaluateModule(Module module, Map<String, Object> parameters)
+            throws IllegalArgumentException {
+
+        if (module == null) {
+            throw new IllegalArgumentException("The parameter \"module\" is null");
+        }
+        if (!(module.getRootSocket() instanceof DefaultFemaleDigitalExpressionSocket)) {
+            throw new IllegalArgumentException("The module " + module.getDisplayName() + " is not a DigitalExpressionModule");
+        }
+        if (parameters == null) {
+            throw new IllegalArgumentException("The parameter \"parameters\" is null");
+        }
+
+        LogixNG_Thread thread = LogixNG_Thread.getThread(LogixNG_Thread.DEFAULT_LOGIXNG_THREAD);
+        ConditionalNG conditionalNG = new DefaultConditionalNG("IQC0000000", null);
+        InternalFemaleExpressionSocket socket = new InternalFemaleExpressionSocket(conditionalNG, module, parameters);
+        AtomicBoolean result = new AtomicBoolean(false);
+        AtomicBoolean completed = new AtomicBoolean(false);
+        thread.runOnLogixNGEventually(() -> {
+            result.set(internalEvaluate(conditionalNG, socket));
+            completed.set(true);
+        });
+
+        while (!completed.get()) {
+            try {
+                Thread.sleep(100);
+            } catch (InterruptedException e) {
+                log.warn("Evaluation of LogixNG Module was prematurely aborted");
+                return false;
+            }
+        }
+
+        return result.get();
+    }
+
+    private static class InternalFemaleActionSocket extends DefaultFemaleDigitalActionSocket {
 
         private final ConditionalNG _conditionalNG;
         private final Module _module;
         private final Map<String, Object> _parameters;
 
-        public InternalFemaleSocket(ConditionalNG conditionalNG, Module module, Map<String, Object> parameters) {
+        public InternalFemaleActionSocket(ConditionalNG conditionalNG, Module module, Map<String, Object> parameters) {
             super(null, new FemaleSocketListener(){
                 @Override
                 public void connected(FemaleSocket socket) {
@@ -214,6 +257,59 @@ public class DefaultConditionalNG extends AbstractBase
 
                 ((DefaultFemaleDigitalActionSocket)socket).execute();
                 _conditionalNG.setSymbolTable(oldSymbolTable);
+            }
+        }
+    }
+
+    private static class InternalFemaleExpressionSocket extends DefaultFemaleDigitalExpressionSocket {
+
+        private final ConditionalNG _conditionalNG;
+        private final Module _module;
+        private final Map<String, Object> _parameters;
+
+        public InternalFemaleExpressionSocket(ConditionalNG conditionalNG, Module module, Map<String, Object> parameters) {
+            super(null, new FemaleSocketListener(){
+                @Override
+                public void connected(FemaleSocket socket) {
+                    // Do nothing
+                }
+
+                @Override
+                public void disconnected(FemaleSocket socket) {
+                    // Do nothing
+                }
+            }, "A");
+            _conditionalNG = conditionalNG;
+            _module = module;
+            _parameters = parameters;
+        }
+
+        @Override
+        public boolean evaluate() throws JmriException {
+            FemaleSocket socket = _module.getRootSocket();
+            if (!(socket instanceof DefaultFemaleDigitalExpressionSocket)) {
+                throw new IllegalArgumentException("The module " + _module.getDisplayName() + " is not a DigitalExpressionModule");
+            }
+
+            synchronized(this) {
+                SymbolTable oldSymbolTable = _conditionalNG.getSymbolTable();
+                DefaultSymbolTable newSymbolTable = new DefaultSymbolTable(_conditionalNG);
+                List<Module.ParameterData> _parameterData = new ArrayList<>();
+                for (Module.Parameter p : _module.getParameters()) {
+                    _parameterData.add(new Module.ParameterData(
+                            p.getName(), SymbolTable.InitialValueType.None, "",
+                            Module.ReturnValueType.None, ""));
+                }
+                newSymbolTable.createSymbols(_conditionalNG.getSymbolTable(), _parameterData);
+                for (var entry : _parameters.entrySet()) {
+                    newSymbolTable.setValue(entry.getKey(), entry.getValue());
+                }
+                _conditionalNG.setSymbolTable(newSymbolTable);
+
+                boolean result = ((DefaultFemaleDigitalExpressionSocket)socket).evaluate();
+                _conditionalNG.setSymbolTable(oldSymbolTable);
+
+                return result;
             }
         }
     }
@@ -283,6 +379,72 @@ public class DefaultConditionalNG extends AbstractBase
 
             conditionalNG.setSymbolTable(newSymbolTable.getPrevSymbolTable());
         }
+    }
+
+    private static boolean internalEvaluate(ConditionalNG conditionalNG, FemaleDigitalExpressionSocket femaleSocket) {
+
+        boolean result = false;
+
+        if (conditionalNG.isEnabled()) {
+            DefaultSymbolTable newSymbolTable = new DefaultSymbolTable(conditionalNG);
+
+            try {
+                conditionalNG.setCurrentConditionalNG(conditionalNG);
+
+                conditionalNG.setSymbolTable(newSymbolTable);
+
+                LogixNG logixNG = conditionalNG.getLogixNG();
+                InlineLogixNG inlineLogixNG = null;
+                if (logixNG != null) {
+                    inlineLogixNG = logixNG.getInlineLogixNG();
+                }
+                if (inlineLogixNG != null) {
+                    List<SymbolTable.VariableData> localVariables = new ArrayList<>();
+                    localVariables.add(new SymbolTable.VariableData(
+                            "__InlineLogixNG__", SymbolTable.InitialValueType.String,
+                            inlineLogixNG.getNameString()));
+//                    localVariables.add(new SymbolTable.VariableData(
+//                            "__PositionableId__", SymbolTable.InitialValueType.String,
+//                            inlineLogixNG.getId()));
+                    localVariables.add(new SymbolTable.VariableData(
+                            "__Editor__", SymbolTable.InitialValueType.String,
+                            inlineLogixNG.getEditorName()));
+                    newSymbolTable.createSymbols(localVariables);
+                }
+
+                result = femaleSocket.evaluate();
+            } catch (AbortConditionalNG_IgnoreException | ReturnException | ExitException e) {
+                // A AbortConditionalNG_IgnoreException should be ignored.
+                // A Return action in a ConditionalNG causes a ReturnException so this is okay.
+                // An Exit action in a ConditionalNG causes a ExitException so this is okay.
+            } catch (ValidationErrorException e) {
+                ThreadingUtil.runOnGUI(()->
+                        JOptionPane.showMessageDialog(null,
+                                e.getMessage(),
+                                Bundle.getMessage("LogixNG_ValidationError"),
+                                JOptionPane.ERROR_MESSAGE)
+                );
+            } catch (PassThruException e) {
+                // This happens due to a a Break action or a Continue action that isn't handled.
+                log.info("ConditionalNG {} was aborted during execute: {}",
+                        conditionalNG.getSystemName(), e.getCause(), e.getCause());
+            } catch (AbortConditionalNGExecutionException e) {
+                if (InstanceManager.getDefault(LogixNGPreferences.class).getShowSystemNameInException()) {
+                    log.warn("ConditionalNG {} was aborted during execute in the item {}: {}",
+                            conditionalNG.getSystemName(), e.getMaleSocket().getSystemName(), e.getCause(), e.getCause());
+                } else {
+                    log.warn("ConditionalNG {} was aborted during execute: {}",
+                            conditionalNG.getSystemName(), e.getCause(), e.getCause());
+                }
+            } catch (JmriException | RuntimeException e) {
+                log.warn("ConditionalNG {} got an exception during execute: {}",
+                        conditionalNG.getSystemName(), e, e);
+            }
+
+            conditionalNG.setSymbolTable(newSymbolTable.getPrevSymbolTable());
+        }
+
+        return result;
     }
 
     private static class ExecuteTask implements ThreadingUtil.ThreadAction {

--- a/java/src/jmri/jmrit/logixng/implementation/DefaultLogixNGManager.java
+++ b/java/src/jmri/jmrit/logixng/implementation/DefaultLogixNGManager.java
@@ -547,6 +547,13 @@ public class DefaultLogixNGManager extends AbstractManager<LogixNG>
 
     /** {@inheritDoc} */
     @Override
+    public boolean evaluateModule(Module module, Map<String, Object> parameters)
+            throws IllegalArgumentException {
+        return DefaultConditionalNG.evaluateModule(module, parameters);
+    }
+
+    /** {@inheritDoc} */
+    @Override
     public FemaleSocket getErrorHandlingModuleSocket() {
         return AbstractMaleSocket.getErrorHandlingModuleSocket();
     }

--- a/java/src/jmri/jmrit/logixng/startup/Bundle.java
+++ b/java/src/jmri/jmrit/logixng/startup/Bundle.java
@@ -1,0 +1,115 @@
+package jmri.jmrit.logixng.startup;
+
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+import java.util.Locale;
+
+import javax.annotation.CheckReturnValue;
+import javax.annotation.CheckForNull;
+import javax.annotation.ParametersAreNonnullByDefault;
+
+@ParametersAreNonnullByDefault
+@CheckReturnValue
+@SuppressFBWarnings(value = {"NM_SAME_SIMPLE_NAME_AS_SUPERCLASS", "HSM_HIDING_METHOD"},
+    justification = "Desired pattern is repeated class names with package-level access to members")
+
+@javax.annotation.concurrent.Immutable
+
+/**
+ * Provides standard access for resource bundles in a package.
+ *
+ * Convention is to provide a subclass of this name in each package, working off
+ * the local resource bundle name.
+ *
+ * @author Bob Jacobsen Copyright (C) 2012
+ * @since 3.3.1
+ */
+public class Bundle extends jmri.jmrit.logixng.Bundle {
+
+    @CheckForNull
+    private static final String name = "jmri.jmrit.logixng.startup.StartupBundle";
+
+    //
+    // below here is boilerplate to be copied exactly
+    //
+    /**
+     * Provides a translated string for a given key from the package resource
+     * bundle or parent.
+     * <p>
+     * Note that this is intentionally package-local access.
+     *
+     * @param key Bundle key to be translated
+     * @return Internationalized text
+     */
+    static String getMessage(String key) {
+        return getBundle().handleGetMessage(key);
+    }
+
+    /**
+     * Provides a translated string for a given key in a given locale from the
+     * package resource bundle or parent.
+     * <p>
+     * Note that this is intentionally package-local access.
+     *
+     * @param locale The locale to be used
+     * @param key    Bundle key to be translated
+     * @return Internationalized text
+     */
+    static String getMessage(Locale locale, String key) {
+        return getBundle().handleGetMessage(locale, key);
+    }
+
+    /**
+     * Merges user data with a translated string for a given key from the
+     * package resource bundle or parent.
+     * <p>
+     * Uses the transformation conventions of the Java MessageFormat utility.
+     * <p>
+     * Note that this is intentionally package-local access.
+     *
+     * @see java.text.MessageFormat
+     * @param key  Bundle key to be translated
+     * @param subs One or more objects to be inserted into the message
+     * @return Internationalized text
+     */
+    static String getMessage(String key, Object... subs) {
+        return getBundle().handleGetMessage(key, subs);
+    }
+
+    /**
+     * Merges user data with a translated string for a given key in a given
+     * locale from the package resource bundle or parent.
+     * <p>
+     * Uses the transformation conventions of the Java MessageFormat utility.
+     * <p>
+     * Note that this is intentionally package-local access.
+     *
+     * @see java.text.MessageFormat
+     * @param locale The locale to be used
+     * @param key    Bundle key to be translated
+     * @param subs   One or more objects to be inserted into the message
+     * @return Internationalized text
+     */
+    static String getMessage(Locale locale, String key, Object... subs) {
+        return getBundle().handleGetMessage(locale, key, subs);
+    }
+
+    private static final Bundle b = new Bundle();
+
+    @Override
+    @CheckForNull
+    protected String bundleName() {
+        return name;
+    }
+
+    protected static jmri.Bundle getBundle() {
+        return b;
+    }
+
+    @Override
+    protected String retry(Locale locale, String key) {
+        return super.getBundle().handleGetMessage(locale, key);
+    }
+
+}

--- a/java/src/jmri/jmrit/logixng/startup/LogixNG_StartupPauseFactory.java
+++ b/java/src/jmri/jmrit/logixng/startup/LogixNG_StartupPauseFactory.java
@@ -16,7 +16,7 @@ import jmri.util.swing.JmriJOptionPane;
 import org.openide.util.lookup.ServiceProvider;
 
 /**
- * Factory for {@link apps.startup.LogixNG_StartupPauseModel} objects.
+ * Factory for {@link LogixNG_StartupPauseModel} objects.
  *
  * @author Randall Wood     (C) 2016
  * @author Daniel Bergqvist (C) 2026

--- a/java/src/jmri/jmrit/logixng/startup/LogixNG_StartupPauseFactory.java
+++ b/java/src/jmri/jmrit/logixng/startup/LogixNG_StartupPauseFactory.java
@@ -1,0 +1,122 @@
+package jmri.jmrit.logixng.startup;
+
+import java.awt.Component;
+
+import javax.swing.*;
+
+import jmri.InstanceManager;
+import jmri.jmrit.logixng.Module;
+import jmri.jmrit.logixng.ModuleManager;
+import jmri.util.startup.StartupModelFactory;
+import jmri.util.startup.StartupModel;
+import jmri.util.startup.StartupActionsManager;
+import jmri.util.swing.JComboBoxUtil;
+import jmri.util.swing.JmriJOptionPane;
+
+import org.openide.util.lookup.ServiceProvider;
+
+/**
+ * Factory for {@link apps.startup.LogixNG_StartupPauseModel} objects.
+ *
+ * @author Randall Wood     (C) 2016
+ * @author Daniel Bergqvist (C) 2026
+ */
+@ServiceProvider(service = StartupModelFactory.class)
+public class LogixNG_StartupPauseFactory implements StartupModelFactory {
+
+    @Override
+    public Class<? extends StartupModel> getModelClass() {
+        return LogixNG_StartupPauseModel.class;
+    }
+
+    @Override
+    public StartupModel newModel() {
+        return new LogixNG_StartupPauseModel();
+    }
+
+    @Override
+    public String getDescription() {
+        return Bundle.getMessage("WaitForLogixNGModuleDescription");
+    }
+
+    @Override
+    public String getActionText() {
+        return Bundle.getMessage("WaitForLogixNGModuleText", this.getDescription()); // NOI18N
+    }
+
+    @Override
+    public void editModel(StartupModel model, Component parent) {
+        if (model instanceof LogixNG_StartupPauseModel && this.getModelClass().isInstance(model)) {
+            LogixNG_StartupPauseModel theModel = (LogixNG_StartupPauseModel) model;
+
+            String moduleName = theModel.getModuleName();
+
+            Module module = null;
+            if (moduleName != null) {
+                module = InstanceManager.getDefault(ModuleManager.class).getModule(moduleName);
+            }
+
+            JComboBox<ModuleItem> moduleComboBox = new JComboBox<>();
+            moduleComboBox.addItem(new ModuleItem(null));
+            for (Module m : InstanceManager.getDefault(ModuleManager.class).getNamedBeanSet()) {
+    //            System.out.format("Root socket type: %s%n", m.getRootSocketType().getName());
+                if ("DefaultFemaleDigitalExpressionSocket".equals(m.getRootSocketType().getName())) {
+                    ModuleItem mi = new ModuleItem(m);
+                    moduleComboBox.addItem(mi);
+                    if (module == m) {
+                        moduleComboBox.setSelectedItem(mi);
+                    }
+                }
+            }
+            JComboBoxUtil.setupComboBoxMaxRows(moduleComboBox);
+
+            int result = JmriJOptionPane.showConfirmDialog(parent,
+                    this.getDialogMessage(moduleComboBox),
+                    this.getDescription(),
+                    JmriJOptionPane.OK_CANCEL_OPTION,
+                    JmriJOptionPane.PLAIN_MESSAGE);
+
+            Module newModule = null;
+            if (moduleComboBox.getSelectedIndex() != -1) {
+                newModule = moduleComboBox.getItemAt(moduleComboBox.getSelectedIndex())._module;
+            }
+            if (result == JmriJOptionPane.OK_OPTION && module != newModule) {
+                if (newModule != null) {
+                    theModel.setModuleName(newModule.getDisplayName());
+                } else {
+                    theModel.setModuleName(null);
+                }
+                InstanceManager.getDefault(StartupActionsManager.class).setRestartRequired();
+            }
+        }
+    }
+
+    @Override
+    public void initialize() {
+        // nothing to do
+    }
+
+    private JPanel getDialogMessage(JComboBox<ModuleItem> comboBox) {
+        JPanel panel = new JPanel();
+        panel.add(new JLabel(Bundle.getMessage("WaitForLogixNGModule_SelectModule"))); // NOI18N
+        panel.add(comboBox);
+        return panel;
+    }
+
+
+    private static class ModuleItem {
+
+        private final Module _module;
+
+        public ModuleItem(Module m) {
+            _module = m;
+        }
+
+        @Override
+        public String toString() {
+            if (_module == null) return "";
+            else return _module.getDisplayName();
+        }
+    }
+
+}

--- a/java/src/jmri/jmrit/logixng/startup/LogixNG_StartupPauseModel.java
+++ b/java/src/jmri/jmrit/logixng/startup/LogixNG_StartupPauseModel.java
@@ -1,0 +1,85 @@
+package jmri.jmrit.logixng.startup;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.annotation.CheckForNull;
+
+import jmri.*;
+import jmri.jmrit.logixng.*;
+import jmri.jmrit.logixng.Module;
+import jmri.util.startup.AbstractStartupModel;
+
+/**
+ * A startup action that evaluates a LogixNG Digital Module and waits until it returns true.
+ *
+ * @author Randall Wood     (C) 2016
+ * @author Daniel Bergqvist (C) 2026
+ */
+public class LogixNG_StartupPauseModel extends AbstractStartupModel {
+
+    private String _moduleName;
+
+    public void setModuleName(String moduleName) {
+        log.info("setModule: {}", _moduleName);
+        _moduleName = moduleName;
+    }
+
+    @CheckForNull
+    public String getModuleName() {
+        log.info("getModule: {}", _moduleName);
+        return _moduleName;
+    }
+
+    @Override
+    public String getName() {
+        if (_moduleName != null) {
+            return Bundle.getMessage("LogixNG_StartupPauseModel.name", _moduleName);
+        } else {
+            return Bundle.getMessage("LogixNG_StartupPauseModel.name_NoModule");
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return true if we have a valid module
+     */
+    @Override
+    public boolean isValid() {
+        if (_moduleName != null) {
+            Module module = InstanceManager.getDefault(ModuleManager.class).getModule(_moduleName);
+            return module != null;
+        } else {
+            return false;
+        }
+    }
+
+    @Override
+    public void performAction() throws JmriException {
+        // We need to ensure that all the LogixNGs are setup
+        InstanceManager.getDefault(LogixNG_Manager.class).setupAllLogixNGs();
+
+        Module module = InstanceManager.getDefault(ModuleManager.class).getModule(_moduleName);
+
+        if (module != null) {
+            Map<String, Object> parameters = new HashMap<>();
+            log.info("Pausing startup actions processing until LogixNG Module \"{}\" returns true.", module.getDisplayName());
+            try {
+                while (true) {
+                    boolean result = InstanceManager.getDefault(LogixNG_Manager.class)
+                            .evaluateModule(module, parameters);
+                    log.info("Waiting for LogixNG Module \"{}\" to return true. Last result: {}", module.getDisplayName(), result);
+                    if (result) return;
+                    Thread.sleep(100);
+                }
+            } catch (InterruptedException ex) {
+                // warn the user that the pause was not as long as expected
+                // this does not throw an error displayed to the user; should it?
+                log.info("Pause in startup actions interrupted.");
+            }
+        }
+    }
+
+    private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(LogixNG_StartupPauseModel.class);
+}

--- a/java/src/jmri/jmrit/logixng/startup/LogixNG_StartupPauseModel.java
+++ b/java/src/jmri/jmrit/logixng/startup/LogixNG_StartupPauseModel.java
@@ -1,13 +1,18 @@
 package jmri.jmrit.logixng.startup;
 
+import java.awt.*;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 
 import javax.annotation.CheckForNull;
+import javax.swing.*;
 
 import jmri.*;
 import jmri.jmrit.logixng.*;
 import jmri.jmrit.logixng.Module;
+import jmri.util.ThreadingUtil;
 import jmri.util.startup.AbstractStartupModel;
 
 /**
@@ -57,6 +62,40 @@ public class LogixNG_StartupPauseModel extends AbstractStartupModel {
 
     @Override
     public void performAction() throws JmriException {
+        AtomicBoolean abort = new AtomicBoolean();
+        AtomicReference<JFrame> frameRef = new AtomicReference<>();
+
+        // Give the user an ability to abort
+        if (!GraphicsEnvironment.isHeadless()) {
+            ThreadingUtil.runOnGUI(() -> {
+                JFrame frame = new JFrame("Waiting for LogixNG Module");
+                JLabel labelAbort = new JLabel(Bundle.getMessage("WaitForLogixNGModule_AbortInfo"));
+                JButton buttonAbort = new JButton(Bundle.getMessage("WaitForLogixNGModule_Abort"));
+                buttonAbort.addActionListener(e -> {
+                    log.error("Daniel");
+                    abort.set(true);
+                });
+                JPanel panel = new JPanel();
+                panel.add(labelAbort);
+                panel.add(buttonAbort);
+                frame.setContentPane(panel);
+                frame.pack();
+
+                // Center the window and pad the frame size slightly
+                Dimension screenDim = Toolkit.getDefaultToolkit().getScreenSize();
+                Rectangle winDim = frame.getBounds();
+                winDim.height = winDim.height + 50;
+                winDim.width = winDim.width + 50;
+                frame.setLocation((screenDim.width - winDim.width) / 2,
+                        (screenDim.height - winDim.height) / 2);
+                frame.setSize(winDim.width, winDim.height);
+
+                frame.setVisible(true);
+
+                frameRef.set(frame);
+            });
+        }
+
         // We need to ensure that all the LogixNGs are setup
         InstanceManager.getDefault(LogixNG_Manager.class).setupAllLogixNGs();
 
@@ -70,7 +109,11 @@ public class LogixNG_StartupPauseModel extends AbstractStartupModel {
                     boolean result = InstanceManager.getDefault(LogixNG_Manager.class)
                             .evaluateModule(module, parameters);
                     log.info("Waiting for LogixNG Module \"{}\" to return true. Last result: {}", module.getDisplayName(), result);
-                    if (result) return;
+                    if (result) break;
+                    if (abort.get()) {
+                        log.warn("Aborted by user");
+                        break;
+                    }
                     Thread.sleep(100);
                 }
             } catch (InterruptedException ex) {
@@ -78,6 +121,11 @@ public class LogixNG_StartupPauseModel extends AbstractStartupModel {
                 // this does not throw an error displayed to the user; should it?
                 log.info("Pause in startup actions interrupted.");
             }
+        }
+
+        JFrame frame = frameRef.get();
+        if (frame != null) {
+            frame.dispose();
         }
     }
 

--- a/java/src/jmri/jmrit/logixng/startup/StartupBundle.properties
+++ b/java/src/jmri/jmrit/logixng/startup/StartupBundle.properties
@@ -6,3 +6,6 @@ LogixNG_StartupPauseModel.name_NoModule      = Wait for LogixNG Module to return
 WaitForLogixNGModuleDescription     = Wait for LogixNG Module
 WaitForLogixNGModuleText            = Wait for LogixNG Module...
 WaitForLogixNGModule_SelectModule   = Select module: 
+
+WaitForLogixNGModule_Abort          = Abort
+WaitForLogixNGModule_AbortInfo      = Press to abort the startup delay

--- a/java/src/jmri/jmrit/logixng/startup/StartupBundle.properties
+++ b/java/src/jmri/jmrit/logixng/startup/StartupBundle.properties
@@ -1,0 +1,8 @@
+# jmri.jmrit.logixng.startup.StartupBundle.properties
+
+LogixNG_StartupPauseModel.name      = Wait for LogixNG Module "{0}" to return true
+LogixNG_StartupPauseModel.name_NoModule      = Wait for LogixNG Module to return true: No module
+
+WaitForLogixNGModuleDescription     = Wait for LogixNG Module
+WaitForLogixNGModuleText            = Wait for LogixNG Module...
+WaitForLogixNGModule_SelectModule   = Select module: 

--- a/java/src/jmri/jmrit/logixng/startup/configurexml/LogixNG_StartupPauseModelXml.java
+++ b/java/src/jmri/jmrit/logixng/startup/configurexml/LogixNG_StartupPauseModelXml.java
@@ -1,0 +1,69 @@
+package jmri.jmrit.logixng.startup.configurexml;
+
+import jmri.InstanceManager;
+import jmri.configurexml.AbstractXmlAdapter;
+import jmri.jmrit.logixng.startup.LogixNG_StartupPauseModel;
+import jmri.util.startup.StartupActionsManager;
+
+import org.jdom2.Attribute;
+import org.jdom2.Element;
+
+/**
+ * Handle XML persistence for {@link jmri.jmrit.logixng.startup.LogixNG_StartupPauseModel} objects.
+ *
+ * @author Randall Wood     (C) 2016
+ * @author Daniel Bergqvist (C) 2026
+ */
+public class LogixNG_StartupPauseModelXml extends AbstractXmlAdapter {
+
+    public LogixNG_StartupPauseModelXml() {
+    }
+
+    @Override
+    public Element store(Object o) {
+        String moduleName = ((LogixNG_StartupPauseModel) o).getModuleName();
+
+        Element element = new Element("perform"); // NOI18N
+        element.setAttribute("name", "Pause");
+        element.setAttribute("type", "Pause");
+        element.setAttribute("enabled", ((LogixNG_StartupPauseModel) o).isEnabled() ? "yes" : "no");
+        element.setAttribute("class", this.getClass().getName());
+        Element property = new Element("property"); // NOI18N
+        property.setAttribute("name", "module"); // NOI18N
+        property.setAttribute("value", moduleName != null ? moduleName : "");
+        element.addContent(property);
+        return element;
+    }
+
+    @Override
+    public boolean loadDeferred() {
+        return true;
+    }
+
+    @Override
+    public boolean load(Element shared, Element perNode) {
+        boolean result = false;
+        LogixNG_StartupPauseModel model = new LogixNG_StartupPauseModel();
+
+        Attribute enabled = shared.getAttribute("enabled");
+        if (enabled != null) {
+            model.setEnabled("yes".equals(enabled.getValue()));
+        } else {
+            model.setEnabled(true);
+        }
+
+        for (Element child : shared.getChildren("property")) {
+            if (child.getAttributeValue("name").equals("module")
+                    && !child.getAttributeValue("value").isEmpty()) {
+                model.setModuleName(child.getAttributeValue("value"));
+            }
+        }
+
+        // store the model
+        InstanceManager.getDefault(StartupActionsManager.class).addAction(model);
+        return result;
+    }
+
+//    private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(LogixNG_StartupPauseModelXml.class);
+
+}


### PR DESCRIPTION
For background:
https://groups.io/g/jmriusers/message/254904

This PR adds a startup option `Wait for LogixNG Module` which every 100ms evaluates a LogixNG Module and waits until the evaluation returns true. It also shows a dialog if not headless that gives the user the option to abort the delay.

An example profile:
[TestLogixNGStartupDelay.jmri.zip](https://github.com/user-attachments/files/31400292/TestLogixNGStartupDelay.jmri.zip)

To get the LogixNG Module to return true, create the file `startup_completed.txt` in the profile folder. An easy way to do that on Linux and Mac is running the command: `touch startup_completed.txt`