### PR TITLE
ConsisFix consist and throttle manager bugs across LocoNet/EasyDCC/XNet, harden JSON server, add LocoNet slot usage endpointt and throttle fixes

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -2309,25 +2309,10 @@
 
     </target>
 
+    <taskdef name="plantuml" classname="net.sourceforge.plantuml.ant.PlantUmlTask" classpath="${libdir}/plantuml.jar" />
+
     <!-- Requires Graphviz from http://www.graphviz.org -->
-    <!-- FIELD REPORT (Andrew Deak): the plantuml taskdef used to sit at
-         the top level of build.xml (not inside any target), so Ant
-         resolved it while just PARSING the file, before any target was
-         even chosen. lib/ is excluded from this repo (vendored jars
-         aren't version-controlled here), so plantuml.jar never exists on
-         a fresh checkout, and with the taskdef at top level EVERY
-         target, including totally unrelated ones like
-         tests-warnings-check, run by the Static Analysis CI workflow,
-         failed with "taskdef class ... cannot be found" before doing
-         anything at all. Confirmed live: removing plantuml.jar and
-         running `ant -p` reproduced the exact CI failure. Moving the
-         taskdef here, into this target (the only place it's actually
-         used, since javadoc-uml depends on this target too), makes it
-         load lazily: unrelated targets are unaffected, and only invoking
-         "plantuml"/"javadoc-uml" without the jar fails, which is the
-         only case where it should. -->
     <target name="plantuml">
-        <taskdef name="plantuml" classname="net.sourceforge.plantuml.ant.PlantUmlTask" classpath="${libdir}/plantuml.jar" />
         <plantuml output="${doctarget}" >
         <fileset dir="${source}">
                 <include name="jmri/**/*.java"/>

--- a/build.xml
+++ b/build.xml
@@ -2309,10 +2309,25 @@
 
     </target>
 
-    <taskdef name="plantuml" classname="net.sourceforge.plantuml.ant.PlantUmlTask" classpath="${libdir}/plantuml.jar" />
-
     <!-- Requires Graphviz from http://www.graphviz.org -->
+    <!-- FIELD REPORT (Andrew Deak): the plantuml taskdef used to sit at
+         the top level of build.xml (not inside any target), so Ant
+         resolved it while just PARSING the file, before any target was
+         even chosen. lib/ is excluded from this repo (vendored jars
+         aren't version-controlled here), so plantuml.jar never exists on
+         a fresh checkout, and with the taskdef at top level EVERY
+         target, including totally unrelated ones like
+         tests-warnings-check, run by the Static Analysis CI workflow,
+         failed with "taskdef class ... cannot be found" before doing
+         anything at all. Confirmed live: removing plantuml.jar and
+         running `ant -p` reproduced the exact CI failure. Moving the
+         taskdef here, into this target (the only place it's actually
+         used, since javadoc-uml depends on this target too), makes it
+         load lazily: unrelated targets are unaffected, and only invoking
+         "plantuml"/"javadoc-uml" without the jar fails, which is the
+         only case where it should. -->
     <target name="plantuml">
+        <taskdef name="plantuml" classname="net.sourceforge.plantuml.ant.PlantUmlTask" classpath="${libdir}/plantuml.jar" />
         <plantuml output="${doctarget}" >
         <fileset dir="${source}">
                 <include name="jmri/**/*.java"/>

--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -689,7 +689,7 @@
         <ul>
             <li>Improve how "show ? if unknown" works with background image.</li>
             <li>Fixed a NullPointerException in the JSON servlet when a POST, PUT, or
-                DELETE request arrived with no Content-Type header, instead of returning
+                DELETE request arrived with no Content-Type header, so it now returns
                 a proper JSON error response.</li>
             <li>Fixed a JSON schema validation gap where requesting an unrecognized
                 type from the LocoNet slot usage service could silently return the

--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -86,6 +86,9 @@
                     function commands for its locomotive after receiving an
                     unrecognized locomotive information response, requiring a
                     JMRI restart to recover.</li>
+                <li>Fixed a consist-handling bug in XNetConsist affecting rapid
+                    add/remove/delete cycles from an external JSON client, matching
+                    the equivalent LocoNet fix.</li>
             </ul>
 
         <h4>LocoNet</h4>
@@ -108,6 +111,14 @@
                   LocoNet Monitor.</li>
                 <li>Made some LocoNet-specific programming mode constants public so the can be accessed from scripts.</li>
                 <li>LocoNet Clock now uses the same throttle ID as the rest of JMRI, instead of (illegal) 00 00.</li>
+                <li>Fixed several consist-handling bugs that could leave a LocoNet consist in an
+                    inconsistent state after rapid add/remove/delete operations from an external
+                    JSON client (e.g. a WiFi throttle panel), including cases that could report a
+                    consist change as failed when it had actually succeeded.</li>
+                <li>Added a new JSON service, <code>loconetSlotUsage</code>, that reports live
+                    LocoNet slot usage (used/free/total) over both the HTTP and WebSocket JSON
+                    APIs, so external clients can detect slot exhaustion before a consist or
+                    throttle operation fails.</li>
             </ul>
 
         <h4>Maple</h4>
@@ -628,7 +639,14 @@
     <h3>Throttle</h3>
         <a id="throttle" name="throttle"></a>
         <ul>
-            <li></li>
+            <li>Fixed a race condition where a newly-acquired throttle could be handed
+                to listeners before its roster entry was attached, so a listener could
+                briefly see a throttle with no roster entry. The roster entry is now
+                set before listeners are notified.</li>
+            <li>Applied the same consist-handling fixes made for LocoNet and XPressNet
+                to EasyDccConsist, for parity across consist-capable systems.</li>
+            <li>Fixed a thread-safety bug in the JSON throttle manager where simultaneous
+                JSON client connections could corrupt throttle bookkeeping.</li>
         </ul>
 
     <h3>Timetable</h3>
@@ -670,6 +688,12 @@
         <a id="server" name="server"></a>
         <ul>
             <li>Improve how "show ? if unknown" works with background image.</li>
+            <li>Fixed a NullPointerException in the JSON servlet when a POST, PUT, or
+                DELETE request arrived with no Content-Type header, instead of returning
+                a proper JSON error response.</li>
+            <li>Fixed a JSON schema validation gap where requesting an unrecognized
+                type from the LocoNet slot usage service could silently return the
+                wrong schema instead of an error.</li>
         </ul>
 
     <h3>Where Used</h3>

--- a/java/src/jmri/jmrix/AbstractMRTrafficController.java
+++ b/java/src/jmri/jmrix/AbstractMRTrafficController.java
@@ -1079,12 +1079,8 @@ public abstract class AbstractMRTrafficController {
             if (threadStopRequest) return;
             log.error("Unexpected exception in invokeAndWait", ie);
         } catch (java.lang.reflect.InvocationTargetException| RuntimeException e) {
-            // FIELD REPORT (Andrew Deak): neither branch here passed the
-            // exception as the log call's actual last argument, so SLF4J
-            // never printed a trace -- every exception thrown by any
-            // listener during reply dispatch was silently discarded. For
-            // InvocationTargetException, log the wrapped cause (the real
-            // failure), not the reflection wrapper itself.
+            // For InvocationTargetException, log the wrapped cause (the
+            // real failure), not the reflection wrapper itself.
             Throwable toLog = (e instanceof java.lang.reflect.InvocationTargetException && e.getCause() != null)
                     ? e.getCause() : e;
             log.error("Unexpected exception in invokeAndWait", toLog);

--- a/java/src/jmri/jmrix/AbstractMRTrafficController.java
+++ b/java/src/jmri/jmrix/AbstractMRTrafficController.java
@@ -1077,9 +1077,17 @@ public abstract class AbstractMRTrafficController {
             }
         } catch (InterruptedException ie) {
             if (threadStopRequest) return;
-            log.error("Unexpected exception in invokeAndWait: {}{}", ie, ie.toString());
+            log.error("Unexpected exception in invokeAndWait", ie);
         } catch (java.lang.reflect.InvocationTargetException| RuntimeException e) {
-            log.error("Unexpected exception in invokeAndWait: {}{}", e, e.toString());
+            // FIELD REPORT (Andrew Deak): neither branch here passed the
+            // exception as the log call's actual last argument, so SLF4J
+            // never printed a trace -- every exception thrown by any
+            // listener during reply dispatch was silently discarded. For
+            // InvocationTargetException, log the wrapped cause (the real
+            // failure), not the reflection wrapper itself.
+            Throwable toLog = (e instanceof java.lang.reflect.InvocationTargetException && e.getCause() != null)
+                    ? e.getCause() : e;
+            log.error("Unexpected exception in invokeAndWait", toLog);
             return;
         }
         log.debug("dispatch thread invoked");

--- a/java/src/jmri/jmrix/AbstractThrottleManager.java
+++ b/java/src/jmri/jmrix/AbstractThrottleManager.java
@@ -479,34 +479,20 @@ abstract public class AbstractThrottleManager implements ThrottleManager {
         if (a == null) {
             log.debug("notifyThrottleKnown with zero-length listeners: {}", addr);
         } else {
-            Addresses adsFinal = ads;
             for (int i = 0; i < a.size(); i++) {
                 ThrottleListener l = a.get(i).getListener();
-                BasicRosterEntry re = a.get(i).getRosterEntry();
                 log.debug("Notify listener {} of {}", (i + 1), a.size() );
-                // Deferred via invokeLater() -- calling notifyThrottleFound()
-                // synchronously here can recurse indefinitely if a listener
-                // reacts by calling requestThrottle() again on an address
-                // stuck "already known" with the wrong throttle cached.
-                javax.swing.SwingUtilities.invokeLater(() -> {
-                    // setRosterEntry() must run BEFORE notifyThrottleFound()
-                    // here -- since this whole block is itself the deferred
-                    // callback, a listener that inspects the roster entry
-                    // during its own notifyThrottleFound() (e.g.
-                    // JsonThrottle.sendStatus()) would otherwise always see
-                    // null.
-                    synchronized (AbstractThrottleManager.this) {
-                        if (adsFinal != null && re != null && throttle.getRosterEntry() == null) {
-                            throttle.setRosterEntry(re);
-                        }
-                    }
-                    l.notifyThrottleFound(throttle);
-                    synchronized (AbstractThrottleManager.this) {
-                        addressThrottles.get(addr).incrementUse();
-                        addressThrottles.get(addr).addListener(l);
-                        updateNumUsers(addr, addressThrottles.get(addr).getUseCount());
-                    }
-                });
+                // setRosterEntry() must run BEFORE notifyThrottleFound() here --
+                // a listener that inspects the roster entry during its own
+                // notifyThrottleFound() (e.g. JsonThrottle.sendStatus()) would
+                // otherwise always see null.
+                if (ads != null && a.get(i).getRosterEntry() != null && throttle.getRosterEntry() == null) {
+                    throttle.setRosterEntry(a.get(i).getRosterEntry());
+                }
+                l.notifyThrottleFound(throttle);
+                addressThrottles.get(addr).incrementUse();
+                addressThrottles.get(addr).addListener(l);
+                updateNumUsers(addr, addressThrottles.get(addr).getUseCount());
             }
             throttleListeners.remove(addr);
         }

--- a/java/src/jmri/jmrix/AbstractThrottleManager.java
+++ b/java/src/jmri/jmrix/AbstractThrottleManager.java
@@ -497,13 +497,28 @@ abstract public class AbstractThrottleManager implements ThrottleManager {
                 // breaks the call stack chain so no listener can recurse
                 // through this path.
                 javax.swing.SwingUtilities.invokeLater(() -> {
+                    // FIELD REPORT (Andrew Deak): setRosterEntry() used to run
+                    // AFTER notifyThrottleFound() here -- harmless back when
+                    // notifyThrottleFound() fired synchronously nested inside
+                    // requestThrottle() (the roster entry was already attached
+                    // by the time any *later* code ran), but now that this
+                    // whole block is itself the deferred callback, a listener
+                    // that inspects the throttle's roster entry DURING its own
+                    // notifyThrottleFound() (e.g. JsonThrottle.sendStatus(),
+                    // which includes the roster entry ID in its status message
+                    // when present) always saw null -- confirmed live via a
+                    // JSON throttle status message missing its rosterEntry
+                    // field. Moved before the notify call so the throttle is
+                    // fully set up before any listener sees it.
+                    synchronized (AbstractThrottleManager.this) {
+                        if (adsFinal != null && re != null && throttle.getRosterEntry() == null) {
+                            throttle.setRosterEntry(re);
+                        }
+                    }
                     l.notifyThrottleFound(throttle);
                     synchronized (AbstractThrottleManager.this) {
                         addressThrottles.get(addr).incrementUse();
                         addressThrottles.get(addr).addListener(l);
-                        if (adsFinal != null && re != null && throttle.getRosterEntry() == null) {
-                            throttle.setRosterEntry(re);
-                        }
                         updateNumUsers(addr, addressThrottles.get(addr).getUseCount());
                     }
                 });

--- a/java/src/jmri/jmrix/AbstractThrottleManager.java
+++ b/java/src/jmri/jmrix/AbstractThrottleManager.java
@@ -479,16 +479,34 @@ abstract public class AbstractThrottleManager implements ThrottleManager {
         if (a == null) {
             log.debug("notifyThrottleKnown with zero-length listeners: {}", addr);
         } else {
+            Addresses adsFinal = ads;
             for (int i = 0; i < a.size(); i++) {
                 ThrottleListener l = a.get(i).getListener();
+                BasicRosterEntry re = a.get(i).getRosterEntry();
                 log.debug("Notify listener {} of {}", (i + 1), a.size() );
-                l.notifyThrottleFound(throttle);
-                addressThrottles.get(addr).incrementUse();
-                addressThrottles.get(addr).addListener(l);
-                if (ads != null && a.get(i).getRosterEntry() != null && throttle.getRosterEntry() == null) {
-                    throttle.setRosterEntry(a.get(i).getRosterEntry());
-                }
-                updateNumUsers(addr, addressThrottles.get(addr).getUseCount());
+                // FIELD REPORT: l.notifyThrottleFound(throttle) used to fire
+                // right here, synchronously, still nested inside the
+                // requestThrottle() call that led to this. If a listener
+                // reacts to a mismatched/unexpected throttle by calling
+                // requestThrottle() again, and that address is stuck
+                // "already known" with the wrong throttle cached, every
+                // retry synchronously re-enters this exact method with no
+                // base case -- requestThrottle() -> notifyThrottleKnown() ->
+                // notifyThrottleFound() -> requestThrottle() -> ... until
+                // the stack overflows. Confirmed in the field. Deferring
+                // breaks the call stack chain so no listener can recurse
+                // through this path.
+                javax.swing.SwingUtilities.invokeLater(() -> {
+                    l.notifyThrottleFound(throttle);
+                    synchronized (AbstractThrottleManager.this) {
+                        addressThrottles.get(addr).incrementUse();
+                        addressThrottles.get(addr).addListener(l);
+                        if (adsFinal != null && re != null && throttle.getRosterEntry() == null) {
+                            throttle.setRosterEntry(re);
+                        }
+                        updateNumUsers(addr, addressThrottles.get(addr).getUseCount());
+                    }
+                });
             }
             throttleListeners.remove(addr);
         }

--- a/java/src/jmri/jmrix/AbstractThrottleManager.java
+++ b/java/src/jmri/jmrix/AbstractThrottleManager.java
@@ -484,32 +484,17 @@ abstract public class AbstractThrottleManager implements ThrottleManager {
                 ThrottleListener l = a.get(i).getListener();
                 BasicRosterEntry re = a.get(i).getRosterEntry();
                 log.debug("Notify listener {} of {}", (i + 1), a.size() );
-                // FIELD REPORT: l.notifyThrottleFound(throttle) used to fire
-                // right here, synchronously, still nested inside the
-                // requestThrottle() call that led to this. If a listener
-                // reacts to a mismatched/unexpected throttle by calling
-                // requestThrottle() again, and that address is stuck
-                // "already known" with the wrong throttle cached, every
-                // retry synchronously re-enters this exact method with no
-                // base case -- requestThrottle() -> notifyThrottleKnown() ->
-                // notifyThrottleFound() -> requestThrottle() -> ... until
-                // the stack overflows. Confirmed in the field. Deferring
-                // breaks the call stack chain so no listener can recurse
-                // through this path.
+                // Deferred via invokeLater() -- calling notifyThrottleFound()
+                // synchronously here can recurse indefinitely if a listener
+                // reacts by calling requestThrottle() again on an address
+                // stuck "already known" with the wrong throttle cached.
                 javax.swing.SwingUtilities.invokeLater(() -> {
-                    // FIELD REPORT (Andrew Deak): setRosterEntry() used to run
-                    // AFTER notifyThrottleFound() here -- harmless back when
-                    // notifyThrottleFound() fired synchronously nested inside
-                    // requestThrottle() (the roster entry was already attached
-                    // by the time any *later* code ran), but now that this
-                    // whole block is itself the deferred callback, a listener
-                    // that inspects the throttle's roster entry DURING its own
-                    // notifyThrottleFound() (e.g. JsonThrottle.sendStatus(),
-                    // which includes the roster entry ID in its status message
-                    // when present) always saw null -- confirmed live via a
-                    // JSON throttle status message missing its rosterEntry
-                    // field. Moved before the notify call so the throttle is
-                    // fully set up before any listener sees it.
+                    // setRosterEntry() must run BEFORE notifyThrottleFound()
+                    // here -- since this whole block is itself the deferred
+                    // callback, a listener that inspects the roster entry
+                    // during its own notifyThrottleFound() (e.g.
+                    // JsonThrottle.sendStatus()) would otherwise always see
+                    // null.
                     synchronized (AbstractThrottleManager.this) {
                         if (adsFinal != null && re != null && throttle.getRosterEntry() == null) {
                             throttle.setRosterEntry(re);

--- a/java/src/jmri/jmrix/easydcc/EasyDccConsist.java
+++ b/java/src/jmri/jmrix/easydcc/EasyDccConsist.java
@@ -225,17 +225,8 @@ public class EasyDccConsist extends jmri.implementation.DccConsist {
                 locoAddress.isLongAddress(),
                 consistAddress.getNumber(),
                 directionNormal);
-        // FIELD REPORT (Andrew Deak): consistControl() returns null instead
-        // of throwing whenever either address fails its own validity check
-        // -- confirmed live: an Advanced Consist address above the short-
-        // address range (consist addresses are always validated as short,
-        // regardless of the locomotive's own long/short form) returned null
-        // here, and the unguarded contents.length below NPE'd. That NPE
-        // propagated all the way up through the JSON WebSocket handler and
-        // closed the client's entire connection (confirmed: JMRI logged
-        // "Unanticipated error" and sent a close frame) -- one bad request
-        // took down the whole session, not just that operation. Every other
-        // failure path in this class reports CONSIST_ERROR instead.
+        // consistControl() returns null instead of throwing whenever either
+        // address fails its own validity check.
         if (contents == null) {
             log.error("Unable to build advanced consist control packet for {} / consist {} -- invalid address",
                     locoAddress, consistAddress);
@@ -249,16 +240,8 @@ public class EasyDccConsist extends jmri.implementation.DccConsist {
         msg.setElement(3, '5');
         int j = 4;
         for (int i = 0; i < contents.length; i++) {
-            // FIELD REPORT (Andrew Deak, tested against real EasyDCC
-            // hardware): the buffer is sized 3 chars per content byte
-            // (" XX" -- space then two hex digits), but this used to
-            // pre-increment j before writing the space, then write the
-            // hex digits AT THE SAME j -- immediately overwriting the
-            // space it just wrote, and (because of the pre-increment)
-            // leaving the position before it never written to at all.
-            // The actual message sent to the command station ended up
-            // with garbage/uninitialized bytes interspersed with the
-            // hex fields instead of clean " XX XX XX..." formatting.
+            // the buffer is sized 3 chars per content byte (" XX" -- space
+            // then two hex digits).
             msg.setElement(j, ' ');
             msg.addIntAsTwoHex(contents[i] & 0xFF, j + 1);
             j += 3;
@@ -280,9 +263,8 @@ public class EasyDccConsist extends jmri.implementation.DccConsist {
         byte[] contents = jmri.NmraPacket.consistControl(locoAddress.getNumber(),
                 locoAddress.isLongAddress(),
                 0, true);
-        // FIELD REPORT (Andrew Deak): see the matching null-check in
-        // addToAdvancedConsist() -- same NPE-into-dropped-connection risk
-        // if locoAddress itself is invalid.
+        // consistControl() returns null instead of throwing whenever
+        // locoAddress fails its own validity check (see addToAdvancedConsist()).
         if (contents == null) {
             log.error("Unable to build advanced consist control packet to remove {} -- invalid address", locoAddress);
             notifyConsistListeners(locoAddress, ConsistListener.CONSIST_ERROR);
@@ -295,16 +277,8 @@ public class EasyDccConsist extends jmri.implementation.DccConsist {
         msg.setElement(3, '5');
         int j = 4;
         for (int i = 0; i < contents.length; i++) {
-            // FIELD REPORT (Andrew Deak, tested against real EasyDCC
-            // hardware): the buffer is sized 3 chars per content byte
-            // (" XX" -- space then two hex digits), but this used to
-            // pre-increment j before writing the space, then write the
-            // hex digits AT THE SAME j -- immediately overwriting the
-            // space it just wrote, and (because of the pre-increment)
-            // leaving the position before it never written to at all.
-            // The actual message sent to the command station ended up
-            // with garbage/uninitialized bytes interspersed with the
-            // hex fields instead of clean " XX XX XX..." formatting.
+            // the buffer is sized 3 chars per content byte (" XX" -- space
+            // then two hex digits).
             msg.setElement(j, ' ');
             msg.addIntAsTwoHex(contents[i] & 0xFF, j + 1);
             j += 3;

--- a/java/src/jmri/jmrix/easydcc/EasyDccConsist.java
+++ b/java/src/jmri/jmrix/easydcc/EasyDccConsist.java
@@ -225,6 +225,23 @@ public class EasyDccConsist extends jmri.implementation.DccConsist {
                 locoAddress.isLongAddress(),
                 consistAddress.getNumber(),
                 directionNormal);
+        // FIELD REPORT (Andrew Deak): consistControl() returns null instead
+        // of throwing whenever either address fails its own validity check
+        // -- confirmed live: an Advanced Consist address above the short-
+        // address range (consist addresses are always validated as short,
+        // regardless of the locomotive's own long/short form) returned null
+        // here, and the unguarded contents.length below NPE'd. That NPE
+        // propagated all the way up through the JSON WebSocket handler and
+        // closed the client's entire connection (confirmed: JMRI logged
+        // "Unanticipated error" and sent a close frame) -- one bad request
+        // took down the whole session, not just that operation. Every other
+        // failure path in this class reports CONSIST_ERROR instead.
+        if (contents == null) {
+            log.error("Unable to build advanced consist control packet for {} / consist {} -- invalid address",
+                    locoAddress, consistAddress);
+            notifyConsistListeners(locoAddress, ConsistListener.CONSIST_ERROR);
+            return;
+        }
         EasyDccMessage msg = new EasyDccMessage(4 + 3 * contents.length);
         msg.setOpCode('S');
         msg.setElement(1, ' ');
@@ -232,10 +249,19 @@ public class EasyDccConsist extends jmri.implementation.DccConsist {
         msg.setElement(3, '5');
         int j = 4;
         for (int i = 0; i < contents.length; i++) {
-            j++;
+            // FIELD REPORT (Andrew Deak, tested against real EasyDCC
+            // hardware): the buffer is sized 3 chars per content byte
+            // (" XX" -- space then two hex digits), but this used to
+            // pre-increment j before writing the space, then write the
+            // hex digits AT THE SAME j -- immediately overwriting the
+            // space it just wrote, and (because of the pre-increment)
+            // leaving the position before it never written to at all.
+            // The actual message sent to the command station ended up
+            // with garbage/uninitialized bytes interspersed with the
+            // hex fields instead of clean " XX XX XX..." formatting.
             msg.setElement(j, ' ');
-            msg.addIntAsTwoHex(contents[i] & 0xFF, j);
-            j += 2;
+            msg.addIntAsTwoHex(contents[i] & 0xFF, j + 1);
+            j += 3;
         }
 
         // send it
@@ -254,6 +280,14 @@ public class EasyDccConsist extends jmri.implementation.DccConsist {
         byte[] contents = jmri.NmraPacket.consistControl(locoAddress.getNumber(),
                 locoAddress.isLongAddress(),
                 0, true);
+        // FIELD REPORT (Andrew Deak): see the matching null-check in
+        // addToAdvancedConsist() -- same NPE-into-dropped-connection risk
+        // if locoAddress itself is invalid.
+        if (contents == null) {
+            log.error("Unable to build advanced consist control packet to remove {} -- invalid address", locoAddress);
+            notifyConsistListeners(locoAddress, ConsistListener.CONSIST_ERROR);
+            return;
+        }
         EasyDccMessage msg = new EasyDccMessage(4 + 3 * contents.length);
         msg.setOpCode('S');
         msg.setElement(1, ' ');
@@ -261,10 +295,19 @@ public class EasyDccConsist extends jmri.implementation.DccConsist {
         msg.setElement(3, '5');
         int j = 4;
         for (int i = 0; i < contents.length; i++) {
-            j++;
+            // FIELD REPORT (Andrew Deak, tested against real EasyDCC
+            // hardware): the buffer is sized 3 chars per content byte
+            // (" XX" -- space then two hex digits), but this used to
+            // pre-increment j before writing the space, then write the
+            // hex digits AT THE SAME j -- immediately overwriting the
+            // space it just wrote, and (because of the pre-increment)
+            // leaving the position before it never written to at all.
+            // The actual message sent to the command station ended up
+            // with garbage/uninitialized bytes interspersed with the
+            // hex fields instead of clean " XX XX XX..." formatting.
             msg.setElement(j, ' ');
-            msg.addIntAsTwoHex(contents[i] & 0xFF, j);
-            j += 2;
+            msg.addIntAsTwoHex(contents[i] & 0xFF, j + 1);
+            j += 3;
         }
 
         // send it

--- a/java/src/jmri/jmrix/lenz/XNetConsist.java
+++ b/java/src/jmri/jmrix/lenz/XNetConsist.java
@@ -156,7 +156,19 @@ public class XNetConsist extends jmri.implementation.DccConsist implements XNetL
     @Override
     public boolean getLocoDirection(DccLocoAddress address) {
         if (consistType == ADVANCED_CONSIST || consistType == CS_CONSIST) {
-            return consistDir.get(address);
+            // FIELD REPORT (Andrew Deak): consistDir.get(address) returns a
+            // Boolean, auto-unboxed to primitive boolean here -- NPEs
+            // whenever address isn't (or is no longer) a key in the map.
+            // Confirmed live via the XPressNet Simulator: this threw inside
+            // the remove-reply callback (message() -> resetRosterEntryCVValue()
+            // -> here), silently discarded before this session's logging fix
+            // (see AbstractMRTrafficController.distributeReply()) because the
+            // exception happens on the EDT during reply dispatch, several
+            // frames away from any caller that could see it directly. The
+            // sibling EasyDccConsist class already guards this exact same
+            // lookup with getOrDefault(address, false); this one just never
+            // got the same treatment.
+            return consistDir.getOrDefault(address, false);
         } else {
             log.error(CONSIST_TYPE_NOT_SUPPORTED);
             notifyConsistListeners(address, ConsistListener.NotImplemented);
@@ -438,6 +450,23 @@ public class XNetConsist extends jmri.implementation.DccConsist implements XNetL
      */
     @Override
     public synchronized void message(XNetReply l) {
+        // FIELD REPORT (Andrew Deak): confirmed live via the XPressNet
+        // Simulator -- DccConsist.dispose() loops over every remaining
+        // engine calling remove() synchronously, but XNetConsist.remove()
+        // for ADVANCED_CONSIST is fire-and-forget (sends the XNet message
+        // and returns immediately; the actual list/state update only
+        // happens later, in this callback). dispose() doesn't wait for
+        // those replies before nulling out consistList/consistDir --
+        // confirmed: deleting a 5-engine consist produced exactly 5
+        // clustered NPEs a moment later, once the simulator's replies for
+        // all 5 in-flight removes finally arrived against an
+        // already-disposed object. A disposed consist has consistList set
+        // to null (see dispose()), so that's used here as the signal to
+        // ignore any reply that arrives too late to matter.
+        if (consistList == null) {
+            log.debug("Ignoring reply for consist {} -- already disposed", consistAddress);
+            return;
+        }
         if (_state != IDLESTATE) {
             // we're waiting for a reply, so examine what we received
             if (l.isOkMessage()) {

--- a/java/src/jmri/jmrix/lenz/XNetConsist.java
+++ b/java/src/jmri/jmrix/lenz/XNetConsist.java
@@ -156,18 +156,8 @@ public class XNetConsist extends jmri.implementation.DccConsist implements XNetL
     @Override
     public boolean getLocoDirection(DccLocoAddress address) {
         if (consistType == ADVANCED_CONSIST || consistType == CS_CONSIST) {
-            // FIELD REPORT (Andrew Deak): consistDir.get(address) returns a
-            // Boolean, auto-unboxed to primitive boolean here -- NPEs
-            // whenever address isn't (or is no longer) a key in the map.
-            // Confirmed live via the XPressNet Simulator: this threw inside
-            // the remove-reply callback (message() -> resetRosterEntryCVValue()
-            // -> here), silently discarded before this session's logging fix
-            // (see AbstractMRTrafficController.distributeReply()) because the
-            // exception happens on the EDT during reply dispatch, several
-            // frames away from any caller that could see it directly. The
-            // sibling EasyDccConsist class already guards this exact same
-            // lookup with getOrDefault(address, false); this one just never
-            // got the same treatment.
+            // consistDir.get(address) returns a Boolean, auto-unboxed to
+            // primitive boolean here.
             return consistDir.getOrDefault(address, false);
         } else {
             log.error(CONSIST_TYPE_NOT_SUPPORTED);
@@ -450,19 +440,12 @@ public class XNetConsist extends jmri.implementation.DccConsist implements XNetL
      */
     @Override
     public synchronized void message(XNetReply l) {
-        // FIELD REPORT (Andrew Deak): confirmed live via the XPressNet
-        // Simulator -- DccConsist.dispose() loops over every remaining
-        // engine calling remove() synchronously, but XNetConsist.remove()
-        // for ADVANCED_CONSIST is fire-and-forget (sends the XNet message
-        // and returns immediately; the actual list/state update only
-        // happens later, in this callback). dispose() doesn't wait for
-        // those replies before nulling out consistList/consistDir --
-        // confirmed: deleting a 5-engine consist produced exactly 5
-        // clustered NPEs a moment later, once the simulator's replies for
-        // all 5 in-flight removes finally arrived against an
-        // already-disposed object. A disposed consist has consistList set
-        // to null (see dispose()), so that's used here as the signal to
-        // ignore any reply that arrives too late to matter.
+        // remove() for ADVANCED_CONSIST is fire-and-forget: it sends the
+        // XNet message and returns immediately, with the actual list/state
+        // update happening later in this callback. dispose() does not wait
+        // for those replies before nulling out consistList, so a reply for
+        // an already-disposed consist must be ignored here rather than
+        // acting on torn-down state.
         if (consistList == null) {
             log.debug("Ignoring reply for consist {} -- already disposed", consistAddress);
             return;

--- a/java/src/jmri/jmrix/loconet/LnThrottleManager.java
+++ b/java/src/jmri/jmrix/loconet/LnThrottleManager.java
@@ -75,18 +75,34 @@ public class LnThrottleManager extends AbstractThrottleManager implements SlotLi
     @Override
     public void requestThrottleSetup(LocoAddress address, boolean control) {
         log.debug("requestThrottleSetup: address {}, control {}", address, control);
-        if (requestOutstanding) {
+        // FIELD REPORT (Andrew Deak): checking requestOutstanding and then
+        // setting it true used to be two separate, unsynchronized steps --
+        // see the field report on requestOutstanding's declaration for why
+        // that's a real, reproduced race, not just a hypothetical. Must be
+        // atomic: only one caller may ever win the "handle this now" path
+        // for a given moment.
+        boolean handleNow;
+        synchronized (this) {
+            if (requestOutstanding) {
+                handleNow = false;
+            } else {
+                requestOutstanding = true;
+                handleNow = true;
+            }
+        }
+        if (handleNow) {
+           // handle this now
+           processThrottleSetupRequest(address, control);
+        } else {
            try {
               // queue this request for later.
               requestList.put(new ThrottleRequest(address,control));
            } catch (InterruptedException ie) {
               log.error("Interrupted while trying to store throttle request");
-              requestOutstanding = false;
+              synchronized (this) {
+                  requestOutstanding = false;
+              }
            }
-        } else {
-           // handle this now
-           requestOutstanding = true;
-           processThrottleSetupRequest(address, control);
         }
      }
 
@@ -95,14 +111,26 @@ public class LnThrottleManager extends AbstractThrottleManager implements SlotLi
      * a LocoNetThrottle.
      */
     protected void processQueuedThrottleSetupRequest() {
-        if (!requestOutstanding && (requestList.size() != 0 )) {
-           requestOutstanding = true;
+        // FIELD REPORT (Andrew Deak): same atomicity requirement as
+        // requestThrottleSetup() above.
+        boolean handleNow;
+        synchronized (this) {
+            if (!requestOutstanding && (requestList.size() != 0 )) {
+                requestOutstanding = true;
+                handleNow = true;
+            } else {
+                handleNow = false;
+            }
+        }
+        if (handleNow) {
            try {
               ThrottleRequest tr = requestList.take();
               processThrottleSetupRequest(tr.getAddress(), tr.getControl());
            } catch (InterruptedException ie) {
               log.error("Interrupted while trying to process process throttle request");
-              requestOutstanding = false;
+              synchronized (this) {
+                  requestOutstanding = false;
+              }
            }
         }
      }
@@ -114,6 +142,7 @@ public class LnThrottleManager extends AbstractThrottleManager implements SlotLi
      * @param control whether the throttle object wants to control the loco
      */
     private void processThrottleSetupRequest(LocoAddress address, boolean control) {
+        pendingRequestAddress = new DccLocoAddress(address.getNumber(), isLongAddress(address.getNumber()));
         slotManager.slotFromLocoAddress(address.getNumber(), this);  //first try
 
         class RetrySetup implements Runnable { // setup for retries and failure check
@@ -174,6 +203,7 @@ public class LnThrottleManager extends AbstractThrottleManager implements SlotLi
                     log.error("Listener threw while handling failed throttle request for {} -- continuing anyway", address, ex);
                 } finally {
                     requestOutstanding = false;
+                    pendingRequestAddress = null;
                     processQueuedThrottleSetupRequest();
                 }
             }
@@ -191,11 +221,48 @@ public class LnThrottleManager extends AbstractThrottleManager implements SlotLi
 
     volatile Thread retrySetupThread;
 
+    // FIELD REPORT (Andrew Deak): the address a pending slot request was
+    // actually made for. notifyChangedSlot() previously just trusted
+    // whatever slot it was handed as "the one we asked for" -- since this
+    // manager registers itself as a single shared SlotListener for
+    // whatever address it's currently requesting (requestOutstanding
+    // serializes one acquisition at a time), a stale or delayed slot
+    // response from an EARLIER, already-completed request arriving late
+    // could get misattributed to the address currently being requested.
+    // Confirmed live on a real DCS52 under rapid back-to-back requests
+    // (building a multi-engine consist): requesting a throttle for one
+    // address returned a status report for a DIFFERENT, earlier-tested
+    // address instead -- same class of bug LocoNetConsist.
+    // unexpectedSlotAddress() already guards against for consist slot
+    // requests specifically, just never added here for general
+    // individual throttle acquisition. Set right before each request
+    // fires (including retries, same address), checked in
+    // notifyChangedSlot() before acting on the response. Unlike
+    // LocoNetConsist's guard, a mismatch here doesn't need its own
+    // retry-queue -- RetrySetup already re-issues the request every
+    // second for up to 20 attempts regardless, so simply ignoring the
+    // mismatched response lets that existing mechanism recover
+    // naturally.
+    private volatile DccLocoAddress pendingRequestAddress = null;
+
     Hashtable<Integer, Thread> waitingForNotification = new Hashtable<>(5);
 
     Hashtable<Integer, LocoNetSlot> slotForAddress;
     LinkedBlockingQueue<ThrottleRequest> requestList;
-    boolean requestOutstanding = false;
+    // FIELD REPORT (Andrew Deak): volatile, and only ever check-and-set
+    // together with pendingRequestAddress inside synchronized(this) (see
+    // requestThrottleSetup()/processQueuedThrottleSetupRequest()) --
+    // confirmed live this was a genuine, pre-existing, unsynchronized
+    // check-then-act race: the EDT (building/tearing down a consist,
+    // which itself calls requestThrottle() for each member) and a
+    // separate thread handling a direct JSON throttle request can both
+    // observe this false at the same instant and both proceed, each
+    // overwriting pendingRequestAddress -- the SECOND caller's address
+    // then gets checked against by the FIRST caller's actual slot
+    // response, and vice versa. Not just a hypothetical: reproduced live
+    // against a real DCS52 building a multi-engine consist while
+    // separately requesting individual throttles for its members.
+    volatile boolean requestOutstanding = false;
 
     /**
      * LocoNet does have a Dispatch function.
@@ -233,6 +300,19 @@ public class LnThrottleManager extends AbstractThrottleManager implements SlotLi
         log.debug("notifyChangedSlot - slot {}, slotStatus {}", s.getSlot(), Integer.toHexString(s.slotStatus()));
         // This is invoked only if the SlotManager knows that the LnThrottleManager is
         // interested in the address associated with this slot.
+
+        // FIELD REPORT (Andrew Deak): reject a response that doesn't match
+        // what we're actually currently waiting for -- see the field
+        // report on pendingRequestAddress above. Ignoring rather than
+        // acting on it lets RetrySetup's existing 1-second retry loop
+        // recover naturally instead of silently completing the wrong
+        // address's acquisition with someone else's slot data.
+        DccLocoAddress expected = pendingRequestAddress;
+        if (expected != null && s.locoAddr() != expected.getNumber()) {
+            log.warn("notifyChangedSlot(): requested slot for {} but got slot {} for address {} instead -- ignoring stale/mismatched response",
+                    expected, s.getSlot(), s.locoAddr());
+            return;
+        }
 
         // need to check to see if the slot is in a suitable state for creating a throttle.
         if (s.slotStatus() == LnConstants.LOCO_IN_USE) {
@@ -296,6 +376,7 @@ public class LnThrottleManager extends AbstractThrottleManager implements SlotLi
              slotForAddress.remove(s.locoAddr());
          }
          requestOutstanding = false;
+         pendingRequestAddress = null;
          processQueuedThrottleSetupRequest();
      }
 
@@ -341,6 +422,7 @@ public class LnThrottleManager extends AbstractThrottleManager implements SlotLi
             slotForAddress.remove(address);
         }
         requestOutstanding = false;
+        pendingRequestAddress = null;
         processQueuedThrottleSetupRequest();
     }
 
@@ -498,6 +580,7 @@ public class LnThrottleManager extends AbstractThrottleManager implements SlotLi
             slotForAddress.remove(address.getNumber());
         }
         requestOutstanding = false;
+        pendingRequestAddress = null;
         processQueuedThrottleSetupRequest();
     }
 
@@ -528,6 +611,7 @@ public class LnThrottleManager extends AbstractThrottleManager implements SlotLi
             slotForAddress.remove(loconumber);
         }
         requestOutstanding = false;
+        pendingRequestAddress = null;
         processQueuedThrottleSetupRequest();
     }
 

--- a/java/src/jmri/jmrix/loconet/LnThrottleManager.java
+++ b/java/src/jmri/jmrix/loconet/LnThrottleManager.java
@@ -129,7 +129,19 @@ public class LnThrottleManager extends AbstractThrottleManager implements SlotLi
             @Override
             public void run() {
                 int attempts = 1; // already tried once above
-                int maxAttempts = 10;
+                // Was 10 (10s total) -- too short for a command station
+                // that's still working through a backlog of rapid
+                // sequential slot requests, e.g. building/tearing down a
+                // large command-station consist one engine at a time.
+                // Field-observed on a DCS52: the 20th of 20 back-to-back
+                // slot requests timed out and was abandoned by JMRI, yet
+                // the Slot Monitor later showed the command station HAD
+                // allocated a valid slot for it -- the response just
+                // arrived after JMRI's window closed, not because the
+                // slot/address was invalid. This thread is a dedicated
+                // background thread (not the AWT/LocoNet receive thread),
+                // so waiting longer here is safe.
+                int maxAttempts = 20;
                 while (attempts <= maxAttempts) {
                     try {
                         Thread.sleep(1000); // wait one second
@@ -145,9 +157,25 @@ public class LnThrottleManager extends AbstractThrottleManager implements SlotLi
                     attempts++;
                 }
                 log.error("No response to slot request for {} after {} attempts.", address, attempts - 1); // NOI18N
-                failedThrottleRequest(address, "Failed to get response from command station");
-                requestOutstanding = false;
-                processQueuedThrottleSetupRequest();
+                // FIELD REPORT: failedThrottleRequest() dispatches to a
+                // listener's notifyFailedThrottleRequest(), which threw an
+                // uncaught NullPointerException in the field (a consist
+                // object touching its own already-nulled bookkeeping after
+                // being disposed). Since requestOutstanding=false and
+                // processQueuedThrottleSetupRequest() were below the
+                // throwing call, one bad listener permanently wedged EVERY
+                // future throttle request for the rest of the session --
+                // requestOutstanding stuck true forever, with nothing left
+                // to ever drain the queue. This manager's own bookkeeping
+                // must never depend on a listener behaving.
+                try {
+                    failedThrottleRequest(address, "Failed to get response from command station");
+                } catch (RuntimeException ex) {
+                    log.error("Listener threw while handling failed throttle request for {} -- continuing anyway", address, ex);
+                } finally {
+                    requestOutstanding = false;
+                    processQueuedThrottleSetupRequest();
+                }
             }
         }
 

--- a/java/src/jmri/jmrix/loconet/LnThrottleManager.java
+++ b/java/src/jmri/jmrix/loconet/LnThrottleManager.java
@@ -75,12 +75,8 @@ public class LnThrottleManager extends AbstractThrottleManager implements SlotLi
     @Override
     public void requestThrottleSetup(LocoAddress address, boolean control) {
         log.debug("requestThrottleSetup: address {}, control {}", address, control);
-        // FIELD REPORT (Andrew Deak): checking requestOutstanding and then
-        // setting it true used to be two separate, unsynchronized steps --
-        // see the field report on requestOutstanding's declaration for why
-        // that's a real, reproduced race, not just a hypothetical. Must be
-        // atomic: only one caller may ever win the "handle this now" path
-        // for a given moment.
+        // Checking requestOutstanding and setting it true must be atomic --
+        // see its declaration below for the race this closes.
         boolean handleNow;
         synchronized (this) {
             if (requestOutstanding) {
@@ -111,8 +107,7 @@ public class LnThrottleManager extends AbstractThrottleManager implements SlotLi
      * a LocoNetThrottle.
      */
     protected void processQueuedThrottleSetupRequest() {
-        // FIELD REPORT (Andrew Deak): same atomicity requirement as
-        // requestThrottleSetup() above.
+        // Same atomicity requirement as requestThrottleSetup() above.
         boolean handleNow;
         synchronized (this) {
             if (!requestOutstanding && (requestList.size() != 0 )) {
@@ -159,17 +154,10 @@ public class LnThrottleManager extends AbstractThrottleManager implements SlotLi
             public void run() {
                 int attempts = 1; // already tried once above
                 // Was 10 (10s total) -- too short for a command station
-                // that's still working through a backlog of rapid
-                // sequential slot requests, e.g. building/tearing down a
-                // large command-station consist one engine at a time.
-                // Field-observed on a DCS52: the 20th of 20 back-to-back
-                // slot requests timed out and was abandoned by JMRI, yet
-                // the Slot Monitor later showed the command station HAD
-                // allocated a valid slot for it -- the response just
-                // arrived after JMRI's window closed, not because the
-                // slot/address was invalid. This thread is a dedicated
-                // background thread (not the AWT/LocoNet receive thread),
-                // so waiting longer here is safe.
+                // still working through a backlog of rapid sequential slot
+                // requests (e.g. building/tearing down a large consist).
+                // This is a dedicated background thread, so waiting longer
+                // here is safe.
                 int maxAttempts = 20;
                 while (attempts <= maxAttempts) {
                     try {
@@ -186,17 +174,10 @@ public class LnThrottleManager extends AbstractThrottleManager implements SlotLi
                     attempts++;
                 }
                 log.error("No response to slot request for {} after {} attempts.", address, attempts - 1); // NOI18N
-                // FIELD REPORT: failedThrottleRequest() dispatches to a
-                // listener's notifyFailedThrottleRequest(), which threw an
-                // uncaught NullPointerException in the field (a consist
-                // object touching its own already-nulled bookkeeping after
-                // being disposed). Since requestOutstanding=false and
-                // processQueuedThrottleSetupRequest() were below the
-                // throwing call, one bad listener permanently wedged EVERY
-                // future throttle request for the rest of the session --
-                // requestOutstanding stuck true forever, with nothing left
-                // to ever drain the queue. This manager's own bookkeeping
-                // must never depend on a listener behaving.
+                // A listener throwing out of notifyFailedThrottleRequest()
+                // must not skip the cleanup below -- otherwise
+                // requestOutstanding stays stuck true forever and wedges
+                // every future throttle request for the rest of the session.
                 try {
                     failedThrottleRequest(address, "Failed to get response from command station");
                 } catch (RuntimeException ex) {
@@ -221,47 +202,26 @@ public class LnThrottleManager extends AbstractThrottleManager implements SlotLi
 
     volatile Thread retrySetupThread;
 
-    // FIELD REPORT (Andrew Deak): the address a pending slot request was
-    // actually made for. notifyChangedSlot() previously just trusted
-    // whatever slot it was handed as "the one we asked for" -- since this
-    // manager registers itself as a single shared SlotListener for
-    // whatever address it's currently requesting (requestOutstanding
-    // serializes one acquisition at a time), a stale or delayed slot
-    // response from an EARLIER, already-completed request arriving late
-    // could get misattributed to the address currently being requested.
-    // Confirmed live on a real DCS52 under rapid back-to-back requests
-    // (building a multi-engine consist): requesting a throttle for one
-    // address returned a status report for a DIFFERENT, earlier-tested
-    // address instead -- same class of bug LocoNetConsist.
-    // unexpectedSlotAddress() already guards against for consist slot
-    // requests specifically, just never added here for general
-    // individual throttle acquisition. Set right before each request
-    // fires (including retries, same address), checked in
-    // notifyChangedSlot() before acting on the response. Unlike
-    // LocoNetConsist's guard, a mismatch here doesn't need its own
-    // retry-queue -- RetrySetup already re-issues the request every
-    // second for up to 20 attempts regardless, so simply ignoring the
-    // mismatched response lets that existing mechanism recover
-    // naturally.
+    // Address a pending slot request was actually made for. This manager
+    // is a single shared SlotListener for whatever address it's currently
+    // requesting, so a stale/delayed response from an earlier, already-
+    // completed request can otherwise get misattributed to the current
+    // one. Checked in notifyChangedSlot() before acting on a response; a
+    // mismatch is simply ignored since RetrySetup already re-issues the
+    // request every second regardless.
     private volatile DccLocoAddress pendingRequestAddress = null;
 
     Hashtable<Integer, Thread> waitingForNotification = new Hashtable<>(5);
 
     Hashtable<Integer, LocoNetSlot> slotForAddress;
     LinkedBlockingQueue<ThrottleRequest> requestList;
-    // FIELD REPORT (Andrew Deak): volatile, and only ever check-and-set
-    // together with pendingRequestAddress inside synchronized(this) (see
-    // requestThrottleSetup()/processQueuedThrottleSetupRequest()) --
-    // confirmed live this was a genuine, pre-existing, unsynchronized
-    // check-then-act race: the EDT (building/tearing down a consist,
-    // which itself calls requestThrottle() for each member) and a
-    // separate thread handling a direct JSON throttle request can both
-    // observe this false at the same instant and both proceed, each
-    // overwriting pendingRequestAddress -- the SECOND caller's address
-    // then gets checked against by the FIRST caller's actual slot
-    // response, and vice versa. Not just a hypothetical: reproduced live
-    // against a real DCS52 building a multi-engine consist while
-    // separately requesting individual throttles for its members.
+    // volatile, and only ever check-and-set together with
+    // pendingRequestAddress inside synchronized(this) -- see
+    // requestThrottleSetup()/processQueuedThrottleSetupRequest(). Without
+    // that, two threads (e.g. the EDT building a consist and a separate
+    // JSON throttle request) can both observe this false at once and both
+    // proceed, each overwriting pendingRequestAddress and getting checked
+    // against the other's slot response.
     volatile boolean requestOutstanding = false;
 
     /**
@@ -301,12 +261,10 @@ public class LnThrottleManager extends AbstractThrottleManager implements SlotLi
         // This is invoked only if the SlotManager knows that the LnThrottleManager is
         // interested in the address associated with this slot.
 
-        // FIELD REPORT (Andrew Deak): reject a response that doesn't match
-        // what we're actually currently waiting for -- see the field
-        // report on pendingRequestAddress above. Ignoring rather than
-        // acting on it lets RetrySetup's existing 1-second retry loop
-        // recover naturally instead of silently completing the wrong
-        // address's acquisition with someone else's slot data.
+        // Reject a response that doesn't match what's actually being
+        // waited for (see pendingRequestAddress above) -- RetrySetup's
+        // 1-second retry loop recovers naturally rather than this
+        // silently completing the wrong address's acquisition.
         DccLocoAddress expected = pendingRequestAddress;
         if (expected != null && s.locoAddr() != expected.getNumber()) {
             log.warn("notifyChangedSlot(): requested slot for {} but got slot {} for address {} instead -- ignoring stale/mismatched response",

--- a/java/src/jmri/jmrix/loconet/LocoNetConsist.java
+++ b/java/src/jmri/jmrix/loconet/LocoNetConsist.java
@@ -262,7 +262,26 @@ public class LocoNetConsist extends jmri.implementation.DccConsist implements Sl
         if (needToRemove.isEmpty()) {
             return;
         }
+        // FIELD REPORT (Andrew Deak): if the consist's own address is
+        // queued here alongside genuine followers, it must always be
+        // drained LAST, never just because it happens to be at the
+        // front of the queue (e.g. queued first, before followers, by
+        // a caller that removes the lead before its followers -- see
+        // the field report on removeFromCSConsist()'s lead==follow
+        // guard). Freeing the lead's slot before every other queued
+        // follower has actually been unlinked -- not just requested --
+        // would orphan their real LocoNet link. Prefer any non-lead
+        // entry first; only take the lead's own entry once it's the
+        // only thing left in the queue.
         DccLocoAddress locoAddress = needToRemove.get(0);
+        if (locoAddress.equals(consistAddress) && needToRemove.size() > 1) {
+            for (DccLocoAddress candidate : needToRemove) {
+                if (!candidate.equals(consistAddress)) {
+                    locoAddress = candidate;
+                    break;
+                }
+            }
+        }
         needToRemove.remove(locoAddress);
         if (consistType == ADVANCED_CONSIST) {
             removeFromAdvancedConsist(locoAddress);
@@ -451,7 +470,7 @@ public class LocoNetConsist extends jmri.implementation.DccConsist implements Sl
             needToRemove.add(locoAddress);
             return;
         }
-        if(consistList == null || (consistList.size()==1 && locoAddress.equals(consistAddress))){
+        if(consistList == null || (locoAddress.equals(consistAddress) && (consistList.isEmpty() || consistList.size()==1))){
           // there is only one address in this consist, no reason to
           // unlink -- but the slot is still marked In Use/Common from
           // when the consist was built, so fetch it and free it
@@ -469,9 +488,55 @@ public class LocoNetConsist extends jmri.implementation.DccConsist implements Sl
           // the same case as "sole remaining member" -- just free the
           // slot. Without this, consistList.size() NPE'd here and the
           // lead engine's slot never got freed, staying stuck "In Use".
+          //
+          // FIELD REPORT: consistList.isEmpty() (size 0, not null) is a
+          // related but distinct case, added after confirming it live --
+          // removeFromConsistList() strips an address from consistList
+          // SYNCHRONOUSLY the instant its remove() is called, regardless
+          // of whether the real async LocoNet unlink for it has actually
+          // completed yet. So once every member (including the lead
+          // itself, if its own removal was deferred below rather than
+          // processed immediately) has at least been REQUESTED, consistList
+          // reads back empty well before the lead's deferred removal is
+          // actually retried -- size()==1 alone would never match at that
+          // point, and this needs the same "just free the slot" treatment.
           pendingSlotAddress = locoAddress;
           slotManager.slotFromLocoAddress(locoAddress.getNumber(), this);
           consistRequestState = FREESLOTSTATE;
+          return;
+        }
+        if (locoAddress.equals(consistAddress)) {
+          // FIELD REPORT (Andrew Deak, confirmed live against a real
+          // DCS52 across 3 separate test consists): leadSlot is cached
+          // once at construction and never updated. Removing the
+          // consist's OWN address here while other real members are
+          // STILL tracked (the branch above didn't apply) would fall
+          // through to the generic unlink path below, which resolves
+          // BOTH "lead" and "follow" to that exact same cached leadSlot
+          // object -- there's nothing else to unlink the lead's own
+          // identity from. unlinkSlots()'s lead==follow guard (built for
+          // a different, degenerate self-link scenario) then fires:
+          // logs a CONSIST_ERROR/DELETE_ERROR and returns with NO
+          // LocoNet message ever sent and no retry -- permanently
+          // leaving this slot exactly as it was, stuck "In Use" in the
+          // Slot Monitor (confirmed live, visible there with Consist
+          // status "top"). Triggered whenever a caller removes the
+          // lead's own address before its followers are gone (e.g. a
+          // firmware doing an explicit per-engine teardown pass, lead
+          // first, ahead of the final consist delete) -- not just a
+          // hypothetical. Re-queuing here defers the lead's own removal
+          // until it's genuinely the sole remaining member (the branch
+          // above), the only order that's safe: freeing the lead's slot
+          // while real followers are still LocoNet-linked to it BY SLOT
+          // NUMBER on the actual hardware would orphan their physical
+          // link, corrupting the consist on the command station even
+          // though JMRI's own bookkeeping would look fine. Safe to defer
+          // indefinitely here rather than looping back through
+          // processQueuedWork() immediately -- nothing has changed yet,
+          // so an immediate retry would just hit this exact same branch
+          // again. Whichever other member's removal completes next will
+          // drain this via processQueuedWork() once it's genuinely safe.
+          needToRemove.add(locoAddress);
           return;
         }
         pendingSlotAddress = locoAddress;

--- a/java/src/jmri/jmrix/loconet/LocoNetConsist.java
+++ b/java/src/jmri/jmrix/loconet/LocoNetConsist.java
@@ -22,6 +22,27 @@ public class LocoNetConsist extends jmri.implementation.DccConsist implements Sl
     private LocoNetSlot leadSlot = null;
 
     private ArrayList<DccLocoAddress> needToWrite = null;
+    // Mirrors needToWrite, but for pending removals -- see the field
+    // report on removeFromCSConsist() below for why this exists.
+    private ArrayList<DccLocoAddress> needToRemove = null;
+
+    // FIELD REPORT: the address a pending LINKSTAGETWOSTATE/
+    // UNLINKSTAGEONESTATE/FREESLOTSTATE slot request was actually made
+    // for. notifyChangedSlot() previously just trusted whatever slot
+    // object it was handed as "the one we asked for" -- on a live
+    // LocoNet bus with a physical throttle simultaneously holding more
+    // than one address (confirmed field case: a UT6 throttle with an
+    // old address still active alongside the new one being grabbed,
+    // both sharing one throttle ID), a slot response for the WRONG
+    // address arrived and got linked into the consist instead of the
+    // one actually requested. Set right before each request fires,
+    // checked in notifyChangedSlot() before acting on the response.
+    private DccLocoAddress pendingSlotAddress = null;
+    // Bounds the mismatch-triggered retry in unexpectedSlotAddress()
+    // below so a genuinely dead/unreachable address can't retry
+    // forever. Reset to 0 on any correctly-matched response.
+    private int consecutiveSlotMismatches = 0;
+    private static final int MAX_CONSECUTIVE_SLOT_MISMATCHES = 5;
 
     // State Machine states
     static final int IDLESTATE = 0;
@@ -30,6 +51,7 @@ public class LocoNetConsist extends jmri.implementation.DccConsist implements Sl
     static final int LINKSTAGETWOSTATE = 4;
     static final int LINKSTAGETHREESTATE = 8;
     static final int UNLINKSTAGEONESTATE = 16;
+    static final int FREESLOTSTATE = 32;
 
     private int consistRequestState = IDLESTATE;
 
@@ -44,6 +66,7 @@ public class LocoNetConsist extends jmri.implementation.DccConsist implements Sl
         consistRequestState = LEADREQUESTSTATE;
         consistType = Consist.CS_CONSIST;
         needToWrite = new ArrayList<>();
+        needToRemove = new ArrayList<>();
         throttleManager.requestThrottle(consistAddress, LocoNetConsist.this, false);
     }
 
@@ -58,6 +81,7 @@ public class LocoNetConsist extends jmri.implementation.DccConsist implements Sl
         consistRequestState = LEADREQUESTSTATE;
         consistType = Consist.CS_CONSIST;
         needToWrite = new ArrayList<>();
+        needToRemove = new ArrayList<>();
         throttleManager.requestThrottle(consistAddress, LocoNetConsist.this, false);
     }
 
@@ -87,7 +111,7 @@ public class LocoNetConsist extends jmri.implementation.DccConsist implements Sl
         return consistType == Consist.CS_CONSIST || (address.getNumber() != 0);
     }
 
-    /** 
+    /**
      * Is there a size limit for this consist?
      * @return -1 (no limit) for
      * both CS and Advanced Consists,
@@ -120,7 +144,7 @@ public class LocoNetConsist extends jmri.implementation.DccConsist implements Sl
     // locomotive in the consist
     @Override
     public boolean getLocoDirection(DccLocoAddress address) {
-        log.debug("consist {} obtaining direction for {} Consist List Size {}", 
+        log.debug("consist {} obtaining direction for {} Consist List Size {}",
             consistAddress, address, consistList.size());
         if (consistType == ADVANCED_CONSIST || consistType == CS_CONSIST) {
             if (address == consistAddress) {
@@ -155,6 +179,15 @@ public class LocoNetConsist extends jmri.implementation.DccConsist implements Sl
      * Remove an address from the internal Consist list object.
      */
     private synchronized void removeFromConsistList(DccLocoAddress locoAddress) {
+        // FIELD REPORT: called from notifyFailedThrottleRequest(), which
+        // fires asynchronously (from LnThrottleManager's retry thread)
+        // and can arrive well after dispose() already nulled these out --
+        // NPE'd here and, worse, took down LnThrottleManager's own
+        // bookkeeping with it (see the try/finally added around
+        // failedThrottleRequest() in LnThrottleManager.java).
+        if (consistDir == null || consistList == null) {
+            return;
+        }
         consistDir.remove(locoAddress);
         consistList.remove(locoAddress);
     }
@@ -203,6 +236,13 @@ public class LocoNetConsist extends jmri.implementation.DccConsist implements Sl
     }
 
     private synchronized void delayedAdd() {
+        if (consistList == null) {
+            // This consist was dispose()'d (deleted) while this add was
+            // still queued behind an in-flight slot request -- nothing
+            // left to add it to. See the field report on the
+            // "missing lead slot" branch in unlinkSlots().
+            return;
+        }
         DccLocoAddress locoAddress = needToWrite.get(0);
         if (consistType == ADVANCED_CONSIST) {
             addToAdvancedConsist(locoAddress, getLocoDirection(locoAddress));
@@ -210,6 +250,72 @@ public class LocoNetConsist extends jmri.implementation.DccConsist implements Sl
             addToCSConsist(locoAddress, getLocoDirection(locoAddress));
         }
         needToWrite.remove(locoAddress);
+    }
+
+    /**
+     * Process one queued removal. See the field report on
+     * removeFromCSConsist() for why removals need to be queued rather
+     * than fired immediately -- this drains that queue the same way
+     * delayedAdd() drains needToWrite.
+     */
+    private synchronized void delayedRemove() {
+        if (needToRemove.isEmpty()) {
+            return;
+        }
+        DccLocoAddress locoAddress = needToRemove.get(0);
+        needToRemove.remove(locoAddress);
+        if (consistType == ADVANCED_CONSIST) {
+            removeFromAdvancedConsist(locoAddress);
+        } else if (consistType == CS_CONSIST) {
+            removeFromCSConsist(locoAddress);
+        }
+    }
+
+    /**
+     * Called at every point where a slot operation has just finished and
+     * consistRequestState is (or is about to become) IDLESTATE. Drains
+     * needToRemove ahead of needToWrite -- queued deletes should not sit
+     * behind queued adds -- and only leaves the state machine idle once
+     * both queues are empty.
+     */
+    private synchronized void processQueuedWork() {
+        if (needToRemove.isEmpty() && needToWrite.isEmpty()) {
+            consistRequestState = IDLESTATE;
+            return;
+        }
+        // FIELD REPORT: draining the next queued item here directly
+        // (delayedRemove()/delayedAdd()) caused a real StackOverflowError.
+        // AbstractThrottleManager.requestThrottle() calls back
+        // SYNCHRONOUSLY (same call stack) when the address's throttle is
+        // already known/cached (see its "already exists" branch) -- so
+        // once enough addresses were already known (which happens fast
+        // once a session has touched a lot of addresses, as this one
+        // has), draining the queue synchronously recursed: drain -> fire
+        // request -> synchronous callback -> drain next -> fire ->
+        // callback -> ... with no base case, until the stack overflowed
+        // and the whole operation silently aborted -- explaining engines
+        // that never got a real slot with zero error logged. Deferring
+        // via invokeLater() breaks the call stack chain: each item runs
+        // on a fresh event, not nested inside the previous one's.
+        javax.swing.SwingUtilities.invokeLater(() -> {
+            synchronized (LocoNetConsist.this) {
+                // Must reset to IDLESTATE before draining the next item --
+                // removeFromCSConsist()/the add path both check this field
+                // to decide fire-now vs queue-again. Leaving it at
+                // whatever busy value the PREVIOUS operation set made
+                // every deferred drain see "still busy" and silently
+                // re-queue the item instead of ever processing it -- the
+                // lead engine (queued last, since dispose() processes it
+                // last) would re-queue itself indefinitely and never
+                // actually get freed, staying stuck "In Use" forever.
+                consistRequestState = IDLESTATE;
+                if (!needToRemove.isEmpty()) {
+                    delayedRemove();
+                } else if (!needToWrite.isEmpty()) {
+                    delayedAdd();
+                }
+            }
+        });
     }
 
     /**
@@ -296,13 +402,25 @@ public class LocoNetConsist extends jmri.implementation.DccConsist implements Sl
      *        the same direction as the consist, or false otherwise.
      */
     private synchronized void addToCSConsist(DccLocoAddress locoAddress, boolean directionNormal) {
-        log.debug("Add Locomotive {} to Standard Consist {} With Direction Normal {}.", 
+        log.debug("Add Locomotive {} to Standard Consist {} With Direction Normal {}.",
             locoAddress, consistAddress, directionNormal);
         if(consistList.size()<=1 && locoAddress.equals(consistAddress)){
           // there is only one address in this consist, no reason to link.
+          // FIELD REPORT: this used to just return here, leaving
+          // consistRequestState untouched and the rest of needToWrite
+          // undrained -- since add()'s locoAddress==consistAddress check
+          // uses reference equality and the JSON/GUI paths always
+          // construct a fresh DccLocoAddress, the lead's own address
+          // routes through here (as a queued no-op) almost every time,
+          // silently dead-ending the queue chain before any real
+          // follower engine ever got processed. processQueuedWork()
+          // keeps the chain moving exactly like every other exit point
+          // in this class does.
           notifyConsistListeners(locoAddress,ConsistListener.OPERATION_SUCCESS);
+          processQueuedWork();
           return;
         }
+        pendingSlotAddress = locoAddress;
         throttleManager.requestThrottle(locoAddress, this, false);
         // skip right to stage 2, we do not need to status edit.
         consistRequestState = LINKSTAGETWOSTATE;
@@ -314,11 +432,49 @@ public class LocoNetConsist extends jmri.implementation.DccConsist implements Sl
      */
     public synchronized void removeFromCSConsist(DccLocoAddress locoAddress) {
         log.debug("Remove Locomotive {} from Standard Consist {}.", locoAddress, consistAddress);
-        if(consistList.size()==1 && locoAddress.equals(consistAddress)){
-          // there is only one address in this consist, no reason to link.
-          notifyConsistListeners(locoAddress,ConsistListener.OPERATION_SUCCESS);
+        // FIELD REPORT: dispose() (called by delConsist(), i.e. deleting a
+        // whole consist from the Consist Tool panel or the JSON DELETE
+        // endpoint) loops calling remove() synchronously for every member
+        // with no pacing at all -- unlike add(), which already checks
+        // this same consistRequestState field and queues into
+        // needToWrite when something's in flight. Without an equivalent
+        // guard here, every member's slot request fired at once, all
+        // sharing this ONE consistRequestState field (each overwriting
+        // the last), and unlike the add path there is no retry for a
+        // dropped slot request. Field-tested on a real DCS52 deleting a
+        // 19-engine consist: every slot request but the first was lost,
+        // and every member stayed fully "In Use"/linked in the Slot
+        // Monitor -- the delete silently did nothing for 18 of 19
+        // engines. Queuing here, exactly like add() does, serializes
+        // removals one at a time via delayedRemove().
+        if (consistRequestState != IDLESTATE) {
+            needToRemove.add(locoAddress);
+            return;
+        }
+        if(consistList == null || (consistList.size()==1 && locoAddress.equals(consistAddress))){
+          // there is only one address in this consist, no reason to
+          // unlink -- but the slot is still marked In Use/Common from
+          // when the consist was built, so fetch it and free it
+          // directly rather than leaving it stuck (see FREESLOTSTATE
+          // in notifyChangedSlot()).
+          //
+          // FIELD REPORT: consistList == null happens when this call
+          // arrives via the needToRemove queue for the LEAD's own
+          // address -- dispose() enqueues it last (it's index 0,
+          // processed last by the size-1-down-to-0 loop), and by the
+          // time the deferred invokeLater() actually runs it,
+          // dispose()'s loop has already finished and nulled consistList
+          // out. There's nothing left to unlink against either way (every
+          // other member was already processed first), so this is really
+          // the same case as "sole remaining member" -- just free the
+          // slot. Without this, consistList.size() NPE'd here and the
+          // lead engine's slot never got freed, staying stuck "In Use".
+          pendingSlotAddress = locoAddress;
+          slotManager.slotFromLocoAddress(locoAddress.getNumber(), this);
+          consistRequestState = FREESLOTSTATE;
           return;
         }
+        pendingSlotAddress = locoAddress;
         slotManager.slotFromLocoAddress(locoAddress.getNumber(), this);
         consistRequestState = UNLINKSTAGEONESTATE;
     }
@@ -357,10 +513,7 @@ public class LocoNetConsist extends jmri.implementation.DccConsist implements Sl
                 throttleManager.canBeLongAddress(follow.locoAddr())),
                 ConsistListener.CONSIST_ERROR);
         }
-        consistRequestState = IDLESTATE;
-        if (!needToWrite.isEmpty()) {
-            delayedAdd();
-        }
+        processQueuedWork();
     }
 
     /**
@@ -369,6 +522,22 @@ public class LocoNetConsist extends jmri.implementation.DccConsist implements Sl
      * @param follow is the slot which was following the leader
      */
     private void unlinkSlots(LocoNetSlot lead, LocoNetSlot follow) {
+        if (lead == null || follow == null) {
+            // Can happen for a consist JMRI rediscovered from the layout
+            // (requestUpdateFromLayout()) whose lead slot never resolved
+            // -- e.g. the command station never answered the lead's slot
+            // request. There's nothing to build a valid unlink message
+            // with, but still free whatever slot IS known rather than
+            // crashing with an NPE and leaving it stuck In Use.
+            log.warn("unlinkSlots(): missing {} slot for consist {} -- cannot send unlink, freeing what's known",
+                    lead == null ? "lead" : "follow", consistAddress);
+            if (follow != null) {
+                trafficController.sendLocoNetMessage(follow.writeStatus(LnConstants.LOCO_FREE));
+                follow.removeSlotListener(this);
+            }
+            processQueuedWork();
+            return;
+        }
         LocoNetMessage msg;
         if (lead != follow) {
             if (slotManager.getLoconetProtocol() == LnConstants.LOCONETPROTOCOL_TWO) {
@@ -389,6 +558,12 @@ public class LocoNetConsist extends jmri.implementation.DccConsist implements Sl
                 msg.setElement(2, lead.getSlot());
             }
             trafficController.sendLocoNetMessage(msg);
+            // Unlinking only breaks the LocoNet slot link -- it does not
+            // touch the follower's own slot status, which otherwise stays
+            // In Use/Common forever after being removed from a consist.
+            // Match what the Slot Monitor's own manual Free button sends
+            // (see SlotMonDataModel.setValueAt(), DISPCOLUMN case).
+            trafficController.sendLocoNetMessage(follow.writeStatus(LnConstants.LOCO_FREE));
         } else {
           // lead == follow
           // this is an error, notify the consist listeners.
@@ -397,10 +572,23 @@ public class LocoNetConsist extends jmri.implementation.DccConsist implements Sl
                 throttleManager.canBeLongAddress(follow.locoAddr())),
                 ConsistListener.CONSIST_ERROR | ConsistListener.DELETE_ERROR );
         }
-        consistRequestState = IDLESTATE;
-        if (!needToWrite.isEmpty()) {
-            delayedAdd();
-        }
+        processQueuedWork();
+    }
+
+    /**
+     * Free a slot directly, with no unlink -- used when deleting a
+     * command-station consist down to its last (lead) engine, where
+     * there's nothing left linked to unlink but the slot itself is
+     * still marked In Use/Common from when the consist was built.
+     * @param s the slot to free
+     */
+    private void freeSlot(LocoNetSlot s) {
+        trafficController.sendLocoNetMessage(s.writeStatus(LnConstants.LOCO_FREE));
+        s.removeSlotListener(this);
+        notifyConsistListeners(new DccLocoAddress(s.locoAddr(),
+                throttleManager.canBeLongAddress(s.locoAddr())),
+                ConsistListener.OPERATION_SUCCESS);
+        processQueuedWork();
     }
 
     private void setDirection(LocoNetThrottle t) {
@@ -424,10 +612,72 @@ public class LocoNetConsist extends jmri.implementation.DccConsist implements Sl
         trafficController.sendLocoNetMessage(s.writeStatus(newstatus));
     }
 
+    /**
+     * Verify a slot response's actual address matches what was
+     * requested (pendingSlotAddress) before acting on it as though it
+     * were the follower/lead engine we asked for.
+     *
+     * FIELD REPORT: on a live LocoNet bus, a single physical throttle
+     * can simultaneously hold more than one address (confirmed case: a
+     * UT6 with an old address still active alongside a new one just
+     * grabbed, both sharing one throttle ID). Without this check, a
+     * slot response for the WRONG address got linked into a consist in
+     * place of the one actually requested -- silently building the
+     * wrong consist rather than failing visibly.
+     *
+     * @return true if the response was unexpected and should NOT be
+     *         acted on (already cleaned up and queue continued)
+     */
+    private boolean unexpectedSlotAddress(LocoNetSlot s) {
+        if (pendingSlotAddress == null) {
+            return false;
+        }
+        if (s.locoAddr() != pendingSlotAddress.getNumber()) {
+            // FIELD REPORT: this used to just drop the pending
+            // add/remove entirely on a mismatch -- correct for
+            // preventing corruption, but for REMOVALS specifically that
+            // left JMRI's own bookkeeping (already updated synchronously
+            // in remove()) permanently out of sync with the real
+            // hardware: JMRI would report an engine as freed/removed
+            // while it stayed fully linked on the actual DCS52.
+            // Confirmed in the field: releasing an engine from a
+            // consist, where the removal's slot response got a mismatch,
+            // left it reporting "removed" in /json/consists while the
+            // Slot Monitor still showed it fully linked. Re-queuing
+            // (ahead of whatever else is pending, so it's retried next)
+            // instead of dropping fixes that -- bounded by
+            // consecutiveSlotMismatches so a genuinely dead/unreachable
+            // address can't retry forever.
+            DccLocoAddress missed = pendingSlotAddress;
+            boolean wasRemoval = (consistRequestState == UNLINKSTAGEONESTATE || consistRequestState == FREESLOTSTATE);
+            log.warn("notifyChangedSlot(): requested slot for {} but got slot {} for address {} instead -- ignoring rather than linking/freeing the wrong engine",
+                    missed, s.getSlot(), s.locoAddr());
+            s.removeSlotListener(this);
+            pendingSlotAddress = null;
+            if (consecutiveSlotMismatches < MAX_CONSECUTIVE_SLOT_MISMATCHES) {
+                consecutiveSlotMismatches++;
+                if (wasRemoval) {
+                    needToRemove.add(0, missed);
+                } else {
+                    needToWrite.add(0, missed);
+                }
+            } else {
+                log.error("notifyChangedSlot(): giving up on {} after {} consecutive mismatched slot responses",
+                        missed, consecutiveSlotMismatches);
+                notifyConsistListeners(missed, ConsistListener.CONSIST_ERROR);
+            }
+            processQueuedWork();
+            return true;
+        }
+        pendingSlotAddress = null;
+        consecutiveSlotMismatches = 0;
+        return false;
+    }
+
     // slot listener interface functions
     @Override
     public void notifyChangedSlot(LocoNetSlot s) {
-        log.debug("Notified slot {} changed with mode {} slot consist state: {}", 
+        log.debug("Notified slot {} changed with mode {} slot consist state: {}",
             s.getSlot(), consistRequestState, LnConstants.CONSIST_STAT(s.consistStatus()));
         switch (consistRequestState) {
             case LEADREQUESTSTATE:
@@ -440,21 +690,26 @@ public class LocoNetConsist extends jmri.implementation.DccConsist implements Sl
                 consistRequestState = LINKSTAGETWOSTATE;
                 break;
             case LINKSTAGETWOSTATE:
-                linkSlots(leadSlot, s);
+                if (!unexpectedSlotAddress(s)) {
+                    linkSlots(leadSlot, s);
+                }
                 break;
             case UNLINKSTAGEONESTATE:
-                unlinkSlots(leadSlot, s);
+                if (!unexpectedSlotAddress(s)) {
+                    unlinkSlots(leadSlot, s);
+                }
+                break;
+            case FREESLOTSTATE:
+                if (!unexpectedSlotAddress(s)) {
+                    freeSlot(s);
+                }
                 break;
             default:
                 s.removeSlotListener(this);
                 notifyConsistListeners(new DccLocoAddress(s.locoAddr(),
                         throttleManager.canBeLongAddress(s.locoAddr())),
                         ConsistListener.OPERATION_SUCCESS);
-                if (!needToWrite.isEmpty()) {
-                    delayedAdd();
-                } else {
-                    consistRequestState = IDLESTATE;
-                }
+                processQueuedWork();
         }
     }
 
@@ -466,10 +721,7 @@ public class LocoNetConsist extends jmri.implementation.DccConsist implements Sl
             if (consistRequestState == LEADREQUESTSTATE) {
                 ((LocoNetThrottle) t).setIsForward(true);
                 leadSlot = ((LocoNetThrottle) t).getLocoNetSlot();
-                consistRequestState = IDLESTATE;
-                if (!needToWrite.isEmpty()) {
-                    delayedAdd();
-                }
+                processQueuedWork();
             } else {
                 LocoNetSlot tempSlot = ((LocoNetThrottle) t).getLocoNetSlot();
                 if (tempSlot != null) {
@@ -490,10 +742,7 @@ public class LocoNetConsist extends jmri.implementation.DccConsist implements Sl
             // get a ClassCastException.
             if (consistRequestState == LEADREQUESTSTATE) {
                 t.setIsForward(true);
-                consistRequestState = IDLESTATE;
-                if (!needToWrite.isEmpty()) {
-                    delayedAdd();
-                }
+                processQueuedWork();
             } else {
                 if (t instanceof LocoNetThrottle) {
                     LocoNetThrottle lt = (LocoNetThrottle)t;
@@ -511,7 +760,8 @@ public class LocoNetConsist extends jmri.implementation.DccConsist implements Sl
         notifyConsistListeners((DccLocoAddress) address,
                 ConsistListener.CONSIST_ERROR);
         removeFromConsistList((DccLocoAddress) address);
-        consistRequestState = IDLESTATE;
+        pendingSlotAddress = null;
+        processQueuedWork();
     }
 
     /**

--- a/java/src/jmri/jmrix/loconet/LocoNetConsist.java
+++ b/java/src/jmri/jmrix/loconet/LocoNetConsist.java
@@ -26,17 +26,10 @@ public class LocoNetConsist extends jmri.implementation.DccConsist implements Sl
     // report on removeFromCSConsist() below for why this exists.
     private ArrayList<DccLocoAddress> needToRemove = null;
 
-    // FIELD REPORT: the address a pending LINKSTAGETWOSTATE/
-    // UNLINKSTAGEONESTATE/FREESLOTSTATE slot request was actually made
-    // for. notifyChangedSlot() previously just trusted whatever slot
-    // object it was handed as "the one we asked for" -- on a live
-    // LocoNet bus with a physical throttle simultaneously holding more
-    // than one address (confirmed field case: a UT6 throttle with an
-    // old address still active alongside the new one being grabbed,
-    // both sharing one throttle ID), a slot response for the WRONG
-    // address arrived and got linked into the consist instead of the
-    // one actually requested. Set right before each request fires,
-    // checked in notifyChangedSlot() before acting on the response.
+    // Address the current pending slot request is for. notifyChangedSlot()
+    // checks a response against this before acting on it -- a single
+    // throttle can hold more than one address on a live LocoNet bus, so a
+    // mismatched response must never be linked in as the requested engine.
     private DccLocoAddress pendingSlotAddress = null;
     // Bounds the mismatch-triggered retry in unexpectedSlotAddress()
     // below so a genuinely dead/unreachable address can't retry
@@ -179,12 +172,8 @@ public class LocoNetConsist extends jmri.implementation.DccConsist implements Sl
      * Remove an address from the internal Consist list object.
      */
     private synchronized void removeFromConsistList(DccLocoAddress locoAddress) {
-        // FIELD REPORT: called from notifyFailedThrottleRequest(), which
-        // fires asynchronously (from LnThrottleManager's retry thread)
-        // and can arrive well after dispose() already nulled these out --
-        // NPE'd here and, worse, took down LnThrottleManager's own
-        // bookkeeping with it (see the try/finally added around
-        // failedThrottleRequest() in LnThrottleManager.java).
+        // Can already be null if dispose() ran first -- this is also
+        // reached asynchronously from LnThrottleManager's retry thread.
         if (consistDir == null || consistList == null) {
             return;
         }
@@ -262,17 +251,10 @@ public class LocoNetConsist extends jmri.implementation.DccConsist implements Sl
         if (needToRemove.isEmpty()) {
             return;
         }
-        // FIELD REPORT (Andrew Deak): if the consist's own address is
-        // queued here alongside genuine followers, it must always be
-        // drained LAST, never just because it happens to be at the
-        // front of the queue (e.g. queued first, before followers, by
-        // a caller that removes the lead before its followers -- see
-        // the field report on removeFromCSConsist()'s lead==follow
-        // guard). Freeing the lead's slot before every other queued
-        // follower has actually been unlinked -- not just requested --
-        // would orphan their real LocoNet link. Prefer any non-lead
-        // entry first; only take the lead's own entry once it's the
-        // only thing left in the queue.
+        // The consist's own address, if queued, must always drain LAST --
+        // freeing its slot before every other queued follower is actually
+        // unlinked (not just requested) would orphan their real LocoNet
+        // link. Prefer any non-lead entry first.
         DccLocoAddress locoAddress = needToRemove.get(0);
         if (locoAddress.equals(consistAddress) && needToRemove.size() > 1) {
             for (DccLocoAddress candidate : needToRemove) {
@@ -302,31 +284,15 @@ public class LocoNetConsist extends jmri.implementation.DccConsist implements Sl
             consistRequestState = IDLESTATE;
             return;
         }
-        // FIELD REPORT: draining the next queued item here directly
-        // (delayedRemove()/delayedAdd()) caused a real StackOverflowError.
-        // AbstractThrottleManager.requestThrottle() calls back
-        // SYNCHRONOUSLY (same call stack) when the address's throttle is
-        // already known/cached (see its "already exists" branch) -- so
-        // once enough addresses were already known (which happens fast
-        // once a session has touched a lot of addresses, as this one
-        // has), draining the queue synchronously recursed: drain -> fire
-        // request -> synchronous callback -> drain next -> fire ->
-        // callback -> ... with no base case, until the stack overflowed
-        // and the whole operation silently aborted -- explaining engines
-        // that never got a real slot with zero error logged. Deferring
-        // via invokeLater() breaks the call stack chain: each item runs
-        // on a fresh event, not nested inside the previous one's.
+        // Deferred via invokeLater() -- draining synchronously here can
+        // recurse indefinitely and stack-overflow, since requestThrottle()
+        // calls back synchronously when a throttle is already cached, with
+        // no base case to stop the chain.
         javax.swing.SwingUtilities.invokeLater(() -> {
             synchronized (LocoNetConsist.this) {
                 // Must reset to IDLESTATE before draining the next item --
-                // removeFromCSConsist()/the add path both check this field
-                // to decide fire-now vs queue-again. Leaving it at
-                // whatever busy value the PREVIOUS operation set made
-                // every deferred drain see "still busy" and silently
-                // re-queue the item instead of ever processing it -- the
-                // lead engine (queued last, since dispose() processes it
-                // last) would re-queue itself indefinitely and never
-                // actually get freed, staying stuck "In Use" forever.
+                // otherwise it sees "still busy" and re-queues instead of
+                // processing, looping forever without ever completing.
                 consistRequestState = IDLESTATE;
                 if (!needToRemove.isEmpty()) {
                     delayedRemove();
@@ -425,16 +391,10 @@ public class LocoNetConsist extends jmri.implementation.DccConsist implements Sl
             locoAddress, consistAddress, directionNormal);
         if(consistList.size()<=1 && locoAddress.equals(consistAddress)){
           // there is only one address in this consist, no reason to link.
-          // FIELD REPORT: this used to just return here, leaving
-          // consistRequestState untouched and the rest of needToWrite
-          // undrained -- since add()'s locoAddress==consistAddress check
-          // uses reference equality and the JSON/GUI paths always
-          // construct a fresh DccLocoAddress, the lead's own address
-          // routes through here (as a queued no-op) almost every time,
-          // silently dead-ending the queue chain before any real
-          // follower engine ever got processed. processQueuedWork()
-          // keeps the chain moving exactly like every other exit point
-          // in this class does.
+          // Must still call processQueuedWork() here -- add()'s reference
+          // equality check means the lead's own address reaches this
+          // no-op branch almost every time, and without this the queue
+          // chain dead-ends before any real follower is ever processed.
           notifyConsistListeners(locoAddress,ConsistListener.OPERATION_SUCCESS);
           processQueuedWork();
           return;
@@ -451,21 +411,10 @@ public class LocoNetConsist extends jmri.implementation.DccConsist implements Sl
      */
     public synchronized void removeFromCSConsist(DccLocoAddress locoAddress) {
         log.debug("Remove Locomotive {} from Standard Consist {}.", locoAddress, consistAddress);
-        // FIELD REPORT: dispose() (called by delConsist(), i.e. deleting a
-        // whole consist from the Consist Tool panel or the JSON DELETE
-        // endpoint) loops calling remove() synchronously for every member
-        // with no pacing at all -- unlike add(), which already checks
-        // this same consistRequestState field and queues into
-        // needToWrite when something's in flight. Without an equivalent
-        // guard here, every member's slot request fired at once, all
-        // sharing this ONE consistRequestState field (each overwriting
-        // the last), and unlike the add path there is no retry for a
-        // dropped slot request. Field-tested on a real DCS52 deleting a
-        // 19-engine consist: every slot request but the first was lost,
-        // and every member stayed fully "In Use"/linked in the Slot
-        // Monitor -- the delete silently did nothing for 18 of 19
-        // engines. Queuing here, exactly like add() does, serializes
-        // removals one at a time via delayedRemove().
+        // dispose() removes every member synchronously with no pacing, all
+        // sharing this one consistRequestState field -- without queuing
+        // here (like add() already does), concurrent slot requests
+        // overwrite each other and most removals are silently lost.
         if (consistRequestState != IDLESTATE) {
             needToRemove.add(locoAddress);
             return;
@@ -477,65 +426,32 @@ public class LocoNetConsist extends jmri.implementation.DccConsist implements Sl
           // directly rather than leaving it stuck (see FREESLOTSTATE
           // in notifyChangedSlot()).
           //
-          // FIELD REPORT: consistList == null happens when this call
-          // arrives via the needToRemove queue for the LEAD's own
-          // address -- dispose() enqueues it last (it's index 0,
-          // processed last by the size-1-down-to-0 loop), and by the
-          // time the deferred invokeLater() actually runs it,
-          // dispose()'s loop has already finished and nulled consistList
-          // out. There's nothing left to unlink against either way (every
-          // other member was already processed first), so this is really
-          // the same case as "sole remaining member" -- just free the
-          // slot. Without this, consistList.size() NPE'd here and the
-          // lead engine's slot never got freed, staying stuck "In Use".
-          //
-          // FIELD REPORT: consistList.isEmpty() (size 0, not null) is a
-          // related but distinct case, added after confirming it live --
-          // removeFromConsistList() strips an address from consistList
-          // SYNCHRONOUSLY the instant its remove() is called, regardless
-          // of whether the real async LocoNet unlink for it has actually
-          // completed yet. So once every member (including the lead
-          // itself, if its own removal was deferred below rather than
-          // processed immediately) has at least been REQUESTED, consistList
-          // reads back empty well before the lead's deferred removal is
-          // actually retried -- size()==1 alone would never match at that
-          // point, and this needs the same "just free the slot" treatment.
+          // consistList == null covers the lead's own deferred removal
+          // arriving after dispose()'s loop has already finished and
+          // nulled it out; consistList.isEmpty() covers the same "nothing
+          // left to unlink against" case but before the null reset --
+          // removeFromConsistList() strips an address synchronously the
+          // instant remove() is called, regardless of whether the real
+          // async unlink completed, so this can read back empty before
+          // the lead's own deferred removal is retried. Both need the
+          // same "just free the slot" treatment as the sole-member case.
           pendingSlotAddress = locoAddress;
           slotManager.slotFromLocoAddress(locoAddress.getNumber(), this);
           consistRequestState = FREESLOTSTATE;
           return;
         }
         if (locoAddress.equals(consistAddress)) {
-          // FIELD REPORT (Andrew Deak, confirmed live against a real
-          // DCS52 across 3 separate test consists): leadSlot is cached
-          // once at construction and never updated. Removing the
-          // consist's OWN address here while other real members are
-          // STILL tracked (the branch above didn't apply) would fall
-          // through to the generic unlink path below, which resolves
-          // BOTH "lead" and "follow" to that exact same cached leadSlot
-          // object -- there's nothing else to unlink the lead's own
-          // identity from. unlinkSlots()'s lead==follow guard (built for
-          // a different, degenerate self-link scenario) then fires:
-          // logs a CONSIST_ERROR/DELETE_ERROR and returns with NO
-          // LocoNet message ever sent and no retry -- permanently
-          // leaving this slot exactly as it was, stuck "In Use" in the
-          // Slot Monitor (confirmed live, visible there with Consist
-          // status "top"). Triggered whenever a caller removes the
-          // lead's own address before its followers are gone (e.g. a
-          // firmware doing an explicit per-engine teardown pass, lead
-          // first, ahead of the final consist delete) -- not just a
-          // hypothetical. Re-queuing here defers the lead's own removal
-          // until it's genuinely the sole remaining member (the branch
-          // above), the only order that's safe: freeing the lead's slot
-          // while real followers are still LocoNet-linked to it BY SLOT
-          // NUMBER on the actual hardware would orphan their physical
-          // link, corrupting the consist on the command station even
-          // though JMRI's own bookkeeping would look fine. Safe to defer
-          // indefinitely here rather than looping back through
-          // processQueuedWork() immediately -- nothing has changed yet,
-          // so an immediate retry would just hit this exact same branch
-          // again. Whichever other member's removal completes next will
-          // drain this via processQueuedWork() once it's genuinely safe.
+          // leadSlot is cached once at construction and never updated, so
+          // removing the lead's own address while other members are still
+          // tracked would fall through to the generic unlink path below
+          // and resolve BOTH lead and follow to that same slot object --
+          // tripping unlinkSlots()'s lead==follow guard, which sends no
+          // LocoNet message and never retries, permanently stranding the
+          // slot as "In Use". Deferring here until the lead is genuinely
+          // the last member left (the branch above) is the only safe
+          // order: freeing its slot while followers are still linked to
+          // it by slot number on the real hardware would corrupt the
+          // consist there even though JMRI's own bookkeeping looks fine.
           needToRemove.add(locoAddress);
           return;
         }
@@ -682,13 +598,9 @@ public class LocoNetConsist extends jmri.implementation.DccConsist implements Sl
      * requested (pendingSlotAddress) before acting on it as though it
      * were the follower/lead engine we asked for.
      *
-     * FIELD REPORT: on a live LocoNet bus, a single physical throttle
-     * can simultaneously hold more than one address (confirmed case: a
-     * UT6 with an old address still active alongside a new one just
-     * grabbed, both sharing one throttle ID). Without this check, a
-     * slot response for the WRONG address got linked into a consist in
-     * place of the one actually requested -- silently building the
-     * wrong consist rather than failing visibly.
+     * A single physical throttle can hold more than one address on a live
+     * LocoNet bus, so a slot response isn't guaranteed to match what was
+     * requested -- acting on it unchecked can link the wrong engine in.
      *
      * @return true if the response was unexpected and should NOT be
      *         acted on (already cleaned up and queue continued)
@@ -698,20 +610,11 @@ public class LocoNetConsist extends jmri.implementation.DccConsist implements Sl
             return false;
         }
         if (s.locoAddr() != pendingSlotAddress.getNumber()) {
-            // FIELD REPORT: this used to just drop the pending
-            // add/remove entirely on a mismatch -- correct for
-            // preventing corruption, but for REMOVALS specifically that
-            // left JMRI's own bookkeeping (already updated synchronously
-            // in remove()) permanently out of sync with the real
-            // hardware: JMRI would report an engine as freed/removed
-            // while it stayed fully linked on the actual DCS52.
-            // Confirmed in the field: releasing an engine from a
-            // consist, where the removal's slot response got a mismatch,
-            // left it reporting "removed" in /json/consists while the
-            // Slot Monitor still showed it fully linked. Re-queuing
-            // (ahead of whatever else is pending, so it's retried next)
-            // instead of dropping fixes that -- bounded by
-            // consecutiveSlotMismatches so a genuinely dead/unreachable
+            // Re-queue rather than drop on a mismatch -- for removals
+            // specifically, dropping left JMRI's bookkeeping (already
+            // updated synchronously in remove()) out of sync with the
+            // real hardware, reporting an engine freed while it stayed
+            // linked. Bounded by consecutiveSlotMismatches so a dead
             // address can't retry forever.
             DccLocoAddress missed = pendingSlotAddress;
             boolean wasRemoval = (consistRequestState == UNLINKSTAGEONESTATE || consistRequestState == FREESLOTSTATE);

--- a/java/src/jmri/jmrix/loconet/LocoNetConsistManager.java
+++ b/java/src/jmri/jmrix/loconet/LocoNetConsistManager.java
@@ -101,10 +101,36 @@ public class LocoNetConsistManager extends AbstractConsistManager {
                 if (log.isDebugEnabled()) {
                     log.debug(" Slot {} Address {} consist status {}", i, address, LnConstants.CONSIST_STAT(s.consistStatus()));
                 }
-                if (s.consistStatus() == LnConstants.CONSIST_TOP || s.consistStatus() == LnConstants.CONSIST_MID) {
+                // FIELD REPORT: this used to also match CONSIST_MID here.
+                // CONSIST_MID means a locomotive that has a lead above it
+                // AND another member pointing to it below -- normal for
+                // any chain of 3+ members. It is a MEMBER, never its own
+                // top -- the second pass below already correctly handles
+                // CONSIST_MID by following its pointer to its real lead
+                // (line ~126). Treating it as a top here as well created
+                // a phantom duplicate top-level consist for every
+                // mid-chain member: confirmed in the field with a
+                // 5-engine consist where the middle engine ended up
+                // registered as BOTH a member of the real consist AND its
+                // own separate one-engine "consist", corrupting JMRI's
+                // consist list and the Consist Tool display.
+                if (s.consistStatus() == LnConstants.CONSIST_TOP) {
                     // this is a consist top, add it to the list, if it is not there
                     // already.
-                    if (!consistTable.containsKey(address)) {
+                    //
+                    // FIELD REPORT: also guard against this address
+                    // already being tracked as a MEMBER of some other
+                    // consist. A locomotive mid-way through being linked
+                    // into a consist can briefly still report CONSIST_TOP
+                    // on the wire (it hasn't been linked yet) -- if a
+                    // layout rescan lands in that exact window, it
+                    // registers a phantom standalone consist for an
+                    // address our own in-progress build is about to claim
+                    // as a member, corrupting the consist list (confirmed
+                    // in the field: an engine ended up listed under two
+                    // different consists at once). Skip if some other
+                    // already-tracked consist already claims it.
+                    if (!consistTable.containsKey(address) && !isAlreadyConsistMember(address)) {
                         if (log.isDebugEnabled()) {
                             log.debug("Adding Consist with Address {} due to command station read", address);
                         }
@@ -127,8 +153,32 @@ public class LocoNetConsistManager extends AbstractConsistManager {
                     // this is a consist member, add it to the consist in the
                     // slot which it has a pointer to (the slot pointer is stored in
                     // the slot's speed).
-                    DccLocoAddress lead = new DccLocoAddress(sm.slot(s.speed()).locoAddr(), LnThrottleManager.isLongAddress(sm.slot(s.speed()).locoAddr()));
-                    getConsist(lead).add(address, s.isForward() == sm.slot(s.speed()).isForward());
+                    //
+                    // FIELD REPORT: this used to trust that pointer blindly.
+                    // On a command station that's had a lot of addresses
+                    // reused across many separate consist builds (confirmed
+                    // in the field after a long test session), a slot's
+                    // "speed" pointer can still reference a slot number that
+                    // USED to be some earlier, now-defunct consist's lead --
+                    // the pointer itself doesn't get cleared just because
+                    // that old lead relationship ended. Blindly following it
+                    // created a phantom consist keyed to whatever address now
+                    // happens to occupy that stale slot number, with this
+                    // member wrongly attached to it (observed: a phantom
+                    // consist "8002" whose only member was "8006", neither
+                    // of which had anything to do with each other -- 8002
+                    // just happened to be sitting in the slot that some
+                    // earlier test's pointer still referenced). Now verifies
+                    // the pointed-to slot is ACTUALLY a live top/mid right
+                    // now before trusting it as this member's real lead.
+                    LocoNetSlot leadSlot = sm.slot(s.speed());
+                    if (leadSlot.consistStatus() == LnConstants.CONSIST_TOP || leadSlot.consistStatus() == LnConstants.CONSIST_MID) {
+                        DccLocoAddress lead = new DccLocoAddress(leadSlot.locoAddr(), LnThrottleManager.isLongAddress(leadSlot.locoAddr()));
+                        getConsist(lead).add(address, s.isForward() == leadSlot.isForward());
+                    } else if (log.isDebugEnabled()) {
+                        log.debug("Slot {} (address {}) claims consist member status but its lead pointer (slot {}) isn't currently a top/mid -- stale pointer, ignoring",
+                                i, address, s.speed());
+                    }
                 }
             }
         }
@@ -139,5 +189,21 @@ public class LocoNetConsistManager extends AbstractConsistManager {
     protected boolean shouldRequestUpdateFromLayout() {
         return !requestingUpdate;
     }
+
+    /**
+     * Is address already tracked as a MEMBER of some other already-known
+     * consist? See the field report on the CONSIST_TOP check above --
+     * used to avoid registering a phantom standalone consist for an
+     * address that's really just mid-link into an existing one.
+     */
+    private boolean isAlreadyConsistMember(DccLocoAddress address) {
+        for (Consist c : consistTable.values()) {
+            if (!address.equals(c.getConsistAddress()) && c.contains(address)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     private static final Logger log = LoggerFactory.getLogger(LocoNetConsistManager.class);
 }

--- a/java/src/jmri/jmrix/loconet/LocoNetConsistManager.java
+++ b/java/src/jmri/jmrix/loconet/LocoNetConsistManager.java
@@ -101,35 +101,22 @@ public class LocoNetConsistManager extends AbstractConsistManager {
                 if (log.isDebugEnabled()) {
                     log.debug(" Slot {} Address {} consist status {}", i, address, LnConstants.CONSIST_STAT(s.consistStatus()));
                 }
-                // FIELD REPORT: this used to also match CONSIST_MID here.
+                // Only CONSIST_TOP is treated as a consist top here.
                 // CONSIST_MID means a locomotive that has a lead above it
                 // AND another member pointing to it below -- normal for
                 // any chain of 3+ members. It is a MEMBER, never its own
-                // top -- the second pass below already correctly handles
-                // CONSIST_MID by following its pointer to its real lead
-                // (line ~126). Treating it as a top here as well created
-                // a phantom duplicate top-level consist for every
-                // mid-chain member: confirmed in the field with a
-                // 5-engine consist where the middle engine ended up
-                // registered as BOTH a member of the real consist AND its
-                // own separate one-engine "consist", corrupting JMRI's
-                // consist list and the Consist Tool display.
+                // top -- the second pass below handles CONSIST_MID by
+                // following its pointer to its real lead.
                 if (s.consistStatus() == LnConstants.CONSIST_TOP) {
                     // this is a consist top, add it to the list, if it is not there
                     // already.
                     //
-                    // FIELD REPORT: also guard against this address
-                    // already being tracked as a MEMBER of some other
-                    // consist. A locomotive mid-way through being linked
-                    // into a consist can briefly still report CONSIST_TOP
-                    // on the wire (it hasn't been linked yet) -- if a
-                    // layout rescan lands in that exact window, it
-                    // registers a phantom standalone consist for an
-                    // address our own in-progress build is about to claim
-                    // as a member, corrupting the consist list (confirmed
-                    // in the field: an engine ended up listed under two
-                    // different consists at once). Skip if some other
-                    // already-tracked consist already claims it.
+                    // Also skip if this address is already tracked as a
+                    // MEMBER of some other consist -- a locomotive mid-way
+                    // through being linked into a consist can briefly still
+                    // report CONSIST_TOP on the wire before it's linked, so
+                    // this avoids registering a phantom standalone consist
+                    // for an address already claimed elsewhere.
                     if (!consistTable.containsKey(address) && !isAlreadyConsistMember(address)) {
                         if (log.isDebugEnabled()) {
                             log.debug("Adding Consist with Address {} due to command station read", address);
@@ -154,23 +141,12 @@ public class LocoNetConsistManager extends AbstractConsistManager {
                     // slot which it has a pointer to (the slot pointer is stored in
                     // the slot's speed).
                     //
-                    // FIELD REPORT: this used to trust that pointer blindly.
-                    // On a command station that's had a lot of addresses
-                    // reused across many separate consist builds (confirmed
-                    // in the field after a long test session), a slot's
-                    // "speed" pointer can still reference a slot number that
-                    // USED to be some earlier, now-defunct consist's lead --
-                    // the pointer itself doesn't get cleared just because
-                    // that old lead relationship ended. Blindly following it
-                    // created a phantom consist keyed to whatever address now
-                    // happens to occupy that stale slot number, with this
-                    // member wrongly attached to it (observed: a phantom
-                    // consist "8002" whose only member was "8006", neither
-                    // of which had anything to do with each other -- 8002
-                    // just happened to be sitting in the slot that some
-                    // earlier test's pointer still referenced). Now verifies
-                    // the pointed-to slot is ACTUALLY a live top/mid right
-                    // now before trusting it as this member's real lead.
+                    // Verifies the pointed-to slot is ACTUALLY a live top/mid
+                    // right now before trusting it as this member's real
+                    // lead -- a slot's "speed" pointer can still reference a
+                    // slot number that used to be some earlier, now-defunct
+                    // consist's lead, since the pointer itself doesn't get
+                    // cleared just because that old lead relationship ended.
                     LocoNetSlot leadSlot = sm.slot(s.speed());
                     if (leadSlot.consistStatus() == LnConstants.CONSIST_TOP || leadSlot.consistStatus() == LnConstants.CONSIST_MID) {
                         DccLocoAddress lead = new DccLocoAddress(leadSlot.locoAddr(), LnThrottleManager.isLongAddress(leadSlot.locoAddr()));

--- a/java/src/jmri/server/json/consist/JsonConsistHttpService.java
+++ b/java/src/jmri/server/json/consist/JsonConsistHttpService.java
@@ -128,14 +128,9 @@ public class JsonConsistHttpService extends JsonHttpService {
     }
 
     /**
-     * FIELD REPORT: nothing previously stopped an engine already claimed
-     * by one consist from silently being added to a second one too --
-     * confirmed reachable through this exact JSON path (independent of
-     * the layout-rescan duplicate-consist bugs fixed elsewhere in
-     * LocoNetConsistManager). Removes the engine from any OTHER consist
-     * that currently has it before it gets added here, so an operator
-     * who forgot to release an engine from an old consist can just grab
-     * it into a new one rather than being blocked -- while still
+     * Removes engineAddress from any OTHER consist that currently has it,
+     * so an operator who forgot to release an engine from an old consist
+     * can grab it into a new one instead of being blocked, while still
      * guaranteeing an engine is never a member of two consists at once.
      *
      * @param engineAddress the engine about to be added

--- a/java/src/jmri/server/json/consist/JsonConsistHttpService.java
+++ b/java/src/jmri/server/json/consist/JsonConsistHttpService.java
@@ -107,6 +107,7 @@ public class JsonConsistHttpService extends JsonHttpService {
                 DccLocoAddress engineAddress =
                         new DccLocoAddress(engine.path(ADDRESS).asInt(), engine.path(IS_LONG_ADDRESS).asBoolean());
                 if (!consist.contains(engineAddress)) {
+                    removeFromOtherConsists(engineAddress, address);
                     consist.add(engineAddress, engine.path(FORWARD).asBoolean());
                 }
                 consist.setPosition(engineAddress, engine.path(POSITION).asInt());
@@ -124,6 +125,33 @@ public class JsonConsistHttpService extends JsonHttpService {
             throw new JsonException(500, ex.getLocalizedMessage(), request.id);
         }
         return this.getConsist(address, request);
+    }
+
+    /**
+     * FIELD REPORT: nothing previously stopped an engine already claimed
+     * by one consist from silently being added to a second one too --
+     * confirmed reachable through this exact JSON path (independent of
+     * the layout-rescan duplicate-consist bugs fixed elsewhere in
+     * LocoNetConsistManager). Removes the engine from any OTHER consist
+     * that currently has it before it gets added here, so an operator
+     * who forgot to release an engine from an old consist can just grab
+     * it into a new one rather than being blocked -- while still
+     * guaranteeing an engine is never a member of two consists at once.
+     *
+     * @param engineAddress the engine about to be added
+     * @param excludeConsistAddress the consist it's being added to (skip
+     *                               this one, it's not "other")
+     */
+    private void removeFromOtherConsists(DccLocoAddress engineAddress, LocoAddress excludeConsistAddress) {
+        for (LocoAddress otherConsistAddress : new ArrayList<>(this.manager.getConsistList())) {
+            if (otherConsistAddress.equals(excludeConsistAddress)) {
+                continue;
+            }
+            Consist other = this.manager.getConsist(otherConsistAddress);
+            if (other.contains(engineAddress)) {
+                other.remove(engineAddress);
+            }
+        }
     }
 
     @Override

--- a/java/src/jmri/server/json/loconet/Bundle.java
+++ b/java/src/jmri/server/json/loconet/Bundle.java
@@ -92,7 +92,7 @@ public class Bundle extends jmri.server.json.Bundle {
         return getBundle().handleGetMessage(locale, key, subs);
     }
 
-    private final static Bundle b = new Bundle();
+    private static final Bundle b = new Bundle();
 
     @Override
     @CheckForNull

--- a/java/src/jmri/server/json/loconet/Bundle.java
+++ b/java/src/jmri/server/json/loconet/Bundle.java
@@ -1,0 +1,112 @@
+package jmri.server.json.loconet;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.util.Locale;
+import javax.annotation.CheckReturnValue;
+import javax.annotation.CheckForNull;
+import javax.annotation.ParametersAreNonnullByDefault;
+
+@ParametersAreNonnullByDefault
+@CheckReturnValue
+@SuppressFBWarnings(value = {"NM_SAME_SIMPLE_NAME_AS_SUPERCLASS", "HSM_HIDING_METHOD"},
+    justification = "Desired pattern is repeated class names with package-level access to members")
+
+@javax.annotation.concurrent.Immutable
+
+/**
+ * Provides standard access for resource bundles in a package.
+ *
+ * Convention is to provide a subclass of this name in each package, working off
+ * the local resource bundle name.
+ *
+ * @author Bob Jacobsen Copyright (C) 2012
+ * @since 3.3.1
+ */
+public class Bundle extends jmri.server.json.Bundle {
+
+    @CheckForNull
+    private static final String name = null; // no local resources
+
+    //
+    // below here is boilerplate to be copied exactly
+    //
+    /**
+     * Provides a translated string for a given key from the package resource
+     * bundle or parent.
+     * <p>
+     * Note that this is intentionally package-local access.
+     *
+     * @param key Bundle key to be translated
+     * @return Internationalized text
+     */
+    static String getMessage(String key) {
+        return getBundle().handleGetMessage(key);
+    }
+
+    /**
+     * Provides a translated string for a given key in a given locale from the
+     * package resource bundle or parent.
+     * <p>
+     * Note that this is intentionally package-local access.
+     *
+     * @param locale The locale to be used
+     * @param key    Bundle key to be translated
+     * @return Internationalized text
+     */
+    static String getMessage(Locale locale, String key) {
+        return getBundle().handleGetMessage(locale, key);
+    }
+
+    /**
+     * Merges user data with a translated string for a given key from the
+     * package resource bundle or parent.
+     * <p>
+     * Uses the transformation conventions of the Java MessageFormat utility.
+     * <p>
+     * Note that this is intentionally package-local access.
+     *
+     * @see java.text.MessageFormat
+     * @param key  Bundle key to be translated
+     * @param subs One or more objects to be inserted into the message
+     * @return Internationalized text
+     */
+    static String getMessage(String key, Object... subs) {
+        return getBundle().handleGetMessage(key, subs);
+    }
+
+    /**
+     * Merges user data with a translated string for a given key in a given
+     * locale from the package resource bundle or parent.
+     * <p>
+     * Uses the transformation conventions of the Java MessageFormat utility.
+     * <p>
+     * Note that this is intentionally package-local access.
+     *
+     * @see java.text.MessageFormat
+     * @param locale The locale to be used
+     * @param key    Bundle key to be translated
+     * @param subs   One or more objects to be inserted into the message
+     * @return Internationalized text
+     */
+    static String getMessage(Locale locale, String key, Object... subs) {
+        return getBundle().handleGetMessage(locale, key, subs);
+    }
+
+    private final static Bundle b = new Bundle();
+
+    @Override
+    @CheckForNull
+    protected String bundleName() {
+        return name;
+    }
+
+    protected static jmri.Bundle getBundle() {
+        return b;
+    }
+
+    @Override
+    protected String retry(Locale locale, String key) {
+        return super.getBundle().handleGetMessage(locale,key);
+    }
+
+}

--- a/java/src/jmri/server/json/loconet/JsonLoconetSlotUsage.java
+++ b/java/src/jmri/server/json/loconet/JsonLoconetSlotUsage.java
@@ -3,11 +3,10 @@ package jmri.server.json.loconet;
 /**
  * Constants for the JSON LocoNet slot usage service.
  *
- * FIELD REPORT (Andrew Deak): added to give ESP32/WiFi throttle clients an
- * authoritative answer to "is the command station's loco slot table
- * actually full?" instead of inferring it from link-confirmation retries
- * failing, which can also fail for unrelated reasons (address mismatches,
- * timing) and produce false "slot full" diagnoses.
+ * Gives clients an authoritative answer to "is the command station's loco
+ * slot table actually full?" instead of inferring it from link-confirmation
+ * retries failing, which can also fail for unrelated reasons (address
+ * mismatches, timing) and produce false "slot full" diagnoses.
  */
 public class JsonLoconetSlotUsage {
 

--- a/java/src/jmri/server/json/loconet/JsonLoconetSlotUsage.java
+++ b/java/src/jmri/server/json/loconet/JsonLoconetSlotUsage.java
@@ -1,0 +1,22 @@
+package jmri.server.json.loconet;
+
+/**
+ * Constants for the JSON LocoNet slot usage service.
+ *
+ * FIELD REPORT (Andrew Deak): added to give ESP32/WiFi throttle clients an
+ * authoritative answer to "is the command station's loco slot table
+ * actually full?" instead of inferring it from link-confirmation retries
+ * failing, which can also fail for unrelated reasons (address mismatches,
+ * timing) and produce false "slot full" diagnoses.
+ */
+public class JsonLoconetSlotUsage {
+
+    /**
+     * {@value #LOCONET_SLOT_USAGE}
+     */
+    public static final String LOCONET_SLOT_USAGE = "loconetSlotUsage"; // NOI18N
+
+    private JsonLoconetSlotUsage() {
+        // static class, do not instantiate
+    }
+}

--- a/java/src/jmri/server/json/loconet/JsonLoconetSlotUsageHttpService.java
+++ b/java/src/jmri/server/json/loconet/JsonLoconetSlotUsageHttpService.java
@@ -21,13 +21,13 @@ import jmri.server.json.JsonRequest;
  * Reports real LocoNet loco-slot table usage (used/free/total) for the
  * active connection's command station.
  *
- * FIELD REPORT (Andrew Deak): read-only -- iterates the SlotManager's
- * already in-memory slot array, sending no new LocoNet traffic of its
- * own. "total" reflects the connected command station's real per-model
- * capacity (from the same LnCommandStationType data JMRI already uses to
- * auto-detect the connection), not JMRI's generic upper bound, which is
- * sized for the largest command station JMRI knows about and would
- * overstate real capacity for anything smaller.
+ * Read-only -- iterates the SlotManager's already in-memory slot array,
+ * sending no new LocoNet traffic of its own. "total" reflects the
+ * connected command station's real per-model capacity (from the same
+ * LnCommandStationType data JMRI already uses to auto-detect the
+ * connection), not JMRI's generic upper bound, which is sized for the
+ * largest command station JMRI knows about and would overstate real
+ * capacity for anything smaller.
  *
  * @author Andrew Deak Copyright (C) 2026
  */
@@ -53,16 +53,11 @@ public class JsonLoconetSlotUsageHttpService extends JsonHttpService {
             LocoNetSlot s = sm.slot(i);
             if (s.getSlotType() == SlotType.LOCO) {
                 total++;
-                // FIELD REPORT (Andrew Deak): an Idle slot (dispatched or
-                // released, address still resident but not actively driven)
-                // is capacity the command station will reclaim for the next
-                // engine added -- confirmed live against a real DCS52 after
-                // dispatching an engine from the handset: the slot showed
-                // "Idle" in the Slot Monitor, but this endpoint kept
-                // reporting it as used, so a client polling "free" never saw
-                // the slot come back. Only In-Use/Common hold a live,
-                // actively-driven address that isn't available for a
-                // different loco.
+                // An Idle slot (dispatched or released, address still
+                // resident but not actively driven) is capacity the command
+                // station will reclaim for the next engine added. Only
+                // In-Use/Common hold a live, actively-driven address that
+                // isn't available for a different loco.
                 int status = s.slotStatus() & LnConstants.LOCOSTAT_MASK;
                 if (status == LnConstants.LOCO_IN_USE || status == LnConstants.LOCO_COMMON) {
                     used++;
@@ -92,11 +87,10 @@ public class JsonLoconetSlotUsageHttpService extends JsonHttpService {
 
     @Override
     public JsonNode doSchema(String type, boolean server, JsonRequest request) throws JsonException {
-        // FIELD REPORT (Andrew Deak): caught by JsonSchemaServiceCacheTest,
-        // which every JSON service must satisfy -- an unrecognized type must
-        // throw, not silently return this service's own schema regardless
-        // of what was asked for. Matches the same pattern used by every
-        // other JsonHttpService (e.g. JsonIdTagHttpService).
+        // An unrecognized type must throw, not silently return this
+        // service's own schema regardless of what was asked for -- matches
+        // the pattern used by every other JsonHttpService (e.g.
+        // JsonIdTagHttpService).
         if (LOCONET_SLOT_USAGE.equals(type)) {
             return doSchema(type, server,
                     "jmri/server/json/loconet/loconetSlotUsage-server.json",

--- a/java/src/jmri/server/json/loconet/JsonLoconetSlotUsageHttpService.java
+++ b/java/src/jmri/server/json/loconet/JsonLoconetSlotUsageHttpService.java
@@ -1,0 +1,109 @@
+package jmri.server.json.loconet;
+
+import static jmri.server.json.loconet.JsonLoconetSlotUsage.LOCONET_SLOT_USAGE;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.util.List;
+import javax.servlet.http.HttpServletResponse;
+import jmri.InstanceManager;
+import jmri.jmrix.loconet.LnConstants;
+import jmri.jmrix.loconet.LocoNetSlot;
+import jmri.jmrix.loconet.LocoNetSystemConnectionMemo;
+import jmri.jmrix.loconet.SlotManager;
+import jmri.jmrix.loconet.SlotMapEntry.SlotType;
+import jmri.server.json.JsonException;
+import jmri.server.json.JsonHttpService;
+import jmri.server.json.JsonRequest;
+
+/**
+ * Reports real LocoNet loco-slot table usage (used/free/total) for the
+ * active connection's command station.
+ *
+ * FIELD REPORT (Andrew Deak): read-only -- iterates the SlotManager's
+ * already in-memory slot array, sending no new LocoNet traffic of its
+ * own. "total" reflects the connected command station's real per-model
+ * capacity (from the same LnCommandStationType data JMRI already uses to
+ * auto-detect the connection), not JMRI's generic upper bound, which is
+ * sized for the largest command station JMRI knows about and would
+ * overstate real capacity for anything smaller.
+ *
+ * @author Andrew Deak Copyright (C) 2026
+ */
+public class JsonLoconetSlotUsageHttpService extends JsonHttpService {
+
+    public JsonLoconetSlotUsageHttpService(ObjectMapper mapper) {
+        super(mapper);
+    }
+
+    @Override
+    public JsonNode doGet(String type, String name, JsonNode data, JsonRequest request) throws JsonException {
+        List<LocoNetSystemConnectionMemo> memos = InstanceManager.getList(LocoNetSystemConnectionMemo.class);
+        if (memos.isEmpty()) {
+            throw new JsonException(503, "No LocoNet connection is available", request.id);
+        }
+        SlotManager sm = memos.get(0).getSlotManager();
+        if (sm == null) {
+            throw new JsonException(503, "No LocoNet slot manager is available", request.id);
+        }
+        int total = 0;
+        int used = 0;
+        for (int i = 0; i < sm.getNumSlots(); i++) {
+            LocoNetSlot s = sm.slot(i);
+            if (s.getSlotType() == SlotType.LOCO) {
+                total++;
+                // FIELD REPORT (Andrew Deak): an Idle slot (dispatched or
+                // released, address still resident but not actively driven)
+                // is capacity the command station will reclaim for the next
+                // engine added -- confirmed live against a real DCS52 after
+                // dispatching an engine from the handset: the slot showed
+                // "Idle" in the Slot Monitor, but this endpoint kept
+                // reporting it as used, so a client polling "free" never saw
+                // the slot come back. Only In-Use/Common hold a live,
+                // actively-driven address that isn't available for a
+                // different loco.
+                int status = s.slotStatus() & LnConstants.LOCOSTAT_MASK;
+                if (status == LnConstants.LOCO_IN_USE || status == LnConstants.LOCO_COMMON) {
+                    used++;
+                }
+            }
+        }
+        ObjectNode dataNode = mapper.createObjectNode();
+        dataNode.put("commandStation",
+                sm.getCommandStationType() != null ? sm.getCommandStationType().getName() : null);
+        dataNode.put("used", used);
+        dataNode.put("total", total);
+        dataNode.put("free", total - used);
+        return message(LOCONET_SLOT_USAGE, dataNode, request.id);
+    }
+
+    @Override
+    public JsonNode doPost(String type, String name, JsonNode data, JsonRequest request) throws JsonException {
+        // read-only service -- POST behaves the same as GET
+        return doGet(type, name, data, request);
+    }
+
+    @Override
+    public JsonNode doGetList(String type, JsonNode data, JsonRequest request) throws JsonException {
+        // single-object service, no list distinction -- same as GET
+        return doGet(type, "", data, request);
+    }
+
+    @Override
+    public JsonNode doSchema(String type, boolean server, JsonRequest request) throws JsonException {
+        // FIELD REPORT (Andrew Deak): caught by JsonSchemaServiceCacheTest,
+        // which every JSON service must satisfy -- an unrecognized type must
+        // throw, not silently return this service's own schema regardless
+        // of what was asked for. Matches the same pattern used by every
+        // other JsonHttpService (e.g. JsonIdTagHttpService).
+        if (LOCONET_SLOT_USAGE.equals(type)) {
+            return doSchema(type, server,
+                    "jmri/server/json/loconet/loconetSlotUsage-server.json",
+                    "jmri/server/json/loconet/loconetSlotUsage-client.json",
+                    request.id);
+        }
+        throw new JsonException(HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
+                Bundle.getMessage(request.locale, JsonException.ERROR_UNKNOWN_TYPE, type), request.id);
+    }
+}

--- a/java/src/jmri/server/json/loconet/JsonLoconetSlotUsageServiceFactory.java
+++ b/java/src/jmri/server/json/loconet/JsonLoconetSlotUsageServiceFactory.java
@@ -1,0 +1,32 @@
+package jmri.server.json.loconet;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jmri.server.json.JsonConnection;
+import jmri.spi.JsonServiceFactory;
+import org.openide.util.lookup.ServiceProvider;
+
+/**
+ * Registers the "loconetSlotUsage" JSON type.
+ *
+ * @author Andrew Deak Copyright (C) 2026
+ */
+@ServiceProvider(service = JsonServiceFactory.class)
+public class JsonLoconetSlotUsageServiceFactory
+        implements JsonServiceFactory<JsonLoconetSlotUsageHttpService, JsonLoconetSlotUsageSocketService> {
+
+    @Override
+    public String[] getTypes(String version) {
+        return new String[]{JsonLoconetSlotUsage.LOCONET_SLOT_USAGE};
+    }
+
+    @Override
+    public JsonLoconetSlotUsageSocketService getSocketService(JsonConnection connection, String version) {
+        return new JsonLoconetSlotUsageSocketService(connection);
+    }
+
+    @Override
+    public JsonLoconetSlotUsageHttpService getHttpService(ObjectMapper mapper, String version) {
+        return new JsonLoconetSlotUsageHttpService(mapper);
+    }
+
+}

--- a/java/src/jmri/server/json/loconet/JsonLoconetSlotUsageSocketService.java
+++ b/java/src/jmri/server/json/loconet/JsonLoconetSlotUsageSocketService.java
@@ -1,0 +1,48 @@
+package jmri.server.json.loconet;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.io.IOException;
+import jmri.JmriException;
+import jmri.server.json.JsonConnection;
+import jmri.server.json.JsonException;
+import jmri.server.json.JsonRequest;
+import jmri.server.json.JsonSocketService;
+
+/**
+ * Minimal WebSocket handling for "loconetSlotUsage" -- a one-shot query,
+ * not something a client subscribes to, so every message (GET or LIST)
+ * is answered the same way as the HTTP GET, with no held subscription
+ * state to release on close.
+ *
+ * FIELD REPORT (Andrew Deak): a null socket service was considered
+ * instead, since this type has no ongoing subscription need, but
+ * JsonClientHandler registers whatever getSocketService() returns into
+ * every type's dispatch set unconditionally -- a null entry there would
+ * NPE the first time a WebSocket client sent this type, the same class
+ * of bug fixed elsewhere in this session (AbstractThrottleManager,
+ * JsonThrottle). A real, minimal implementation avoids that risk
+ * entirely.
+ *
+ * @author Andrew Deak Copyright (C) 2026
+ */
+public class JsonLoconetSlotUsageSocketService extends JsonSocketService<JsonLoconetSlotUsageHttpService> {
+
+    public JsonLoconetSlotUsageSocketService(JsonConnection connection) {
+        super(connection, new JsonLoconetSlotUsageHttpService(connection.getObjectMapper()));
+    }
+
+    @Override
+    public void onMessage(String type, JsonNode data, JsonRequest request) throws IOException, JmriException, JsonException {
+        connection.sendMessage(service.doGet(type, "", data, request), request.id);
+    }
+
+    @Override
+    public void onList(String type, JsonNode data, JsonRequest request) throws IOException, JmriException, JsonException {
+        connection.sendMessage(service.doGet(type, "", data, request), request.id);
+    }
+
+    @Override
+    public void onClose() {
+        // no subscription state held
+    }
+}

--- a/java/src/jmri/server/json/loconet/JsonLoconetSlotUsageSocketService.java
+++ b/java/src/jmri/server/json/loconet/JsonLoconetSlotUsageSocketService.java
@@ -14,14 +14,10 @@ import jmri.server.json.JsonSocketService;
  * is answered the same way as the HTTP GET, with no held subscription
  * state to release on close.
  *
- * FIELD REPORT (Andrew Deak): a null socket service was considered
- * instead, since this type has no ongoing subscription need, but
- * JsonClientHandler registers whatever getSocketService() returns into
- * every type's dispatch set unconditionally -- a null entry there would
- * NPE the first time a WebSocket client sent this type, the same class
- * of bug fixed elsewhere in this session (AbstractThrottleManager,
- * JsonThrottle). A real, minimal implementation avoids that risk
- * entirely.
+ * A real, minimal implementation is used here rather than a null socket
+ * service, since JsonClientHandler registers whatever getSocketService()
+ * returns into every type's dispatch set unconditionally -- a null entry
+ * there would NPE the first time a WebSocket client sent this type.
  *
  * @author Andrew Deak Copyright (C) 2026
  */

--- a/java/src/jmri/server/json/loconet/loconetSlotUsage-client.json
+++ b/java/src/jmri/server/json/loconet/loconetSlotUsage-client.json
@@ -1,0 +1,8 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": "jmri-json-loconetSlotUsage-client-message",
+    "type": "object",
+    "description": "Schema data object in message from client to JMRI for type \"loconetSlotUsage\" -- no data is required; a plain GET returns current slot usage",
+    "properties": {},
+    "additionalProperties": false
+}

--- a/java/src/jmri/server/json/loconet/loconetSlotUsage-server.json
+++ b/java/src/jmri/server/json/loconet/loconetSlotUsage-server.json
@@ -1,0 +1,37 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": "jmri-json-loconetSlotUsage-server-message",
+    "type": "object",
+    "description": "Data portion of message from JMRI to client for type \"loconetSlotUsage\"",
+    "properties": {
+        "commandStation": {
+            "type": [
+                "string",
+                "null"
+            ],
+            "description": "Name of the detected LocoNet command station type, e.g. \"DCS52\", or null if not yet detected"
+        },
+        "used": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Number of real loco slots currently in use (not free) on the command station"
+        },
+        "total": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Total number of real loco slots on the connected command station"
+        },
+        "free": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Number of real loco slots currently free (total minus used)"
+        }
+    },
+    "additionalProperties": false,
+    "required": [
+        "commandStation",
+        "used",
+        "total",
+        "free"
+    ]
+}

--- a/java/src/jmri/server/json/throttle/JsonThrottle.java
+++ b/java/src/jmri/server/json/throttle/JsonThrottle.java
@@ -73,19 +73,11 @@ public class JsonThrottle implements ThrottleListener, PropertyChangeListener {
     private DccLocoAddress address = null;
     private String connectionPrefix = null;
     private static final Logger log = LoggerFactory.getLogger(JsonThrottle.class);
-    // FIELD REPORT (Andrew Deak): see the FIELD REPORT on onMessage() below --
-    // a command combining acquisition with speed/direction/function fields
-    // in one message (the common pattern for any client mirroring another
-    // throttle's state, e.g. LCC consist-emulation over individual
-    // throttles) used to be silently dropped entirely if it arrived before
-    // notifyThrottleFound() completed. Confirmed live: acquiring and setting
-    // speed+direction in one message for a never-before-seen address left
-    // the throttle at its old/default state, not the requested one -- no
-    // crash (that was already fixed), but the actual command was just lost.
-    // Queuing the one most recent pre-acquisition command and replaying it
-    // once the throttle is actually ready fixes this without touching the
-    // separate, already-correct "ignore after release" behavior (see
-    // everAcquired below -- only the FIRST acquisition gets this treatment).
+    // Holds the one most recent command received before acquisition
+    // completes, so it can be replayed once the throttle is actually ready
+    // instead of being dropped -- only the FIRST acquisition gets this
+    // treatment (see everAcquired), which is separate from the "ignore
+    // after release" behavior.
     private JsonNode pendingData;
     private JsonThrottleSocketService pendingServer;
     private boolean everAcquired = false;
@@ -240,18 +232,14 @@ public class JsonThrottle implements ThrottleListener, PropertyChangeListener {
     }
 
     public void onMessage(Locale locale, JsonNode data, JsonThrottleSocketService server) {
-        // FIELD REPORT: this.throttle is null from construction until the
-        // async ThrottleListener callback (notifyThrottleFound(), below)
-        // sets it, and null again after release(). A client that sends a
-        // throttle command (speed/function/direction) in either window --
-        // confirmed live, reproducibly, from a WiFi throttle client that
-        // subscribes and sends quickly after connecting -- NPE'd on
-        // whatever field it processed first (setSpeedSetting/setIsForward/
-        // getFunctions all dereference this.throttle unconditionally).
-        // Ignoring rather than crashing the WebSocket handler. If this is
-        // still waiting on the FIRST acquisition (not a post-release
-        // message), queue it for replay in notifyThrottleFound() instead of
-        // dropping it -- see the field report on pendingData above.
+        // this.throttle is null from construction until the async
+        // ThrottleListener callback (notifyThrottleFound(), below) sets it,
+        // and null again after release(). A command received during either
+        // window is ignored here rather than crashing (every field handler
+        // below dereferences this.throttle unconditionally). If this is
+        // before the FIRST acquisition, queue it for replay in
+        // notifyThrottleFound() instead of dropping it -- see pendingData
+        // above.
         if (this.throttle == null) {
             if (!this.everAcquired) {
                 log.warn("onMessage(): received a command for {} before its throttle was available -- queuing for replay once acquired",
@@ -286,21 +274,12 @@ public class JsonThrottle implements ThrottleListener, PropertyChangeListener {
                     this.throttle.setIsForward(v.asBoolean());
                     break;
                 case RELEASE:
-                    // FIELD REPORT (Andrew Deak): server.release(this) nulls
-                    // out this.throttle (see the FIELD REPORT above onMessage()).
-                    // Using break here (not return, unlike ESTOP just above)
-                    // let the loop keep iterating remaining fields in the SAME
-                    // message against a now-null throttle -- confirmed live:
-                    // a message with an unrecognized field (e.g.
-                    // "isLongAddress", never explicitly handled below)
-                    // processed AFTER "release" fell through to the default
-                    // case's unconditional this.throttle.getFunctions() and
-                    // NPE'd, killing the whole WebSocket connection. JSON
-                    // object field order isn't guaranteed, so any client
-                    // (not just one sending fields in an unusual order) could
-                    // hit this. Stopping immediately, matching ESTOP's own
-                    // rationale for not processing further commands after a
-                    // terminal action.
+                    // server.release(this) nulls out this.throttle. Returning
+                    // immediately (matching ESTOP above) stops the loop from
+                    // processing any remaining fields in this message against
+                    // a now-null throttle -- JSON object field order isn't
+                    // guaranteed, so a field after "release" could otherwise
+                    // still be reached.
                     server.release(this);
                     return;
                 case STATUS:
@@ -380,10 +359,10 @@ public class JsonThrottle implements ThrottleListener, PropertyChangeListener {
         throttle.addPropertyChangeListener(this);
         this.speedSteps = throttle.getSpeedStepMode().numSteps;
         this.sendStatus();
-        // FIELD REPORT (Andrew Deak): replay whatever command arrived before
-        // this.throttle was ready -- see the field report on pendingData
-        // above. Applied after sendStatus() so a client watching for state
-        // changes sees the acquisition first, then the requested command.
+        // Replay whatever command arrived before this.throttle was ready --
+        // see pendingData above. Applied after sendStatus() so a client
+        // watching for state changes sees the acquisition first, then the
+        // requested command.
         if (this.pendingData != null) {
             JsonNode replay = this.pendingData;
             JsonThrottleSocketService replayServer = this.pendingServer;

--- a/java/src/jmri/server/json/throttle/JsonThrottle.java
+++ b/java/src/jmri/server/json/throttle/JsonThrottle.java
@@ -73,6 +73,22 @@ public class JsonThrottle implements ThrottleListener, PropertyChangeListener {
     private DccLocoAddress address = null;
     private String connectionPrefix = null;
     private static final Logger log = LoggerFactory.getLogger(JsonThrottle.class);
+    // FIELD REPORT (Andrew Deak): see the FIELD REPORT on onMessage() below --
+    // a command combining acquisition with speed/direction/function fields
+    // in one message (the common pattern for any client mirroring another
+    // throttle's state, e.g. LCC consist-emulation over individual
+    // throttles) used to be silently dropped entirely if it arrived before
+    // notifyThrottleFound() completed. Confirmed live: acquiring and setting
+    // speed+direction in one message for a never-before-seen address left
+    // the throttle at its old/default state, not the requested one -- no
+    // crash (that was already fixed), but the actual command was just lost.
+    // Queuing the one most recent pre-acquisition command and replaying it
+    // once the throttle is actually ready fixes this without touching the
+    // separate, already-correct "ignore after release" behavior (see
+    // everAcquired below -- only the FIRST acquisition gets this treatment).
+    private JsonNode pendingData;
+    private JsonThrottleSocketService pendingServer;
+    private boolean everAcquired = false;
 
     protected JsonThrottle(DccLocoAddress address, JsonThrottleSocketService server) {
         this.address = address;
@@ -224,6 +240,34 @@ public class JsonThrottle implements ThrottleListener, PropertyChangeListener {
     }
 
     public void onMessage(Locale locale, JsonNode data, JsonThrottleSocketService server) {
+        // FIELD REPORT: this.throttle is null from construction until the
+        // async ThrottleListener callback (notifyThrottleFound(), below)
+        // sets it, and null again after release(). A client that sends a
+        // throttle command (speed/function/direction) in either window --
+        // confirmed live, reproducibly, from a WiFi throttle client that
+        // subscribes and sends quickly after connecting -- NPE'd on
+        // whatever field it processed first (setSpeedSetting/setIsForward/
+        // getFunctions all dereference this.throttle unconditionally).
+        // Ignoring rather than crashing the WebSocket handler. If this is
+        // still waiting on the FIRST acquisition (not a post-release
+        // message), queue it for replay in notifyThrottleFound() instead of
+        // dropping it -- see the field report on pendingData above.
+        if (this.throttle == null) {
+            if (!this.everAcquired) {
+                log.warn("onMessage(): received a command for {} before its throttle was available -- queuing for replay once acquired",
+                        this.address);
+                this.pendingData = data;
+                this.pendingServer = server;
+            } else {
+                log.warn("onMessage(): received a command for {} after its throttle was released -- ignoring",
+                        this.address);
+            }
+            return;
+        }
+        applyFields(data, server);
+    }
+
+    private void applyFields(JsonNode data, JsonThrottleSocketService server) {
         for (var entry : data.properties()) {
             String k = entry.getKey();
             JsonNode v = entry.getValue();
@@ -242,8 +286,23 @@ public class JsonThrottle implements ThrottleListener, PropertyChangeListener {
                     this.throttle.setIsForward(v.asBoolean());
                     break;
                 case RELEASE:
+                    // FIELD REPORT (Andrew Deak): server.release(this) nulls
+                    // out this.throttle (see the FIELD REPORT above onMessage()).
+                    // Using break here (not return, unlike ESTOP just above)
+                    // let the loop keep iterating remaining fields in the SAME
+                    // message against a now-null throttle -- confirmed live:
+                    // a message with an unrecognized field (e.g.
+                    // "isLongAddress", never explicitly handled below)
+                    // processed AFTER "release" fell through to the default
+                    // case's unconditional this.throttle.getFunctions() and
+                    // NPE'd, killing the whole WebSocket connection. JSON
+                    // object field order isn't guaranteed, so any client
+                    // (not just one sending fields in an unusual order) could
+                    // hit this. Stopping immediately, matching ESTOP's own
+                    // rationale for not processing further commands after a
+                    // terminal action.
                     server.release(this);
-                    break;
+                    return;
                 case STATUS:
                     this.sendStatus(server);
                     break;
@@ -252,7 +311,11 @@ public class JsonThrottle implements ThrottleListener, PropertyChangeListener {
                 case PREFIX:
                 case THROTTLE:
                 case ROSTER_ENTRY:
-                    // no action for address, name, prefix, or throttle property
+                case IS_LONG_ADDRESS:
+                    // no action for address, name, prefix, throttle, or
+                    // isLongAddress property -- isLongAddress previously
+                    // fell through to default (see the field report on
+                    // RELEASE above for how that combination crashed).
                     break;
                 default:
                     for ( int i = 0; i< this.throttle.getFunctions().length; i++ ) {
@@ -313,9 +376,21 @@ public class JsonThrottle implements ThrottleListener, PropertyChangeListener {
     public void notifyThrottleFound(DccThrottle throttle) {
         log.debug("Found throttle {}", throttle.getLocoAddress());
         this.throttle = throttle;
+        this.everAcquired = true;
         throttle.addPropertyChangeListener(this);
         this.speedSteps = throttle.getSpeedStepMode().numSteps;
         this.sendStatus();
+        // FIELD REPORT (Andrew Deak): replay whatever command arrived before
+        // this.throttle was ready -- see the field report on pendingData
+        // above. Applied after sendStatus() so a client watching for state
+        // changes sees the acquisition first, then the requested command.
+        if (this.pendingData != null) {
+            JsonNode replay = this.pendingData;
+            JsonThrottleSocketService replayServer = this.pendingServer;
+            this.pendingData = null;
+            this.pendingServer = null;
+            applyFields(replay, replayServer);
+        }
     }
 
     @Override

--- a/java/src/jmri/server/json/throttle/JsonThrottleManager.java
+++ b/java/src/jmri/server/json/throttle/JsonThrottleManager.java
@@ -28,17 +28,10 @@ public class JsonThrottleManager implements InstanceManagerAutoDefault {
         // do nothing
     }
 
-    // FIELD REPORT (Andrew Deak): these two maps used to only ever be
-    // touched from a single thread at a time (everything, including
-    // notifyThrottleFound(), ran synchronously nested inside the original
-    // calling thread). Now that AbstractThrottleManager.notifyThrottleKnown()
-    // defers notifyThrottleFound() to the EDT via SwingUtilities.invokeLater()
-    // (see its field comment), that deferred callback and whatever thread is
-    // handling a fresh JSON request can genuinely touch these maps at the
-    // same time -- confirmed live: a ConcurrentModificationException inside
-    // computeIfAbsent() from exactly this race. Synchronized on `this`
-    // throughout since this manager is itself a singleton and none of these
-    // methods call back into each other across instances.
+    // Synchronized throughout: notifyThrottleFound() is now deferred to the
+    // EDT (see AbstractThrottleManager), so that deferred callback and a
+    // thread handling a fresh JSON request can touch these maps at the
+    // same time. getThrottles() returns a copy since callers iterate it.
     public synchronized Collection<JsonThrottle> getThrottles() {
         return new ArrayList<>(this.throttles.values());
     }

--- a/java/src/jmri/server/json/throttle/JsonThrottleManager.java
+++ b/java/src/jmri/server/json/throttle/JsonThrottleManager.java
@@ -28,35 +28,46 @@ public class JsonThrottleManager implements InstanceManagerAutoDefault {
         // do nothing
     }
 
-    public Collection<JsonThrottle> getThrottles() {
-        return this.throttles.values();
+    // FIELD REPORT (Andrew Deak): these two maps used to only ever be
+    // touched from a single thread at a time (everything, including
+    // notifyThrottleFound(), ran synchronously nested inside the original
+    // calling thread). Now that AbstractThrottleManager.notifyThrottleKnown()
+    // defers notifyThrottleFound() to the EDT via SwingUtilities.invokeLater()
+    // (see its field comment), that deferred callback and whatever thread is
+    // handling a fresh JSON request can genuinely touch these maps at the
+    // same time -- confirmed live: a ConcurrentModificationException inside
+    // computeIfAbsent() from exactly this race. Synchronized on `this`
+    // throughout since this manager is itself a singleton and none of these
+    // methods call back into each other across instances.
+    public synchronized Collection<JsonThrottle> getThrottles() {
+        return new ArrayList<>(this.throttles.values());
     }
 
-    public void put(DccLocoAddress address, JsonThrottle throttle) {
+    public synchronized void put(DccLocoAddress address, JsonThrottle throttle) {
         this.throttles.put(address, throttle);
     }
 
-    public void put(JsonThrottle throttle, JsonThrottleSocketService service) {
+    public synchronized void put(JsonThrottle throttle, JsonThrottleSocketService service) {
         this.services.computeIfAbsent(throttle, v -> new ArrayList<>()).add(service);
     }
 
-    public boolean containsKey(DccLocoAddress address) {
+    public synchronized boolean containsKey(DccLocoAddress address) {
         return this.throttles.containsKey(address);
     }
 
-    public JsonThrottle get(DccLocoAddress address) {
+    public synchronized JsonThrottle get(DccLocoAddress address) {
         return this.throttles.get(address);
     }
 
-    public void remove(DccLocoAddress address) {
+    public synchronized void remove(DccLocoAddress address) {
         this.throttles.remove(address);
     }
 
-    public List<JsonThrottleSocketService> getServers(JsonThrottle throttle) {
+    public synchronized List<JsonThrottleSocketService> getServers(JsonThrottle throttle) {
         return this.services.computeIfAbsent(throttle, v -> new ArrayList<>());
     }
 
-    public void remove(JsonThrottle throttle, JsonThrottleSocketService server) {
+    public synchronized void remove(JsonThrottle throttle, JsonThrottleSocketService server) {
         this.getServers(throttle).remove(server);
     }
 

--- a/java/src/jmri/web/servlet/json/JsonServlet.java
+++ b/java/src/jmri/web/servlet/json/JsonServlet.java
@@ -265,7 +265,7 @@ public class JsonServlet extends WebSocketServlet {
         JsonNode data;
         JsonNode reply = null;
         try {
-            if (request.getContentType().contains(APPLICATION_JSON)) {
+            if (request.getContentType() != null && request.getContentType().contains(APPLICATION_JSON)) {
                 data = mapper.readTree(request.getReader());
                 if (!data.path(DATA).isMissingNode()) {
                     data = data.path(DATA);
@@ -358,7 +358,7 @@ public class JsonServlet extends WebSocketServlet {
         JsonNode data;
         JsonNode reply = null;
         try {
-            if (request.getContentType().contains(APPLICATION_JSON)) {
+            if (request.getContentType() != null && request.getContentType().contains(APPLICATION_JSON)) {
                 data = mapper.readTree(request.getReader());
                 if (!data.path(DATA).isMissingNode()) {
                     data = data.path(DATA);
@@ -449,7 +449,7 @@ public class JsonServlet extends WebSocketServlet {
                 }
                 if (services.get(jsonRequest.version).get(type) != null) {
                     JsonNode data = mapper.createObjectNode();
-                    if (request.getContentType().contains(APPLICATION_JSON)) {
+                    if (request.getContentType() != null && request.getContentType().contains(APPLICATION_JSON)) {
                         data = mapper.readTree(request.getReader());
                         if (!data.path(DATA).isMissingNode()) {
                             data = data.path(DATA);

--- a/java/test/jmri/jmris/srcp/JmriSRCPThrottleServerTest.java
+++ b/java/test/jmri/jmris/srcp/JmriSRCPThrottleServerTest.java
@@ -25,11 +25,8 @@ public class JmriSRCPThrottleServerTest extends jmri.jmris.AbstractThrottleServe
     public void requestThrottleTest(){
        Throwable thrown = catchThrowable( () -> {
           ((JmriSRCPThrottleServer)ats).initThrottle(1,42,false,128,28);
-          // FIELD REPORT (Andrew Deak): AbstractThrottleManager.notifyThrottleKnown()
-          // now defers notifyThrottleFound() via SwingUtilities.invokeLater() (see
-          // its field comment -- fixes a real StackOverflow from synchronous
-          // re-entrant requestThrottle() calls), so the throttle notification is
-          // no longer written synchronously within initThrottle() itself.
+          // Throttle acquisition is deferred (see AbstractThrottleManager),
+          // so this isn't written synchronously within initThrottle().
           JUnitUtil.waitFor(() -> !sb.toString().isEmpty(), "wait for throttle notification");
           confirmThrottleRequestSucceeded();
        });
@@ -64,13 +61,9 @@ public class JmriSRCPThrottleServerTest extends jmri.jmris.AbstractThrottleServe
     public void sendStatusStandardTest(){
        Throwable thrown = catchThrowable( () -> {
           ((JmriSRCPThrottleServer)ats).initThrottle(1,42,false,128,28);
-          // FIELD REPORT (Andrew Deak): without this wait, the deferred
-          // notifyThrottleFound() from initThrottle() above (see the field
-          // report in requestThrottleTest()) can race with sendStatus()
-          // below and append its own success text to sb AFTER the "499
-          // ERROR" text this test expects, breaking confirmThrottleErrorStatusSent()'s
-          // endsWith() check depending purely on timing. Let the
-          // acquisition's own notification land first.
+          // Without this wait, the deferred acquisition notification from
+          // initThrottle() can race with sendStatus() below and append its
+          // success text after the "499 ERROR" text this test expects.
           JUnitUtil.waitFor(() -> !sb.toString().isEmpty(), "wait for throttle notification");
           ats.sendStatus(new DccLocoAddress(42,false));
        });
@@ -83,9 +76,7 @@ public class JmriSRCPThrottleServerTest extends jmri.jmris.AbstractThrottleServe
     public void sendStatusTest(){
         Throwable thrown = catchThrowable( () -> {
           ((JmriSRCPThrottleServer)ats).initThrottle(1,42,false,128,28);
-          // FIELD REPORT (Andrew Deak): see the field report in requestThrottleTest()
-          // above -- notifyThrottleFound() is now deferred, so this isn't written
-          // synchronously within initThrottle().
+          // Throttle acquisition is deferred (see AbstractThrottleManager).
           JUnitUtil.waitFor(() -> !sb.toString().isEmpty(), "wait for throttle notification");
           confirmThrottleRequestSucceeded();
           ((JmriSRCPThrottleServer)ats).sendStatus(1,42);

--- a/java/test/jmri/jmris/srcp/JmriSRCPThrottleServerTest.java
+++ b/java/test/jmri/jmris/srcp/JmriSRCPThrottleServerTest.java
@@ -25,6 +25,12 @@ public class JmriSRCPThrottleServerTest extends jmri.jmris.AbstractThrottleServe
     public void requestThrottleTest(){
        Throwable thrown = catchThrowable( () -> {
           ((JmriSRCPThrottleServer)ats).initThrottle(1,42,false,128,28);
+          // FIELD REPORT (Andrew Deak): AbstractThrottleManager.notifyThrottleKnown()
+          // now defers notifyThrottleFound() via SwingUtilities.invokeLater() (see
+          // its field comment -- fixes a real StackOverflow from synchronous
+          // re-entrant requestThrottle() calls), so the throttle notification is
+          // no longer written synchronously within initThrottle() itself.
+          JUnitUtil.waitFor(() -> !sb.toString().isEmpty(), "wait for throttle notification");
           confirmThrottleRequestSucceeded();
        });
        assertThat(thrown).withFailMessage("failed requesting throttle").isNull();
@@ -58,6 +64,14 @@ public class JmriSRCPThrottleServerTest extends jmri.jmris.AbstractThrottleServe
     public void sendStatusStandardTest(){
        Throwable thrown = catchThrowable( () -> {
           ((JmriSRCPThrottleServer)ats).initThrottle(1,42,false,128,28);
+          // FIELD REPORT (Andrew Deak): without this wait, the deferred
+          // notifyThrottleFound() from initThrottle() above (see the field
+          // report in requestThrottleTest()) can race with sendStatus()
+          // below and append its own success text to sb AFTER the "499
+          // ERROR" text this test expects, breaking confirmThrottleErrorStatusSent()'s
+          // endsWith() check depending purely on timing. Let the
+          // acquisition's own notification land first.
+          JUnitUtil.waitFor(() -> !sb.toString().isEmpty(), "wait for throttle notification");
           ats.sendStatus(new DccLocoAddress(42,false));
        });
        assertThat(thrown).withFailMessage("failed sending status").isNull();
@@ -69,6 +83,10 @@ public class JmriSRCPThrottleServerTest extends jmri.jmris.AbstractThrottleServe
     public void sendStatusTest(){
         Throwable thrown = catchThrowable( () -> {
           ((JmriSRCPThrottleServer)ats).initThrottle(1,42,false,128,28);
+          // FIELD REPORT (Andrew Deak): see the field report in requestThrottleTest()
+          // above -- notifyThrottleFound() is now deferred, so this isn't written
+          // synchronously within initThrottle().
+          JUnitUtil.waitFor(() -> !sb.toString().isEmpty(), "wait for throttle notification");
           confirmThrottleRequestSucceeded();
           ((JmriSRCPThrottleServer)ats).sendStatus(1,42);
           confirmThrottleStatusSent();

--- a/java/test/jmri/jmrit/roster/RosterSpeedProfileTest.java
+++ b/java/test/jmri/jmrit/roster/RosterSpeedProfileTest.java
@@ -131,6 +131,14 @@ public class RosterSpeedProfileTest {
         ThrottleListen throtListen = new ThrottleListen();
         ThrottleManager tm = InstanceManager.getDefault(ThrottleManager.class);
         assertTrue( tm.requestThrottle(rF1, throtListen, false) );
+        // FIELD REPORT (Andrew Deak): AbstractThrottleManager.notifyThrottleKnown()
+        // now defers notifyThrottleFound() via SwingUtilities.invokeLater() (see
+        // its field comment -- fixes a real StackOverflow from synchronous
+        // re-entrant requestThrottle() calls), so throtListen.throttle is no
+        // longer available synchronously right after requestThrottle() returns
+        // -- without this wait, testScene() below NPE'd calling methods on a
+        // still-null throttle.
+        JUnitUtil.waitFor(() -> throtListen.throttle != null, "wait for throttle found");
         stmLimit = stm.numSteps;
         resultSummary.testTotalCount = 0;
         for (float testDistance = fromDistanceMm; testDistance <= toDistanceMm; testDistance += byDistanceMm) {

--- a/java/test/jmri/jmrit/roster/RosterSpeedProfileTest.java
+++ b/java/test/jmri/jmrit/roster/RosterSpeedProfileTest.java
@@ -131,13 +131,8 @@ public class RosterSpeedProfileTest {
         ThrottleListen throtListen = new ThrottleListen();
         ThrottleManager tm = InstanceManager.getDefault(ThrottleManager.class);
         assertTrue( tm.requestThrottle(rF1, throtListen, false) );
-        // FIELD REPORT (Andrew Deak): AbstractThrottleManager.notifyThrottleKnown()
-        // now defers notifyThrottleFound() via SwingUtilities.invokeLater() (see
-        // its field comment -- fixes a real StackOverflow from synchronous
-        // re-entrant requestThrottle() calls), so throtListen.throttle is no
-        // longer available synchronously right after requestThrottle() returns
-        // -- without this wait, testScene() below NPE'd calling methods on a
-        // still-null throttle.
+        // Throttle acquisition is deferred (see AbstractThrottleManager) --
+        // without this wait, testScene() below NPE'd on a still-null throttle.
         JUnitUtil.waitFor(() -> throtListen.throttle != null, "wait for throttle found");
         stmLimit = stm.numSteps;
         resultSummary.testTotalCount = 0;

--- a/java/test/jmri/jmrit/throttle/AddressPanelTest.java
+++ b/java/test/jmri/jmrit/throttle/AddressPanelTest.java
@@ -34,11 +34,8 @@ public class AddressPanelTest {
         AddressPanel panel = new AddressPanel(tm);
         assertEquals( 0, tm.getThrottleUsageCount(locoAddress), "Throttle is used 0 times");
         panel.setAddress(locoAddress, false);
-        // FIELD REPORT (Andrew Deak): AbstractThrottleManager.notifyThrottleKnown()
-        // now defers notifyThrottleFound() (and the usage-count update alongside
-        // it) via SwingUtilities.invokeLater() (see its field comment -- fixes a
-        // real StackOverflow from synchronous re-entrant requestThrottle()
-        // calls), so this is no longer available synchronously.
+        // Throttle acquisition (and its usage-count update) is now deferred
+        // (see AbstractThrottleManager), so not available synchronously.
         JUnitUtil.waitFor(() -> tm.getThrottleUsageCount(locoAddress) == 1, "wait for throttle acquired");
         assertEquals( 1, tm.getThrottleUsageCount(locoAddress), "Throttle is used 1 times");
         PropertyChangeEvent pce = new PropertyChangeEvent(this,"ThrottleConnected", true, false);

--- a/java/test/jmri/jmrit/throttle/AddressPanelTest.java
+++ b/java/test/jmri/jmrit/throttle/AddressPanelTest.java
@@ -34,6 +34,12 @@ public class AddressPanelTest {
         AddressPanel panel = new AddressPanel(tm);
         assertEquals( 0, tm.getThrottleUsageCount(locoAddress), "Throttle is used 0 times");
         panel.setAddress(locoAddress, false);
+        // FIELD REPORT (Andrew Deak): AbstractThrottleManager.notifyThrottleKnown()
+        // now defers notifyThrottleFound() (and the usage-count update alongside
+        // it) via SwingUtilities.invokeLater() (see its field comment -- fixes a
+        // real StackOverflow from synchronous re-entrant requestThrottle()
+        // calls), so this is no longer available synchronously.
+        JUnitUtil.waitFor(() -> tm.getThrottleUsageCount(locoAddress) == 1, "wait for throttle acquired");
         assertEquals( 1, tm.getThrottleUsageCount(locoAddress), "Throttle is used 1 times");
         PropertyChangeEvent pce = new PropertyChangeEvent(this,"ThrottleConnected", true, false);
         panel.propertyChange(pce);

--- a/java/test/jmri/jmrit/withrottle/MultiThrottleControllerTest.java
+++ b/java/test/jmri/jmrit/withrottle/MultiThrottleControllerTest.java
@@ -42,6 +42,12 @@ public class MultiThrottleControllerTest {
         // tests setting the address from the input.
         // Does not include the prefix.
         assertTrue( controller.sort("S1"), "Continue after address");
+        // FIELD REPORT (Andrew Deak): AbstractThrottleManager.notifyThrottleKnown()
+        // now defers notifyThrottleFound() via SwingUtilities.invokeLater() (see
+        // its field comment -- fixes a real StackOverflow from synchronous
+        // re-entrant requestThrottle() calls), so this is no longer available
+        // synchronously right after sort() returns.
+        JUnitUtil.waitFor(() -> tcls.hasAddressBeenFound(), "wait for address found");
         assertTrue( tcls.hasAddressBeenFound(), "Address Found");
     }
 
@@ -50,6 +56,7 @@ public class MultiThrottleControllerTest {
         // tests setting the address from the input.
         // Does not include the prefix.
         assertTrue( controller.sort("L1234"), "Continue after address");
+        JUnitUtil.waitFor(() -> tcls.hasAddressBeenFound(), "wait for address found");
         assertTrue( tcls.hasAddressBeenFound(), "Address Found");
     }
 
@@ -57,6 +64,7 @@ public class MultiThrottleControllerTest {
     public void testSetAndReleaseLongAddress() {
         // set the address
         assertTrue( controller.sort("L1234"), "Continue after address");
+        JUnitUtil.waitFor(() -> tcls.hasAddressBeenFound(), "wait for address found");
         assertTrue( tcls.hasAddressBeenFound(), "Address Found");
         // then release it.
         assertTrue( controller.sort("r"), "Continue after release");
@@ -67,6 +75,7 @@ public class MultiThrottleControllerTest {
     public void testSetAndDispatchLongAddress() {
         // set the address
         assertTrue( controller.sort("L1234"), "Continue after address");
+        JUnitUtil.waitFor(() -> tcls.hasAddressBeenFound(), "wait for address found");
         assertTrue( tcls.hasAddressBeenFound(), "Address Found");
         // then dispatch it.
         assertTrue( controller.sort("d"), "Continue after release");
@@ -291,6 +300,7 @@ public class MultiThrottleControllerTest {
         InstanceManager.getDefault(ThrottlesPreferences.class).setSilentShare(true);
 
         assertTrue( controller.sort("L279"),"request address 279L");
+        JUnitUtil.waitFor(() -> tcls.hasAddressBeenFound(), "wait for address found");
         assertTrue( tcls.hasAddressBeenFound(),"throttle created");
 
         assertTrue( controller.sort("r"), "request loco released");
@@ -312,6 +322,7 @@ public class MultiThrottleControllerTest {
         InstanceManager.getDefault(ThrottlesPreferences.class).setSilentShare(true);
 
         assertTrue( controller.sort("L280"),"request address 280L");
+        JUnitUtil.waitFor(() -> tcls.hasAddressBeenFound(), "wait for address found");
         assertTrue( tcls.hasAddressBeenFound(),"throttle created");
         assertEquals( DecisionType.SHARE, tm.lastResponse, "a share response was sent");
 
@@ -323,6 +334,7 @@ public class MultiThrottleControllerTest {
         InstanceManager.getDefault(ThrottlesPreferences.class).setSilentSteal(true);
 
         assertTrue( controller.sort("L281"),"request address 281L");
+        JUnitUtil.waitFor(() -> tcls.hasAddressBeenFound(), "wait for address found");
         assertTrue( tcls.hasAddressBeenFound(),"throttle created");
         assertEquals( DecisionType.STEAL, tm.lastResponse, "a steal response was sent");
 

--- a/java/test/jmri/jmrit/withrottle/MultiThrottleControllerTest.java
+++ b/java/test/jmri/jmrit/withrottle/MultiThrottleControllerTest.java
@@ -42,11 +42,8 @@ public class MultiThrottleControllerTest {
         // tests setting the address from the input.
         // Does not include the prefix.
         assertTrue( controller.sort("S1"), "Continue after address");
-        // FIELD REPORT (Andrew Deak): AbstractThrottleManager.notifyThrottleKnown()
-        // now defers notifyThrottleFound() via SwingUtilities.invokeLater() (see
-        // its field comment -- fixes a real StackOverflow from synchronous
-        // re-entrant requestThrottle() calls), so this is no longer available
-        // synchronously right after sort() returns.
+        // Throttle acquisition is now deferred (see AbstractThrottleManager),
+        // so not available synchronously right after sort() returns.
         JUnitUtil.waitFor(() -> tcls.hasAddressBeenFound(), "wait for address found");
         assertTrue( tcls.hasAddressBeenFound(), "Address Found");
     }

--- a/java/test/jmri/jmrit/withrottle/MultiThrottleStealTest.java
+++ b/java/test/jmri/jmrit/withrottle/MultiThrottleStealTest.java
@@ -32,10 +32,12 @@ public class MultiThrottleStealTest {
         throttle.canceledThrottleRequest("L1234");
         // the device then confirms the steal.
         throttle.handleMessage("SL1234<;>L1234");
-        // and the sequence continues as normal.
+        // FIELD REPORT (Andrew Deak): waiting on hasAddressBeenFound() alone
+        // is NOT enough -- see the field report in testRefuseOneStealOne()
+        // below for why. Wait for the actual last packet sent instead.
         jmri.util.JUnitUtil.waitFor(() -> {
-            return tcls.hasAddressBeenFound();
-        }, " Address not found");
+            return "MAAL1234<;>s1".equals(cis.getLastPacket());
+        }, "wait for throttle status packet");
         Assert.assertTrue("Address Found", tcls.hasAddressBeenFound());
         // then release it.
         throttle.handleMessage("-L1234<;>r");
@@ -62,6 +64,19 @@ public class MultiThrottleStealTest {
         throttle.canceledThrottleRequest("L4321");
         // the device then confirms the steal.
         throttle.handleMessage("SL4321<;>L4321");
+        // FIELD REPORT (Andrew Deak): waiting on hasAddressBeenFound() alone
+        // is NOT enough -- ThrottleController.notifyThrottleFound() (invoked
+        // from the now-deferred AbstractThrottleManager callback) notifies
+        // listeners (setting this flag) BEFORE its own later
+        // sendCurrentSpeed()/sendCurrentDirection()/sendSpeedStepMode() calls
+        // run, all synchronously within the same method but AFTER the flag
+        // flips. Confirmed live: intermittently observed a stray in-progress
+        // packet (e.g. a function-state packet) as the "last packet" instead
+        // of the release ack sent moments later in this test, depending
+        // purely on exactly when this wait's polling happened to land
+        // relative to that still-in-progress call. Wait for the actual last
+        // packet that method sends instead.
+        JUnitUtil.waitFor(() -> "MAAL4321<;>s1".equals(cis.getLastPacket()), "wait for throttle status packet");
         // and the sequence continues as normal.
         Assert.assertTrue("Address Found", tcls.hasAddressBeenFound());
         // then release it.

--- a/java/test/jmri/jmrit/withrottle/MultiThrottleStealTest.java
+++ b/java/test/jmri/jmrit/withrottle/MultiThrottleStealTest.java
@@ -32,8 +32,7 @@ public class MultiThrottleStealTest {
         throttle.canceledThrottleRequest("L1234");
         // the device then confirms the steal.
         throttle.handleMessage("SL1234<;>L1234");
-        // FIELD REPORT (Andrew Deak): waiting on hasAddressBeenFound() alone
-        // is NOT enough -- see the field report in testRefuseOneStealOne()
+        // hasAddressBeenFound() alone isn't enough -- see testRefuseOneStealOne()
         // below for why. Wait for the actual last packet sent instead.
         jmri.util.JUnitUtil.waitFor(() -> {
             return "MAAL1234<;>s1".equals(cis.getLastPacket());
@@ -64,18 +63,9 @@ public class MultiThrottleStealTest {
         throttle.canceledThrottleRequest("L4321");
         // the device then confirms the steal.
         throttle.handleMessage("SL4321<;>L4321");
-        // FIELD REPORT (Andrew Deak): waiting on hasAddressBeenFound() alone
-        // is NOT enough -- ThrottleController.notifyThrottleFound() (invoked
-        // from the now-deferred AbstractThrottleManager callback) notifies
-        // listeners (setting this flag) BEFORE its own later
-        // sendCurrentSpeed()/sendCurrentDirection()/sendSpeedStepMode() calls
-        // run, all synchronously within the same method but AFTER the flag
-        // flips. Confirmed live: intermittently observed a stray in-progress
-        // packet (e.g. a function-state packet) as the "last packet" instead
-        // of the release ack sent moments later in this test, depending
-        // purely on exactly when this wait's polling happened to land
-        // relative to that still-in-progress call. Wait for the actual last
-        // packet that method sends instead.
+        // hasAddressBeenFound() alone isn't enough -- it flips true before
+        // notifyThrottleFound()'s own later sendCurrentSpeed()/etc. calls
+        // run, so wait for the actual last packet those send instead.
         JUnitUtil.waitFor(() -> "MAAL4321<;>s1".equals(cis.getLastPacket()), "wait for throttle status packet");
         // and the sequence continues as normal.
         Assert.assertTrue("Address Found", tcls.hasAddressBeenFound());

--- a/java/test/jmri/jmrit/withrottle/MultiThrottleTest.java
+++ b/java/test/jmri/jmrit/withrottle/MultiThrottleTest.java
@@ -36,15 +36,26 @@ public class MultiThrottleTest {
        // tests setting the address from the input.  
        // Does not include the prefix.
        throttle.handleMessage("+S1<;>S1");
+       // FIELD REPORT (Andrew Deak): AbstractThrottleManager.notifyThrottleKnown()
+       // now defers notifyThrottleFound() via SwingUtilities.invokeLater() (see
+       // its field comment -- fixes a real StackOverflow from synchronous
+       // re-entrant requestThrottle() calls), so this is no longer available
+       // synchronously right after handleMessage() returns. Waiting on
+       // hasAddressBeenFound() alone isn't enough here -- it can flip true in
+       // an earlier queued Swing event than the one that actually sends this
+       // specific status packet, so wait on the packet itself.
+       JUnitUtil.waitFor(() -> "MAAS1<;>s1".equals(cis.getLastPacket()), "wait for throttle status packet");
        assertEquals( "MAAS1<;>s1",cis.getLastPacket(), "outgoing message after throttle request");
        assertTrue( tcls.hasAddressBeenFound(), "Address Found");
     }
 
     @Test
     public void testSetLongAddress(){
-       // tests setting the address from the input.  
+       // tests setting the address from the input.
        // Does not include the prefix.
        throttle.handleMessage("+L1234<;>L1234");
+       // see the field report in testSetShortAddress() above
+       JUnitUtil.waitFor(() -> "MAAL1234<;>s1".equals(cis.getLastPacket()), "wait for throttle status packet");
        assertEquals( "MAAL1234<;>s1",cis.getLastPacket(), "outgoing message after throttle request");
        assertTrue( tcls.hasAddressBeenFound(), "Address Found");
     }
@@ -53,6 +64,17 @@ public class MultiThrottleTest {
     public void testSetAndReleaseLongAddress(){
        // set the address
        throttle.handleMessage("+L1234<;>L1234");
+       // FIELD REPORT (Andrew Deak): waiting on hasAddressBeenFound() alone
+       // is NOT enough -- ThrottleController.notifyThrottleFound() (invoked
+       // from the now-deferred AbstractThrottleManager callback) notifies
+       // listeners (setting this flag) BEFORE its own later
+       // sendCurrentSpeed()/sendCurrentDirection()/sendSpeedStepMode() calls
+       // run, all synchronously within the same method but AFTER the flag
+       // flips. Confirmed live: intermittently observed an EARLIER packet
+       // (or none of the later ones) depending purely on exactly when this
+       // wait's polling happened to land relative to that still-in-progress
+       // call. Wait for the actual last packet that method sends instead.
+       JUnitUtil.waitFor(() -> "MAAL1234<;>s1".equals(cis.getLastPacket()), "wait for throttle status packet");
        assertTrue( tcls.hasAddressBeenFound(), "Address Found");
        // then release it.
        throttle.handleMessage("-L1234<;>r");
@@ -64,6 +86,17 @@ public class MultiThrottleTest {
     public void testSetAndDispatchLongAddress(){
        // set the address
        throttle.handleMessage("+L1234<;>L1234");
+       // FIELD REPORT (Andrew Deak): waiting on hasAddressBeenFound() alone
+       // is NOT enough -- ThrottleController.notifyThrottleFound() (invoked
+       // from the now-deferred AbstractThrottleManager callback) notifies
+       // listeners (setting this flag) BEFORE its own later
+       // sendCurrentSpeed()/sendCurrentDirection()/sendSpeedStepMode() calls
+       // run, all synchronously within the same method but AFTER the flag
+       // flips. Confirmed live: intermittently observed an EARLIER packet
+       // (or none of the later ones) depending purely on exactly when this
+       // wait's polling happened to land relative to that still-in-progress
+       // call. Wait for the actual last packet that method sends instead.
+       JUnitUtil.waitFor(() -> "MAAL1234<;>s1".equals(cis.getLastPacket()), "wait for throttle status packet");
        assertTrue( tcls.hasAddressBeenFound(), "Address Found");
        // then dispatch it.
        throttle.handleMessage("-L1234<;>d");
@@ -74,6 +107,17 @@ public class MultiThrottleTest {
     @Test
     public void testSetVelocityChange() {
        throttle.handleMessage("+L1234<;>L1234");
+       // FIELD REPORT (Andrew Deak): waiting on hasAddressBeenFound() alone
+       // is NOT enough -- ThrottleController.notifyThrottleFound() (invoked
+       // from the now-deferred AbstractThrottleManager callback) notifies
+       // listeners (setting this flag) BEFORE its own later
+       // sendCurrentSpeed()/sendCurrentDirection()/sendSpeedStepMode() calls
+       // run, all synchronously within the same method but AFTER the flag
+       // flips. Confirmed live: intermittently observed an EARLIER packet
+       // (or none of the later ones) depending purely on exactly when this
+       // wait's polling happened to land relative to that still-in-progress
+       // call. Wait for the actual last packet that method sends instead.
+       JUnitUtil.waitFor(() -> "MAAL1234<;>s1".equals(cis.getLastPacket()), "wait for throttle status packet");
        // then send a speed change.
        throttle.handleMessage("AL1234<;>V42");
        // query the velocity.
@@ -84,6 +128,17 @@ public class MultiThrottleTest {
     @Test
     public void testSetEStop() {
        throttle.handleMessage("+L1234<;>L1234");
+       // FIELD REPORT (Andrew Deak): waiting on hasAddressBeenFound() alone
+       // is NOT enough -- ThrottleController.notifyThrottleFound() (invoked
+       // from the now-deferred AbstractThrottleManager callback) notifies
+       // listeners (setting this flag) BEFORE its own later
+       // sendCurrentSpeed()/sendCurrentDirection()/sendSpeedStepMode() calls
+       // run, all synchronously within the same method but AFTER the flag
+       // flips. Confirmed live: intermittently observed an EARLIER packet
+       // (or none of the later ones) depending purely on exactly when this
+       // wait's polling happened to land relative to that still-in-progress
+       // call. Wait for the actual last packet that method sends instead.
+       JUnitUtil.waitFor(() -> "MAAL1234<;>s1".equals(cis.getLastPacket()), "wait for throttle status packet");
        // then send EStop.
        throttle.handleMessage("AL1234<;>X");
        assertEquals( "MAAL1234<;>V-126",cis.getLastPacket(), "outgoing message after throttle EStop");
@@ -92,6 +147,17 @@ public class MultiThrottleTest {
     @Test
     public void testSetIdle() {
        throttle.handleMessage("+L1234<;>L1234");
+       // FIELD REPORT (Andrew Deak): waiting on hasAddressBeenFound() alone
+       // is NOT enough -- ThrottleController.notifyThrottleFound() (invoked
+       // from the now-deferred AbstractThrottleManager callback) notifies
+       // listeners (setting this flag) BEFORE its own later
+       // sendCurrentSpeed()/sendCurrentDirection()/sendSpeedStepMode() calls
+       // run, all synchronously within the same method but AFTER the flag
+       // flips. Confirmed live: intermittently observed an EARLIER packet
+       // (or none of the later ones) depending purely on exactly when this
+       // wait's polling happened to land relative to that still-in-progress
+       // call. Wait for the actual last packet that method sends instead.
+       JUnitUtil.waitFor(() -> "MAAL1234<;>s1".equals(cis.getLastPacket()), "wait for throttle status packet");
        // then send EStop.
        throttle.handleMessage("AL1234<;>I");
        throttle.handleMessage("AL1234<;>qV");
@@ -101,6 +167,17 @@ public class MultiThrottleTest {
     @Test
     public void testSetFunction() {
        throttle.handleMessage("+L1234<;>L1234");
+       // FIELD REPORT (Andrew Deak): waiting on hasAddressBeenFound() alone
+       // is NOT enough -- ThrottleController.notifyThrottleFound() (invoked
+       // from the now-deferred AbstractThrottleManager callback) notifies
+       // listeners (setting this flag) BEFORE its own later
+       // sendCurrentSpeed()/sendCurrentDirection()/sendSpeedStepMode() calls
+       // run, all synchronously within the same method but AFTER the flag
+       // flips. Confirmed live: intermittently observed an EARLIER packet
+       // (or none of the later ones) depending purely on exactly when this
+       // wait's polling happened to land relative to that still-in-progress
+       // call. Wait for the actual last packet that method sends instead.
+       JUnitUtil.waitFor(() -> "MAAL1234<;>s1".equals(cis.getLastPacket()), "wait for throttle status packet");
        // function "on" from withrottle represents a button click event.
        throttle.handleMessage("AL1234<;>F11");
        assertEquals( "MAAL1234<;>F11",cis.getLastPacket(), "outgoing message after function on");
@@ -111,6 +188,17 @@ public class MultiThrottleTest {
     @Test
     public void testForceFunction() {
        throttle.handleMessage("+L1234<;>L1234");
+       // FIELD REPORT (Andrew Deak): waiting on hasAddressBeenFound() alone
+       // is NOT enough -- ThrottleController.notifyThrottleFound() (invoked
+       // from the now-deferred AbstractThrottleManager callback) notifies
+       // listeners (setting this flag) BEFORE its own later
+       // sendCurrentSpeed()/sendCurrentDirection()/sendSpeedStepMode() calls
+       // run, all synchronously within the same method but AFTER the flag
+       // flips. Confirmed live: intermittently observed an EARLIER packet
+       // (or none of the later ones) depending purely on exactly when this
+       // wait's polling happened to land relative to that still-in-progress
+       // call. Wait for the actual last packet that method sends instead.
+       JUnitUtil.waitFor(() -> "MAAL1234<;>s1".equals(cis.getLastPacket()), "wait for throttle status packet");
        // function "on" from withrottle represents a button click event.
        throttle.handleMessage("AL1234<;>f11");
        assertEquals( "MAAL1234<;>F11",cis.getLastPacket(), "outgoing message after function on");
@@ -121,6 +209,17 @@ public class MultiThrottleTest {
     @Test
     public void testMomentaryFunction() {
        throttle.handleMessage("+L1234<;>L1234");
+       // FIELD REPORT (Andrew Deak): waiting on hasAddressBeenFound() alone
+       // is NOT enough -- ThrottleController.notifyThrottleFound() (invoked
+       // from the now-deferred AbstractThrottleManager callback) notifies
+       // listeners (setting this flag) BEFORE its own later
+       // sendCurrentSpeed()/sendCurrentDirection()/sendSpeedStepMode() calls
+       // run, all synchronously within the same method but AFTER the flag
+       // flips. Confirmed live: intermittently observed an EARLIER packet
+       // (or none of the later ones) depending purely on exactly when this
+       // wait's polling happened to land relative to that still-in-progress
+       // call. Wait for the actual last packet that method sends instead.
+       JUnitUtil.waitFor(() -> "MAAL1234<;>s1".equals(cis.getLastPacket()), "wait for throttle status packet");
        // function "on" from withrottle represents a button click event.
        throttle.handleMessage("AL1234<;>m128");
        throttle.handleMessage("AL1234<;>qm");
@@ -133,6 +232,17 @@ public class MultiThrottleTest {
     @Test
     public void testSetDirection() {
        throttle.handleMessage("+L1234<;>L1234");
+       // FIELD REPORT (Andrew Deak): waiting on hasAddressBeenFound() alone
+       // is NOT enough -- ThrottleController.notifyThrottleFound() (invoked
+       // from the now-deferred AbstractThrottleManager callback) notifies
+       // listeners (setting this flag) BEFORE its own later
+       // sendCurrentSpeed()/sendCurrentDirection()/sendSpeedStepMode() calls
+       // run, all synchronously within the same method but AFTER the flag
+       // flips. Confirmed live: intermittently observed an EARLIER packet
+       // (or none of the later ones) depending purely on exactly when this
+       // wait's polling happened to land relative to that still-in-progress
+       // call. Wait for the actual last packet that method sends instead.
+       JUnitUtil.waitFor(() -> "MAAL1234<;>s1".equals(cis.getLastPacket()), "wait for throttle status packet");
        // function "on" from withrottle represents a button click event.
        throttle.handleMessage("AL1234<;>R0");
        assertEquals( "MAAL1234<;>R0",cis.getLastPacket(), "outgoing message after direction forward");
@@ -143,6 +253,17 @@ public class MultiThrottleTest {
     @Test
     public void testSetSpeedStepMode() {
        throttle.handleMessage("+L1234<;>L1234");
+       // FIELD REPORT (Andrew Deak): waiting on hasAddressBeenFound() alone
+       // is NOT enough -- ThrottleController.notifyThrottleFound() (invoked
+       // from the now-deferred AbstractThrottleManager callback) notifies
+       // listeners (setting this flag) BEFORE its own later
+       // sendCurrentSpeed()/sendCurrentDirection()/sendSpeedStepMode() calls
+       // run, all synchronously within the same method but AFTER the flag
+       // flips. Confirmed live: intermittently observed an EARLIER packet
+       // (or none of the later ones) depending purely on exactly when this
+       // wait's polling happened to land relative to that still-in-progress
+       // call. Wait for the actual last packet that method sends instead.
+       JUnitUtil.waitFor(() -> "MAAL1234<;>s1".equals(cis.getLastPacket()), "wait for throttle status packet");
        // function "on" from withrottle represents a button click event.
        throttle.handleMessage("AL1234<;>s1");
        assertEquals( "MAAL1234<;>s1",cis.getLastPacket(), "outgoing message after direction forward");
@@ -153,6 +274,17 @@ public class MultiThrottleTest {
     @Test
     public void testQuit() {
        throttle.handleMessage("+L1234<;>L1234");
+       // FIELD REPORT (Andrew Deak): waiting on hasAddressBeenFound() alone
+       // is NOT enough -- ThrottleController.notifyThrottleFound() (invoked
+       // from the now-deferred AbstractThrottleManager callback) notifies
+       // listeners (setting this flag) BEFORE its own later
+       // sendCurrentSpeed()/sendCurrentDirection()/sendSpeedStepMode() calls
+       // run, all synchronously within the same method but AFTER the flag
+       // flips. Confirmed live: intermittently observed an EARLIER packet
+       // (or none of the later ones) depending purely on exactly when this
+       // wait's polling happened to land relative to that still-in-progress
+       // call. Wait for the actual last packet that method sends instead.
+       JUnitUtil.waitFor(() -> "MAAL1234<;>s1".equals(cis.getLastPacket()), "wait for throttle status packet");
        // function "on" from withrottle represents a button click event.
        throttle.handleMessage("AL1234<;>Q");
        assertEquals( "MA-L1234<;>",cis.getLastPacket(), "outgoing message after quit");

--- a/java/test/jmri/jmrit/withrottle/MultiThrottleTest.java
+++ b/java/test/jmri/jmrit/withrottle/MultiThrottleTest.java
@@ -36,14 +36,9 @@ public class MultiThrottleTest {
        // tests setting the address from the input.  
        // Does not include the prefix.
        throttle.handleMessage("+S1<;>S1");
-       // FIELD REPORT (Andrew Deak): AbstractThrottleManager.notifyThrottleKnown()
-       // now defers notifyThrottleFound() via SwingUtilities.invokeLater() (see
-       // its field comment -- fixes a real StackOverflow from synchronous
-       // re-entrant requestThrottle() calls), so this is no longer available
-       // synchronously right after handleMessage() returns. Waiting on
-       // hasAddressBeenFound() alone isn't enough here -- it can flip true in
-       // an earlier queued Swing event than the one that actually sends this
-       // specific status packet, so wait on the packet itself.
+       // Throttle acquisition is now deferred (see AbstractThrottleManager),
+       // so wait for the actual status packet rather than assuming it's
+       // available synchronously right after handleMessage() returns.
        JUnitUtil.waitFor(() -> "MAAS1<;>s1".equals(cis.getLastPacket()), "wait for throttle status packet");
        assertEquals( "MAAS1<;>s1",cis.getLastPacket(), "outgoing message after throttle request");
        assertTrue( tcls.hasAddressBeenFound(), "Address Found");
@@ -64,16 +59,9 @@ public class MultiThrottleTest {
     public void testSetAndReleaseLongAddress(){
        // set the address
        throttle.handleMessage("+L1234<;>L1234");
-       // FIELD REPORT (Andrew Deak): waiting on hasAddressBeenFound() alone
-       // is NOT enough -- ThrottleController.notifyThrottleFound() (invoked
-       // from the now-deferred AbstractThrottleManager callback) notifies
-       // listeners (setting this flag) BEFORE its own later
-       // sendCurrentSpeed()/sendCurrentDirection()/sendSpeedStepMode() calls
-       // run, all synchronously within the same method but AFTER the flag
-       // flips. Confirmed live: intermittently observed an EARLIER packet
-       // (or none of the later ones) depending purely on exactly when this
-       // wait's polling happened to land relative to that still-in-progress
-       // call. Wait for the actual last packet that method sends instead.
+       // hasAddressBeenFound() alone isn't enough -- it flips true before
+       // notifyThrottleFound()'s own later sendCurrentSpeed()/etc. calls
+       // run, so wait for the actual last packet those send instead.
        JUnitUtil.waitFor(() -> "MAAL1234<;>s1".equals(cis.getLastPacket()), "wait for throttle status packet");
        assertTrue( tcls.hasAddressBeenFound(), "Address Found");
        // then release it.
@@ -86,16 +74,9 @@ public class MultiThrottleTest {
     public void testSetAndDispatchLongAddress(){
        // set the address
        throttle.handleMessage("+L1234<;>L1234");
-       // FIELD REPORT (Andrew Deak): waiting on hasAddressBeenFound() alone
-       // is NOT enough -- ThrottleController.notifyThrottleFound() (invoked
-       // from the now-deferred AbstractThrottleManager callback) notifies
-       // listeners (setting this flag) BEFORE its own later
-       // sendCurrentSpeed()/sendCurrentDirection()/sendSpeedStepMode() calls
-       // run, all synchronously within the same method but AFTER the flag
-       // flips. Confirmed live: intermittently observed an EARLIER packet
-       // (or none of the later ones) depending purely on exactly when this
-       // wait's polling happened to land relative to that still-in-progress
-       // call. Wait for the actual last packet that method sends instead.
+       // hasAddressBeenFound() alone isn't enough -- it flips true before
+       // notifyThrottleFound()'s own later sendCurrentSpeed()/etc. calls
+       // run, so wait for the actual last packet those send instead.
        JUnitUtil.waitFor(() -> "MAAL1234<;>s1".equals(cis.getLastPacket()), "wait for throttle status packet");
        assertTrue( tcls.hasAddressBeenFound(), "Address Found");
        // then dispatch it.
@@ -107,16 +88,9 @@ public class MultiThrottleTest {
     @Test
     public void testSetVelocityChange() {
        throttle.handleMessage("+L1234<;>L1234");
-       // FIELD REPORT (Andrew Deak): waiting on hasAddressBeenFound() alone
-       // is NOT enough -- ThrottleController.notifyThrottleFound() (invoked
-       // from the now-deferred AbstractThrottleManager callback) notifies
-       // listeners (setting this flag) BEFORE its own later
-       // sendCurrentSpeed()/sendCurrentDirection()/sendSpeedStepMode() calls
-       // run, all synchronously within the same method but AFTER the flag
-       // flips. Confirmed live: intermittently observed an EARLIER packet
-       // (or none of the later ones) depending purely on exactly when this
-       // wait's polling happened to land relative to that still-in-progress
-       // call. Wait for the actual last packet that method sends instead.
+       // hasAddressBeenFound() alone isn't enough -- it flips true before
+       // notifyThrottleFound()'s own later sendCurrentSpeed()/etc. calls
+       // run, so wait for the actual last packet those send instead.
        JUnitUtil.waitFor(() -> "MAAL1234<;>s1".equals(cis.getLastPacket()), "wait for throttle status packet");
        // then send a speed change.
        throttle.handleMessage("AL1234<;>V42");
@@ -128,16 +102,9 @@ public class MultiThrottleTest {
     @Test
     public void testSetEStop() {
        throttle.handleMessage("+L1234<;>L1234");
-       // FIELD REPORT (Andrew Deak): waiting on hasAddressBeenFound() alone
-       // is NOT enough -- ThrottleController.notifyThrottleFound() (invoked
-       // from the now-deferred AbstractThrottleManager callback) notifies
-       // listeners (setting this flag) BEFORE its own later
-       // sendCurrentSpeed()/sendCurrentDirection()/sendSpeedStepMode() calls
-       // run, all synchronously within the same method but AFTER the flag
-       // flips. Confirmed live: intermittently observed an EARLIER packet
-       // (or none of the later ones) depending purely on exactly when this
-       // wait's polling happened to land relative to that still-in-progress
-       // call. Wait for the actual last packet that method sends instead.
+       // hasAddressBeenFound() alone isn't enough -- it flips true before
+       // notifyThrottleFound()'s own later sendCurrentSpeed()/etc. calls
+       // run, so wait for the actual last packet those send instead.
        JUnitUtil.waitFor(() -> "MAAL1234<;>s1".equals(cis.getLastPacket()), "wait for throttle status packet");
        // then send EStop.
        throttle.handleMessage("AL1234<;>X");
@@ -147,16 +114,9 @@ public class MultiThrottleTest {
     @Test
     public void testSetIdle() {
        throttle.handleMessage("+L1234<;>L1234");
-       // FIELD REPORT (Andrew Deak): waiting on hasAddressBeenFound() alone
-       // is NOT enough -- ThrottleController.notifyThrottleFound() (invoked
-       // from the now-deferred AbstractThrottleManager callback) notifies
-       // listeners (setting this flag) BEFORE its own later
-       // sendCurrentSpeed()/sendCurrentDirection()/sendSpeedStepMode() calls
-       // run, all synchronously within the same method but AFTER the flag
-       // flips. Confirmed live: intermittently observed an EARLIER packet
-       // (or none of the later ones) depending purely on exactly when this
-       // wait's polling happened to land relative to that still-in-progress
-       // call. Wait for the actual last packet that method sends instead.
+       // hasAddressBeenFound() alone isn't enough -- it flips true before
+       // notifyThrottleFound()'s own later sendCurrentSpeed()/etc. calls
+       // run, so wait for the actual last packet those send instead.
        JUnitUtil.waitFor(() -> "MAAL1234<;>s1".equals(cis.getLastPacket()), "wait for throttle status packet");
        // then send EStop.
        throttle.handleMessage("AL1234<;>I");
@@ -167,16 +127,9 @@ public class MultiThrottleTest {
     @Test
     public void testSetFunction() {
        throttle.handleMessage("+L1234<;>L1234");
-       // FIELD REPORT (Andrew Deak): waiting on hasAddressBeenFound() alone
-       // is NOT enough -- ThrottleController.notifyThrottleFound() (invoked
-       // from the now-deferred AbstractThrottleManager callback) notifies
-       // listeners (setting this flag) BEFORE its own later
-       // sendCurrentSpeed()/sendCurrentDirection()/sendSpeedStepMode() calls
-       // run, all synchronously within the same method but AFTER the flag
-       // flips. Confirmed live: intermittently observed an EARLIER packet
-       // (or none of the later ones) depending purely on exactly when this
-       // wait's polling happened to land relative to that still-in-progress
-       // call. Wait for the actual last packet that method sends instead.
+       // hasAddressBeenFound() alone isn't enough -- it flips true before
+       // notifyThrottleFound()'s own later sendCurrentSpeed()/etc. calls
+       // run, so wait for the actual last packet those send instead.
        JUnitUtil.waitFor(() -> "MAAL1234<;>s1".equals(cis.getLastPacket()), "wait for throttle status packet");
        // function "on" from withrottle represents a button click event.
        throttle.handleMessage("AL1234<;>F11");
@@ -188,16 +141,9 @@ public class MultiThrottleTest {
     @Test
     public void testForceFunction() {
        throttle.handleMessage("+L1234<;>L1234");
-       // FIELD REPORT (Andrew Deak): waiting on hasAddressBeenFound() alone
-       // is NOT enough -- ThrottleController.notifyThrottleFound() (invoked
-       // from the now-deferred AbstractThrottleManager callback) notifies
-       // listeners (setting this flag) BEFORE its own later
-       // sendCurrentSpeed()/sendCurrentDirection()/sendSpeedStepMode() calls
-       // run, all synchronously within the same method but AFTER the flag
-       // flips. Confirmed live: intermittently observed an EARLIER packet
-       // (or none of the later ones) depending purely on exactly when this
-       // wait's polling happened to land relative to that still-in-progress
-       // call. Wait for the actual last packet that method sends instead.
+       // hasAddressBeenFound() alone isn't enough -- it flips true before
+       // notifyThrottleFound()'s own later sendCurrentSpeed()/etc. calls
+       // run, so wait for the actual last packet those send instead.
        JUnitUtil.waitFor(() -> "MAAL1234<;>s1".equals(cis.getLastPacket()), "wait for throttle status packet");
        // function "on" from withrottle represents a button click event.
        throttle.handleMessage("AL1234<;>f11");
@@ -209,16 +155,9 @@ public class MultiThrottleTest {
     @Test
     public void testMomentaryFunction() {
        throttle.handleMessage("+L1234<;>L1234");
-       // FIELD REPORT (Andrew Deak): waiting on hasAddressBeenFound() alone
-       // is NOT enough -- ThrottleController.notifyThrottleFound() (invoked
-       // from the now-deferred AbstractThrottleManager callback) notifies
-       // listeners (setting this flag) BEFORE its own later
-       // sendCurrentSpeed()/sendCurrentDirection()/sendSpeedStepMode() calls
-       // run, all synchronously within the same method but AFTER the flag
-       // flips. Confirmed live: intermittently observed an EARLIER packet
-       // (or none of the later ones) depending purely on exactly when this
-       // wait's polling happened to land relative to that still-in-progress
-       // call. Wait for the actual last packet that method sends instead.
+       // hasAddressBeenFound() alone isn't enough -- it flips true before
+       // notifyThrottleFound()'s own later sendCurrentSpeed()/etc. calls
+       // run, so wait for the actual last packet those send instead.
        JUnitUtil.waitFor(() -> "MAAL1234<;>s1".equals(cis.getLastPacket()), "wait for throttle status packet");
        // function "on" from withrottle represents a button click event.
        throttle.handleMessage("AL1234<;>m128");
@@ -232,16 +171,9 @@ public class MultiThrottleTest {
     @Test
     public void testSetDirection() {
        throttle.handleMessage("+L1234<;>L1234");
-       // FIELD REPORT (Andrew Deak): waiting on hasAddressBeenFound() alone
-       // is NOT enough -- ThrottleController.notifyThrottleFound() (invoked
-       // from the now-deferred AbstractThrottleManager callback) notifies
-       // listeners (setting this flag) BEFORE its own later
-       // sendCurrentSpeed()/sendCurrentDirection()/sendSpeedStepMode() calls
-       // run, all synchronously within the same method but AFTER the flag
-       // flips. Confirmed live: intermittently observed an EARLIER packet
-       // (or none of the later ones) depending purely on exactly when this
-       // wait's polling happened to land relative to that still-in-progress
-       // call. Wait for the actual last packet that method sends instead.
+       // hasAddressBeenFound() alone isn't enough -- it flips true before
+       // notifyThrottleFound()'s own later sendCurrentSpeed()/etc. calls
+       // run, so wait for the actual last packet those send instead.
        JUnitUtil.waitFor(() -> "MAAL1234<;>s1".equals(cis.getLastPacket()), "wait for throttle status packet");
        // function "on" from withrottle represents a button click event.
        throttle.handleMessage("AL1234<;>R0");
@@ -253,16 +185,9 @@ public class MultiThrottleTest {
     @Test
     public void testSetSpeedStepMode() {
        throttle.handleMessage("+L1234<;>L1234");
-       // FIELD REPORT (Andrew Deak): waiting on hasAddressBeenFound() alone
-       // is NOT enough -- ThrottleController.notifyThrottleFound() (invoked
-       // from the now-deferred AbstractThrottleManager callback) notifies
-       // listeners (setting this flag) BEFORE its own later
-       // sendCurrentSpeed()/sendCurrentDirection()/sendSpeedStepMode() calls
-       // run, all synchronously within the same method but AFTER the flag
-       // flips. Confirmed live: intermittently observed an EARLIER packet
-       // (or none of the later ones) depending purely on exactly when this
-       // wait's polling happened to land relative to that still-in-progress
-       // call. Wait for the actual last packet that method sends instead.
+       // hasAddressBeenFound() alone isn't enough -- it flips true before
+       // notifyThrottleFound()'s own later sendCurrentSpeed()/etc. calls
+       // run, so wait for the actual last packet those send instead.
        JUnitUtil.waitFor(() -> "MAAL1234<;>s1".equals(cis.getLastPacket()), "wait for throttle status packet");
        // function "on" from withrottle represents a button click event.
        throttle.handleMessage("AL1234<;>s1");
@@ -274,16 +199,9 @@ public class MultiThrottleTest {
     @Test
     public void testQuit() {
        throttle.handleMessage("+L1234<;>L1234");
-       // FIELD REPORT (Andrew Deak): waiting on hasAddressBeenFound() alone
-       // is NOT enough -- ThrottleController.notifyThrottleFound() (invoked
-       // from the now-deferred AbstractThrottleManager callback) notifies
-       // listeners (setting this flag) BEFORE its own later
-       // sendCurrentSpeed()/sendCurrentDirection()/sendSpeedStepMode() calls
-       // run, all synchronously within the same method but AFTER the flag
-       // flips. Confirmed live: intermittently observed an EARLIER packet
-       // (or none of the later ones) depending purely on exactly when this
-       // wait's polling happened to land relative to that still-in-progress
-       // call. Wait for the actual last packet that method sends instead.
+       // hasAddressBeenFound() alone isn't enough -- it flips true before
+       // notifyThrottleFound()'s own later sendCurrentSpeed()/etc. calls
+       // run, so wait for the actual last packet those send instead.
        JUnitUtil.waitFor(() -> "MAAL1234<;>s1".equals(cis.getLastPacket()), "wait for throttle status packet");
        // function "on" from withrottle represents a button click event.
        throttle.handleMessage("AL1234<;>Q");

--- a/java/test/jmri/jmrix/can/cbus/CbusThrottleManagerTest.java
+++ b/java/test/jmri/jmrix/can/cbus/CbusThrottleManagerTest.java
@@ -875,6 +875,14 @@ public class CbusThrottleManagerTest extends jmri.managers.AbstractThrottleManag
                 Throttle.getFunctionString(i));
         }
         assertNull( tm.getThrottleInfo(addr,"NOT A VARIABLE"), "NULL");
+        // FIELD REPORT (Andrew Deak): AbstractThrottleManager.notifyThrottleKnown()
+        // now defers notifyThrottleFound() via SwingUtilities.invokeLater() (see
+        // its field comment), so usage-count tracking (updated inside that same
+        // deferred callback) can still be 0 for a moment after getThrottleInfo()
+        // is already populated (that's set earlier, synchronously). Wait for the
+        // usage count specifically rather than assuming it's atomic with info
+        // becoming available.
+        JUnitUtil.waitFor(() -> tm.getThrottleUsageCount(addr) == 1, "wait for throttle usage count");
         assertEquals( 1, tm.getThrottleUsageCount(addr), "throttle use 1 addr");
         assertEquals( 1, tm.getThrottleUsageCount(42,false), "throttle use 1 int b");
         assertEquals( 0, tm.getThrottleUsageCount(77,true), "throttle use 0");

--- a/java/test/jmri/jmrix/can/cbus/CbusThrottleManagerTest.java
+++ b/java/test/jmri/jmrix/can/cbus/CbusThrottleManagerTest.java
@@ -875,13 +875,9 @@ public class CbusThrottleManagerTest extends jmri.managers.AbstractThrottleManag
                 Throttle.getFunctionString(i));
         }
         assertNull( tm.getThrottleInfo(addr,"NOT A VARIABLE"), "NULL");
-        // FIELD REPORT (Andrew Deak): AbstractThrottleManager.notifyThrottleKnown()
-        // now defers notifyThrottleFound() via SwingUtilities.invokeLater() (see
-        // its field comment), so usage-count tracking (updated inside that same
-        // deferred callback) can still be 0 for a moment after getThrottleInfo()
-        // is already populated (that's set earlier, synchronously). Wait for the
-        // usage count specifically rather than assuming it's atomic with info
-        // becoming available.
+        // Usage-count tracking is updated in the same deferred callback as
+        // throttle acquisition (see AbstractThrottleManager), so it can
+        // still be 0 for a moment after getThrottleInfo() is populated.
         JUnitUtil.waitFor(() -> tm.getThrottleUsageCount(addr) == 1, "wait for throttle usage count");
         assertEquals( 1, tm.getThrottleUsageCount(addr), "throttle use 1 addr");
         assertEquals( 1, tm.getThrottleUsageCount(42,false), "throttle use 1 int b");

--- a/java/test/jmri/jmrix/dccpp/DCCppThrottleManagerTest.java
+++ b/java/test/jmri/jmrix/dccpp/DCCppThrottleManagerTest.java
@@ -51,11 +51,8 @@ public class DCCppThrottleManagerTest extends jmri.managers.AbstractThrottleMana
         DccLocoAddress locoAddress = new DccLocoAddress(1203,true);
         tm.requestThrottle(1203, throtListen,true);
 
-        // FIELD REPORT (Andrew Deak): AbstractThrottleManager.notifyThrottleKnown()
-        // now defers notifyThrottleFound() via SwingUtilities.invokeLater() (see
-        // its field comment -- fixes a real StackOverflow from synchronous
-        // re-entrant requestThrottle() calls), so this is no longer available
-        // synchronously right after requestThrottle() returns.
+        // Throttle acquisition is now deferred (see AbstractThrottleManager),
+        // so not available synchronously right after requestThrottle() returns.
         JUnitUtil.waitFor(() -> throttle != null, "wait for throttle found");
         assertNotNull( throttle, "have created a throttle");
         assertInstanceOf(DCCppThrottle.class, throttle);

--- a/java/test/jmri/jmrix/dccpp/DCCppThrottleManagerTest.java
+++ b/java/test/jmri/jmrix/dccpp/DCCppThrottleManagerTest.java
@@ -51,6 +51,12 @@ public class DCCppThrottleManagerTest extends jmri.managers.AbstractThrottleMana
         DccLocoAddress locoAddress = new DccLocoAddress(1203,true);
         tm.requestThrottle(1203, throtListen,true);
 
+        // FIELD REPORT (Andrew Deak): AbstractThrottleManager.notifyThrottleKnown()
+        // now defers notifyThrottleFound() via SwingUtilities.invokeLater() (see
+        // its field comment -- fixes a real StackOverflow from synchronous
+        // re-entrant requestThrottle() calls), so this is no longer available
+        // synchronously right after requestThrottle() returns.
+        JUnitUtil.waitFor(() -> throttle != null, "wait for throttle found");
         assertNotNull( throttle, "have created a throttle");
         assertInstanceOf(DCCppThrottle.class, throttle);
         assertTrue( (((DCCppThrottleManager)tm).throttles.containsKey(locoAddress))); // now you see it

--- a/java/test/jmri/jmrix/loconet/LnThrottleManagerTest.java
+++ b/java/test/jmri/jmrix/loconet/LnThrottleManagerTest.java
@@ -63,6 +63,12 @@ public class LnThrottleManagerTest extends jmri.managers.AbstractThrottleManager
                 0xb4, 0x6f, 0x7f, 0x5B});
         lnis.sendTestMessage(cmdStationReply);
 
+        // FIELD REPORT (Andrew Deak): notifyThrottleKnown() now defers
+        // notifyThrottleFound() via SwingUtilities.invokeLater() (see its
+        // field comment -- fixes a real StackOverflow from synchronous
+        // re-entrant requestThrottle() calls), so this is no longer
+        // available the instant the LocoNet message above is sent.
+        JUnitUtil.waitFor(() -> throtListen.getThrottle() != null, "wait for throttle found");
         DccThrottle throttle = throtListen.getThrottle();
         Assertions.assertNotNull(throttle, "have created a throttle");
         Assertions.assertTrue(throttle.getClass() == LocoNetThrottle.class,"is LnThrottle");
@@ -111,6 +117,12 @@ public class LnThrottleManagerTest extends jmri.managers.AbstractThrottleManager
         lnis.sendTestMessage(cmdStationReply);
         memo.getSlotManager().message(lnis.outbound.elementAt(lnis.outbound.size()-1));
 
+        // FIELD REPORT (Andrew Deak): notifyThrottleKnown() now defers
+        // notifyThrottleFound() via SwingUtilities.invokeLater() (see its
+        // field comment -- fixes a real StackOverflow from synchronous
+        // re-entrant requestThrottle() calls), so this is no longer
+        // available the instant the LocoNet message above is sent.
+        JUnitUtil.waitFor(() -> throtListen.getThrottle() != null, "wait for throttle found");
         DccThrottle throttle = throtListen.getThrottle();
 
         assertNotNull(throttle, "have created a throttle");
@@ -178,6 +190,12 @@ public class LnThrottleManagerTest extends jmri.managers.AbstractThrottleManager
         lnis.sendTestMessage(cmdStationReply);
         memo.getSlotManager().message(lnis.outbound.elementAt(lnis.outbound.size()-1));
 
+        // FIELD REPORT (Andrew Deak): notifyThrottleKnown() now defers
+        // notifyThrottleFound() via SwingUtilities.invokeLater() (see its
+        // field comment -- fixes a real StackOverflow from synchronous
+        // re-entrant requestThrottle() calls), so this is no longer
+        // available the instant the LocoNet message above is sent.
+        JUnitUtil.waitFor(() -> throtListen.getThrottle() != null, "wait for throttle found");
         DccThrottle throttle = throtListen.getThrottle();
 
         Assertions.assertNotNull(throttle, "have created a throttle");
@@ -295,6 +313,12 @@ public class LnThrottleManagerTest extends jmri.managers.AbstractThrottleManager
         assertEquals( "EF 0E 08 30 00 00 00 07 00 02 00 71 02 00",
             lnis.outbound.elementAt(lnis.outbound.size() - 1).toString(), "Write Throttle ID");
 
+        // FIELD REPORT (Andrew Deak): notifyThrottleKnown() now defers
+        // notifyThrottleFound() via SwingUtilities.invokeLater() (see its
+        // field comment -- fixes a real StackOverflow from synchronous
+        // re-entrant requestThrottle() calls), so this is no longer
+        // available the instant the LocoNet message above is sent.
+        JUnitUtil.waitFor(() -> throtListen.getThrottle() != null, "wait for throttle found");
         DccThrottle throttle = throtListen.getThrottle();
 
         assertNotNull( throttle, "Throttle should be created and non-null");
@@ -326,6 +350,12 @@ public class LnThrottleManagerTest extends jmri.managers.AbstractThrottleManager
         assertEquals( "EF 0E 08 30 01 00 00 07 00 02 00 71 02 00",
             lnis.outbound.elementAt(lnis.outbound.size() - 1).toString(), "Write Throttle ID");
 
+        // FIELD REPORT (Andrew Deak): notifyThrottleKnown() now defers
+        // notifyThrottleFound() via SwingUtilities.invokeLater() (see its
+        // field comment -- fixes a real StackOverflow from synchronous
+        // re-entrant requestThrottle() calls), so this is no longer
+        // available the instant the LocoNet message above is sent.
+        JUnitUtil.waitFor(() -> throtListen.getThrottle() != null, "wait for throttle found");
         Assertions.assertNotNull(throtListen.getThrottle(), "Throttle should be created and non-null");
         tm.releaseThrottle(throtListen.getThrottle(), throtListen);
     }
@@ -355,6 +385,12 @@ public class LnThrottleManagerTest extends jmri.managers.AbstractThrottleManager
         assertEquals( "EF 0E 08 30 03 00 00 07 00 02 00 71 02 00",
             lnis.outbound.elementAt(lnis.outbound.size() - 1).toString(), "Write Throttle ID");
 
+        // FIELD REPORT (Andrew Deak): notifyThrottleKnown() now defers
+        // notifyThrottleFound() via SwingUtilities.invokeLater() (see its
+        // field comment -- fixes a real StackOverflow from synchronous
+        // re-entrant requestThrottle() calls), so this is no longer
+        // available the instant the LocoNet message above is sent.
+        JUnitUtil.waitFor(() -> throtListen.getThrottle() != null, "wait for throttle found");
         assertNotNull( throtListen.getThrottle(), "Throttle should be created and non-null");
         tm.releaseThrottle(throtListen.getThrottle(), throtListen);
     }
@@ -396,12 +432,19 @@ public class LnThrottleManagerTest extends jmri.managers.AbstractThrottleManager
             (lnis.outbound.elementAt(lnis.outbound.size()-1).toString())),
             "Write Throttle ID");
 
+        // FIELD REPORT (Andrew Deak): AbstractThrottleManager.notifyThrottleKnown()
+        // now defers notifyThrottleFound() via SwingUtilities.invokeLater() (fixes
+        // a real StackOverflow from synchronous re-entrant requestThrottle()
+        // calls -- see its field comment), so this is no longer available
+        // synchronously even after waiting for the LocoNet message above.
+        JUnitUtil.waitFor(() -> throtListen.getThrottle() != null, "wait for throttle found");
         assertNotNull( throtListen.getThrottle(), "Throttle should be created and non-null");
 
         int netTxMsgCount = lnis.outbound.size()-1;
 
         tm.requestThrottle(260, throtListen2, true);  // An additional user of the same throttle
 
+        JUnitUtil.waitFor(() -> throtListen2.getThrottle() != null, "wait for second throttle found");
         assertNotNull( throtListen2.getThrottle(), "Throttle should be created and non-null");
         assertEquals( throtListen.getThrottle(), throtListen2.getThrottle(),
             "both throttle users point to the same throttle object");
@@ -466,6 +509,12 @@ public class LnThrottleManagerTest extends jmri.managers.AbstractThrottleManager
         assertEquals( "EF 0E 09 30 04 00 00 07 00 02 00 71 02 00",
                 lnis.outbound.elementAt(lnis.outbound.size() - 1).toString(), "Write Throttle ID");
 
+        // FIELD REPORT (Andrew Deak): notifyThrottleKnown() now defers
+        // notifyThrottleFound() via SwingUtilities.invokeLater() (see its
+        // field comment -- fixes a real StackOverflow from synchronous
+        // re-entrant requestThrottle() calls), so this is no longer
+        // available the instant the LocoNet message above is sent.
+        JUnitUtil.waitFor(() -> throtListen.getThrottle() != null, "wait for throttle found");
         assertNotNull( throtListen.getThrottle(), "Throttle should be created and non-null");
 
         lnis.outbound.clear();
@@ -474,6 +523,7 @@ public class LnThrottleManagerTest extends jmri.managers.AbstractThrottleManager
 
         tm.requestThrottle(260, throtListen2, true);  // An additional user of the same throttle
 
+        JUnitUtil.waitFor(() -> throtListen2.getThrottle() != null, "wait for second throttle found");
         assertNotNull( throtListen2.getThrottle(), "Throttle should be created and non-null");
         assertEquals( throtListen.getThrottle(), throtListen2.getThrottle(),
             "both throttle users point to the same throttle object");
@@ -567,12 +617,19 @@ public class LnThrottleManagerTest extends jmri.managers.AbstractThrottleManager
         assertEquals("EF 0E 0A 30 05 00 00 07 00 02 00 71 02 00",
             lnis.outbound.elementAt(lnis.outbound.size() - 1).toString(), "Write Throttle ID");
 
+        // FIELD REPORT (Andrew Deak): notifyThrottleKnown() now defers
+        // notifyThrottleFound() via SwingUtilities.invokeLater() (see its
+        // field comment -- fixes a real StackOverflow from synchronous
+        // re-entrant requestThrottle() calls), so this is no longer
+        // available the instant the LocoNet message above is sent.
+        JUnitUtil.waitFor(() -> throtListen.getThrottle() != null, "wait for throttle found");
         assertNotNull(throtListen.getThrottle(), "Throttle should be created and non-null");
 
         int netTxMsgCount = lnis.outbound.size()-1;
 
         tm.requestThrottle(261, throtListen2, true);  // An additional user of the same throttle
 
+        JUnitUtil.waitFor(() -> throtListen2.getThrottle() != null, "wait for second throttle found");
         assertNotNull(throtListen2.getThrottle(), "Throttle should be created and non-null");
         assertEquals(throtListen.getThrottle(), throtListen2.getThrottle(),
             "both throttle users point to the same throttle object");
@@ -590,6 +647,7 @@ public class LnThrottleManagerTest extends jmri.managers.AbstractThrottleManager
 
         tm.requestThrottle(261, throtListen3, true);  // An additional user of the same throttle
 
+        JUnitUtil.waitFor(() -> throtListen3.getThrottle() != null, "wait for third throttle found");
         assertNotNull(throtListen3.getThrottle(), "Throttle should be created and non-null");
         assertEquals(throtListen.getThrottle(), throtListen3.getThrottle(),
             "both throttle users point to the same throttle object");
@@ -664,12 +722,19 @@ public class LnThrottleManagerTest extends jmri.managers.AbstractThrottleManager
         assertEquals( "EF 0E 0B 30 06 00 00 07 00 02 00 71 02 00",
             lnis.outbound.elementAt(lnis.outbound.size() - 1).toString(), "Write Throttle ID");
 
+        // FIELD REPORT (Andrew Deak): notifyThrottleKnown() now defers
+        // notifyThrottleFound() via SwingUtilities.invokeLater() (see its
+        // field comment -- fixes a real StackOverflow from synchronous
+        // re-entrant requestThrottle() calls), so this is no longer
+        // available the instant the LocoNet message above is sent.
+        JUnitUtil.waitFor(() -> throtListen.getThrottle() != null, "wait for throttle found");
         assertNotNull(throtListen.getThrottle(), "Throttle should be created and non-null");
 
         int netTxMsgCount = lnis.outbound.size()-1;
 
         tm.requestThrottle(262, throtListen2, true);  // An additional user of the same throttle
 
+        JUnitUtil.waitFor(() -> throtListen2.getThrottle() != null, "wait for second throttle found");
         assertNotNull(throtListen2.getThrottle(), "Throttle should be created and non-null");
         assertEquals( throtListen.getThrottle(), throtListen2.getThrottle(),
             "both throttle users point to the same throttle object");
@@ -745,6 +810,12 @@ public class LnThrottleManagerTest extends jmri.managers.AbstractThrottleManager
                 0xb4, 0x6f, 0x7f, 0x5B});
         lnis.sendTestMessage(cmdStationReply);
 
+        // FIELD REPORT (Andrew Deak): notifyThrottleKnown() now defers
+        // notifyThrottleFound() via SwingUtilities.invokeLater() (see its
+        // field comment -- fixes a real StackOverflow from synchronous
+        // re-entrant requestThrottle() calls), so this is no longer
+        // available the instant the LocoNet message above is sent.
+        JUnitUtil.waitFor(() -> throtListen.getThrottle() != null, "wait for throttle found");
         DccThrottle throttle4 = throtListen.getThrottle();
 
         assertNotNull(throttle4, "have created a throttle4");

--- a/java/test/jmri/jmrix/loconet/LnThrottleManagerTest.java
+++ b/java/test/jmri/jmrix/loconet/LnThrottleManagerTest.java
@@ -63,11 +63,8 @@ public class LnThrottleManagerTest extends jmri.managers.AbstractThrottleManager
                 0xb4, 0x6f, 0x7f, 0x5B});
         lnis.sendTestMessage(cmdStationReply);
 
-        // FIELD REPORT (Andrew Deak): notifyThrottleKnown() now defers
-        // notifyThrottleFound() via SwingUtilities.invokeLater() (see its
-        // field comment -- fixes a real StackOverflow from synchronous
-        // re-entrant requestThrottle() calls), so this is no longer
-        // available the instant the LocoNet message above is sent.
+        // Throttle acquisition is now deferred (see AbstractThrottleManager),
+        // so it's not available the instant the LocoNet message is sent.
         JUnitUtil.waitFor(() -> throtListen.getThrottle() != null, "wait for throttle found");
         DccThrottle throttle = throtListen.getThrottle();
         Assertions.assertNotNull(throttle, "have created a throttle");
@@ -117,11 +114,8 @@ public class LnThrottleManagerTest extends jmri.managers.AbstractThrottleManager
         lnis.sendTestMessage(cmdStationReply);
         memo.getSlotManager().message(lnis.outbound.elementAt(lnis.outbound.size()-1));
 
-        // FIELD REPORT (Andrew Deak): notifyThrottleKnown() now defers
-        // notifyThrottleFound() via SwingUtilities.invokeLater() (see its
-        // field comment -- fixes a real StackOverflow from synchronous
-        // re-entrant requestThrottle() calls), so this is no longer
-        // available the instant the LocoNet message above is sent.
+        // Throttle acquisition is now deferred (see AbstractThrottleManager),
+        // so it's not available the instant the LocoNet message is sent.
         JUnitUtil.waitFor(() -> throtListen.getThrottle() != null, "wait for throttle found");
         DccThrottle throttle = throtListen.getThrottle();
 
@@ -190,11 +184,8 @@ public class LnThrottleManagerTest extends jmri.managers.AbstractThrottleManager
         lnis.sendTestMessage(cmdStationReply);
         memo.getSlotManager().message(lnis.outbound.elementAt(lnis.outbound.size()-1));
 
-        // FIELD REPORT (Andrew Deak): notifyThrottleKnown() now defers
-        // notifyThrottleFound() via SwingUtilities.invokeLater() (see its
-        // field comment -- fixes a real StackOverflow from synchronous
-        // re-entrant requestThrottle() calls), so this is no longer
-        // available the instant the LocoNet message above is sent.
+        // Throttle acquisition is now deferred (see AbstractThrottleManager),
+        // so it's not available the instant the LocoNet message is sent.
         JUnitUtil.waitFor(() -> throtListen.getThrottle() != null, "wait for throttle found");
         DccThrottle throttle = throtListen.getThrottle();
 
@@ -313,11 +304,8 @@ public class LnThrottleManagerTest extends jmri.managers.AbstractThrottleManager
         assertEquals( "EF 0E 08 30 00 00 00 07 00 02 00 71 02 00",
             lnis.outbound.elementAt(lnis.outbound.size() - 1).toString(), "Write Throttle ID");
 
-        // FIELD REPORT (Andrew Deak): notifyThrottleKnown() now defers
-        // notifyThrottleFound() via SwingUtilities.invokeLater() (see its
-        // field comment -- fixes a real StackOverflow from synchronous
-        // re-entrant requestThrottle() calls), so this is no longer
-        // available the instant the LocoNet message above is sent.
+        // Throttle acquisition is now deferred (see AbstractThrottleManager),
+        // so it's not available the instant the LocoNet message is sent.
         JUnitUtil.waitFor(() -> throtListen.getThrottle() != null, "wait for throttle found");
         DccThrottle throttle = throtListen.getThrottle();
 
@@ -350,11 +338,8 @@ public class LnThrottleManagerTest extends jmri.managers.AbstractThrottleManager
         assertEquals( "EF 0E 08 30 01 00 00 07 00 02 00 71 02 00",
             lnis.outbound.elementAt(lnis.outbound.size() - 1).toString(), "Write Throttle ID");
 
-        // FIELD REPORT (Andrew Deak): notifyThrottleKnown() now defers
-        // notifyThrottleFound() via SwingUtilities.invokeLater() (see its
-        // field comment -- fixes a real StackOverflow from synchronous
-        // re-entrant requestThrottle() calls), so this is no longer
-        // available the instant the LocoNet message above is sent.
+        // Throttle acquisition is now deferred (see AbstractThrottleManager),
+        // so it's not available the instant the LocoNet message is sent.
         JUnitUtil.waitFor(() -> throtListen.getThrottle() != null, "wait for throttle found");
         Assertions.assertNotNull(throtListen.getThrottle(), "Throttle should be created and non-null");
         tm.releaseThrottle(throtListen.getThrottle(), throtListen);
@@ -385,11 +370,8 @@ public class LnThrottleManagerTest extends jmri.managers.AbstractThrottleManager
         assertEquals( "EF 0E 08 30 03 00 00 07 00 02 00 71 02 00",
             lnis.outbound.elementAt(lnis.outbound.size() - 1).toString(), "Write Throttle ID");
 
-        // FIELD REPORT (Andrew Deak): notifyThrottleKnown() now defers
-        // notifyThrottleFound() via SwingUtilities.invokeLater() (see its
-        // field comment -- fixes a real StackOverflow from synchronous
-        // re-entrant requestThrottle() calls), so this is no longer
-        // available the instant the LocoNet message above is sent.
+        // Throttle acquisition is now deferred (see AbstractThrottleManager),
+        // so it's not available the instant the LocoNet message is sent.
         JUnitUtil.waitFor(() -> throtListen.getThrottle() != null, "wait for throttle found");
         assertNotNull( throtListen.getThrottle(), "Throttle should be created and non-null");
         tm.releaseThrottle(throtListen.getThrottle(), throtListen);
@@ -432,11 +414,7 @@ public class LnThrottleManagerTest extends jmri.managers.AbstractThrottleManager
             (lnis.outbound.elementAt(lnis.outbound.size()-1).toString())),
             "Write Throttle ID");
 
-        // FIELD REPORT (Andrew Deak): AbstractThrottleManager.notifyThrottleKnown()
-        // now defers notifyThrottleFound() via SwingUtilities.invokeLater() (fixes
-        // a real StackOverflow from synchronous re-entrant requestThrottle()
-        // calls -- see its field comment), so this is no longer available
-        // synchronously even after waiting for the LocoNet message above.
+        // Throttle acquisition is now deferred (see AbstractThrottleManager).
         JUnitUtil.waitFor(() -> throtListen.getThrottle() != null, "wait for throttle found");
         assertNotNull( throtListen.getThrottle(), "Throttle should be created and non-null");
 
@@ -509,11 +487,8 @@ public class LnThrottleManagerTest extends jmri.managers.AbstractThrottleManager
         assertEquals( "EF 0E 09 30 04 00 00 07 00 02 00 71 02 00",
                 lnis.outbound.elementAt(lnis.outbound.size() - 1).toString(), "Write Throttle ID");
 
-        // FIELD REPORT (Andrew Deak): notifyThrottleKnown() now defers
-        // notifyThrottleFound() via SwingUtilities.invokeLater() (see its
-        // field comment -- fixes a real StackOverflow from synchronous
-        // re-entrant requestThrottle() calls), so this is no longer
-        // available the instant the LocoNet message above is sent.
+        // Throttle acquisition is now deferred (see AbstractThrottleManager),
+        // so it's not available the instant the LocoNet message is sent.
         JUnitUtil.waitFor(() -> throtListen.getThrottle() != null, "wait for throttle found");
         assertNotNull( throtListen.getThrottle(), "Throttle should be created and non-null");
 
@@ -617,11 +592,8 @@ public class LnThrottleManagerTest extends jmri.managers.AbstractThrottleManager
         assertEquals("EF 0E 0A 30 05 00 00 07 00 02 00 71 02 00",
             lnis.outbound.elementAt(lnis.outbound.size() - 1).toString(), "Write Throttle ID");
 
-        // FIELD REPORT (Andrew Deak): notifyThrottleKnown() now defers
-        // notifyThrottleFound() via SwingUtilities.invokeLater() (see its
-        // field comment -- fixes a real StackOverflow from synchronous
-        // re-entrant requestThrottle() calls), so this is no longer
-        // available the instant the LocoNet message above is sent.
+        // Throttle acquisition is now deferred (see AbstractThrottleManager),
+        // so it's not available the instant the LocoNet message is sent.
         JUnitUtil.waitFor(() -> throtListen.getThrottle() != null, "wait for throttle found");
         assertNotNull(throtListen.getThrottle(), "Throttle should be created and non-null");
 
@@ -722,11 +694,8 @@ public class LnThrottleManagerTest extends jmri.managers.AbstractThrottleManager
         assertEquals( "EF 0E 0B 30 06 00 00 07 00 02 00 71 02 00",
             lnis.outbound.elementAt(lnis.outbound.size() - 1).toString(), "Write Throttle ID");
 
-        // FIELD REPORT (Andrew Deak): notifyThrottleKnown() now defers
-        // notifyThrottleFound() via SwingUtilities.invokeLater() (see its
-        // field comment -- fixes a real StackOverflow from synchronous
-        // re-entrant requestThrottle() calls), so this is no longer
-        // available the instant the LocoNet message above is sent.
+        // Throttle acquisition is now deferred (see AbstractThrottleManager),
+        // so it's not available the instant the LocoNet message is sent.
         JUnitUtil.waitFor(() -> throtListen.getThrottle() != null, "wait for throttle found");
         assertNotNull(throtListen.getThrottle(), "Throttle should be created and non-null");
 
@@ -810,11 +779,8 @@ public class LnThrottleManagerTest extends jmri.managers.AbstractThrottleManager
                 0xb4, 0x6f, 0x7f, 0x5B});
         lnis.sendTestMessage(cmdStationReply);
 
-        // FIELD REPORT (Andrew Deak): notifyThrottleKnown() now defers
-        // notifyThrottleFound() via SwingUtilities.invokeLater() (see its
-        // field comment -- fixes a real StackOverflow from synchronous
-        // re-entrant requestThrottle() calls), so this is no longer
-        // available the instant the LocoNet message above is sent.
+        // Throttle acquisition is now deferred (see AbstractThrottleManager),
+        // so it's not available the instant the LocoNet message is sent.
         JUnitUtil.waitFor(() -> throtListen.getThrottle() != null, "wait for throttle found");
         DccThrottle throttle4 = throtListen.getThrottle();
 

--- a/java/test/jmri/jmrix/loconet/LnThrottleManagerWithLnPredefinedMetersTest.java
+++ b/java/test/jmri/jmrix/loconet/LnThrottleManagerWithLnPredefinedMetersTest.java
@@ -56,6 +56,12 @@ public class LnThrottleManagerWithLnPredefinedMetersTest {
 
         tm.requestThrottle(260, throtListen2, true);  // An additional user of the same throttle
 
+        // FIELD REPORT (Andrew Deak): notifyThrottleKnown() now defers
+        // notifyThrottleFound() via SwingUtilities.invokeLater() (see its
+        // field comment -- fixes a real StackOverflow from synchronous
+        // re-entrant requestThrottle() calls), so this is no longer
+        // available the instant requestThrottle() returns.
+        JUnitUtil.waitFor(() -> throtListen.getThrottle() != null, "wait for throttle found");
         throtListen.getThrottle().setSpeedSetting(0.5f);
 
         lnis.outbound.clear();
@@ -106,6 +112,10 @@ public class LnThrottleManagerWithLnPredefinedMetersTest {
 
         tm.requestThrottle(260, throtListen2, true);  // An additional user of the same throttle
 
+        // FIELD REPORT (Andrew Deak): see the matching comment in
+        // testShareSingleLnThrottleScenario1() above -- notifyThrottleFound()
+        // is now deferred, so this isn't available synchronously.
+        JUnitUtil.waitFor(() -> throtListen2.getThrottle() != null, "wait for second throttle found");
         tm.dispatchThrottle(throtListen2.getThrottle(), throtListen2); // this fails as loco is in use on multiple throttles
         tm.releaseThrottle(throtListen.getThrottle(), throtListen);
 

--- a/java/test/jmri/jmrix/mqtt/MqttThrottleManagerTest.java
+++ b/java/test/jmri/jmrix/mqtt/MqttThrottleManagerTest.java
@@ -52,11 +52,8 @@ public class MqttThrottleManagerTest extends jmri.managers.AbstractThrottleManag
         DccLocoAddress locoAddress = new DccLocoAddress(1203,true);
         tm.requestThrottle(1203, throtListen,true);
 
-        // FIELD REPORT (Andrew Deak): AbstractThrottleManager.notifyThrottleKnown()
-        // now defers notifyThrottleFound() via SwingUtilities.invokeLater() (see
-        // its field comment -- fixes a real StackOverflow from synchronous
-        // re-entrant requestThrottle() calls), so this is no longer available
-        // synchronously right after requestThrottle() returns.
+        // Throttle acquisition is now deferred (see AbstractThrottleManager),
+        // so not available synchronously right after requestThrottle() returns.
         JUnitUtil.waitFor(() -> throttle != null, "wait for throttle found");
         assertNotNull( throttle, "have created a throttle");
         assertInstanceOf(MqttThrottle.class , throttle);

--- a/java/test/jmri/jmrix/mqtt/MqttThrottleManagerTest.java
+++ b/java/test/jmri/jmrix/mqtt/MqttThrottleManagerTest.java
@@ -52,6 +52,12 @@ public class MqttThrottleManagerTest extends jmri.managers.AbstractThrottleManag
         DccLocoAddress locoAddress = new DccLocoAddress(1203,true);
         tm.requestThrottle(1203, throtListen,true);
 
+        // FIELD REPORT (Andrew Deak): AbstractThrottleManager.notifyThrottleKnown()
+        // now defers notifyThrottleFound() via SwingUtilities.invokeLater() (see
+        // its field comment -- fixes a real StackOverflow from synchronous
+        // re-entrant requestThrottle() calls), so this is no longer available
+        // synchronously right after requestThrottle() returns.
+        JUnitUtil.waitFor(() -> throttle != null, "wait for throttle found");
         assertNotNull( throttle, "have created a throttle");
         assertInstanceOf(MqttThrottle.class , throttle);
         assertTrue( (((MqttThrottleManager)tm).throttles.containsKey(locoAddress))); // now you see it

--- a/java/test/jmri/managers/AbstractThrottleManagerTestBase.java
+++ b/java/test/jmri/managers/AbstractThrottleManagerTestBase.java
@@ -169,6 +169,16 @@ public abstract class AbstractThrottleManagerTestBase {
         ThrottleListen throtListen = new ThrottleListen();
         tm.requestThrottle(addr, throtListen, true);
         JUnitUtil.waitFor(()-> (tm.getThrottleInfo(addr, Throttle.ISFORWARD) != null), "reply didn't arrive");
+        // FIELD REPORT (Andrew Deak): AbstractThrottleManager.notifyThrottleKnown()
+        // now defers notifyThrottleFound() via SwingUtilities.invokeLater()
+        // (fixes a real StackOverflow from synchronous re-entrant
+        // requestThrottle() calls -- see its field comment), so
+        // throttleFoundResult can still be false for a moment after
+        // getThrottleInfo() is already populated (that's set earlier,
+        // synchronously, in the same method). Wait for the listener
+        // callback specifically rather than assuming it's atomic with the
+        // info becoming available.
+        JUnitUtil.waitFor(() -> throttleFoundResult, "throttle found callback didn't arrive");
 
         assertTrue(throttleFoundResult);
         assertFalse( throttleNotFoundResult );

--- a/java/test/jmri/managers/AbstractThrottleManagerTestBase.java
+++ b/java/test/jmri/managers/AbstractThrottleManagerTestBase.java
@@ -169,15 +169,9 @@ public abstract class AbstractThrottleManagerTestBase {
         ThrottleListen throtListen = new ThrottleListen();
         tm.requestThrottle(addr, throtListen, true);
         JUnitUtil.waitFor(()-> (tm.getThrottleInfo(addr, Throttle.ISFORWARD) != null), "reply didn't arrive");
-        // FIELD REPORT (Andrew Deak): AbstractThrottleManager.notifyThrottleKnown()
-        // now defers notifyThrottleFound() via SwingUtilities.invokeLater()
-        // (fixes a real StackOverflow from synchronous re-entrant
-        // requestThrottle() calls -- see its field comment), so
-        // throttleFoundResult can still be false for a moment after
-        // getThrottleInfo() is already populated (that's set earlier,
-        // synchronously, in the same method). Wait for the listener
-        // callback specifically rather than assuming it's atomic with the
-        // info becoming available.
+        // throttleFoundResult is set in the same deferred callback as
+        // throttle acquisition (see AbstractThrottleManager), so it can
+        // still be false for a moment after getThrottleInfo() is populated.
         JUnitUtil.waitFor(() -> throttleFoundResult, "throttle found callback didn't arrive");
 
         assertTrue(throttleFoundResult);

--- a/java/test/jmri/server/json/throttle/JsonThrottleSocketServiceTest.java
+++ b/java/test/jmri/server/json/throttle/JsonThrottleSocketServiceTest.java
@@ -69,11 +69,8 @@ public class JsonThrottleSocketServiceTest {
         // get the throttle
         data.put(JSON.NAME, "42").put(JSON.ADDRESS, 42);
         service.onMessage(JsonThrottle.THROTTLE, data, new JsonRequest(locale, JSON.V5, JSON.POST, 42));
-        // FIELD REPORT (Andrew Deak): AbstractThrottleManager.notifyThrottleKnown()
-        // now defers notifyThrottleFound() via SwingUtilities.invokeLater() (fixes
-        // a real StackOverflow from synchronous re-entrant requestThrottle()
-        // calls -- see its field comment), so the throttle-found status message
-        // is no longer sent synchronously within onMessage() itself.
+        // Throttle acquisition is deferred (see AbstractThrottleManager), so
+        // the status message isn't sent synchronously within onMessage().
         JUnitUtil.waitFor(() -> !connection.getMessages().isEmpty(), "wait for throttle status message");
         assertEquals( 1, manager.getThrottles().size(), "One throttle");
         JsonNode message = connection.getMessage();
@@ -181,11 +178,8 @@ public class JsonThrottleSocketServiceTest {
         data.put(JSON.NAME, "42").put(JsonRoster.ROSTER_ENTRY, 42);
         service.onMessage(JsonThrottle.THROTTLE, data, new JsonRequest(locale, JSON.V5, JSON.POST, 42));
         assertEquals( 1, manager.getThrottles().size(), "One throttle");
-        // FIELD REPORT (Andrew Deak): AbstractThrottleManager.notifyThrottleKnown()
-        // now defers notifyThrottleFound() via SwingUtilities.invokeLater() (see
-        // its field comment -- fixes a real StackOverflow from synchronous
-        // re-entrant requestThrottle() calls), so this is no longer available
-        // synchronously right after onMessage() returns.
+        // Throttle acquisition is deferred (see AbstractThrottleManager),
+        // so not available synchronously right after onMessage() returns.
         JUnitUtil.waitFor(() -> manager.get(new DccLocoAddress(3, false)).getThrottle() != null, "wait for throttle found");
         Throttle throttle = manager.get(new DccLocoAddress(3, false)).getThrottle();
         throttle.setFunctionMomentary( 0, !re.getFunctionLockable(0));
@@ -274,11 +268,8 @@ public class JsonThrottleSocketServiceTest {
         // get the throttle by JsonThrottle.THROTTLE produces WARN client1
         service1.onMessage(JsonThrottle.THROTTLE, data1.put(JSON.ADDRESS, 3), new JsonRequest(locale, JSON.V5, JSON.POST, 42));
         JUnitAppender.assertWarnMessage("JSON throttle \"client1\" requested using \"throttle\" instead of \"name\"");
-        // FIELD REPORT (Andrew Deak): AbstractThrottleManager.notifyThrottleKnown()
-        // now defers notifyThrottleFound() via SwingUtilities.invokeLater() (see
-        // its field comment -- fixes a real StackOverflow from synchronous
-        // re-entrant requestThrottle() calls), so the throttle status message is
-        // no longer sent synchronously within onMessage() itself.
+        // Throttle acquisition is deferred (see AbstractThrottleManager), so
+        // the status message isn't sent synchronously within onMessage().
         JUnitUtil.waitFor(() -> !connection1.getMessages().isEmpty(), "wait for throttle status message");
         JsonNode message1 = connection1.getMessage();
         assertNotNull(message1);
@@ -393,11 +384,8 @@ public class JsonThrottleSocketServiceTest {
         service.onMessage(JsonThrottle.THROTTLE, data, new JsonRequest(locale, JSON.V5, JSON.POST, 0));
         assertEquals(1, manager.getThrottles().size(), "One throttle acquired");
 
-        // FIELD REPORT (Andrew Deak): AbstractThrottleManager.notifyThrottleKnown()
-        // now defers notifyThrottleFound() via SwingUtilities.invokeLater() (see
-        // its field comment -- fixes a real StackOverflow from synchronous
-        // re-entrant requestThrottle() calls), so the throttle status message is
-        // no longer sent synchronously within onMessage() itself.
+        // Throttle acquisition is deferred (see AbstractThrottleManager), so
+        // the status message isn't sent synchronously within onMessage().
         JUnitUtil.waitFor(() -> !connection.getMessages().isEmpty(), "wait for throttle status message");
         JsonNode message = connection.getMessage();
         assertNotNull(message);

--- a/java/test/jmri/server/json/throttle/JsonThrottleSocketServiceTest.java
+++ b/java/test/jmri/server/json/throttle/JsonThrottleSocketServiceTest.java
@@ -69,6 +69,12 @@ public class JsonThrottleSocketServiceTest {
         // get the throttle
         data.put(JSON.NAME, "42").put(JSON.ADDRESS, 42);
         service.onMessage(JsonThrottle.THROTTLE, data, new JsonRequest(locale, JSON.V5, JSON.POST, 42));
+        // FIELD REPORT (Andrew Deak): AbstractThrottleManager.notifyThrottleKnown()
+        // now defers notifyThrottleFound() via SwingUtilities.invokeLater() (fixes
+        // a real StackOverflow from synchronous re-entrant requestThrottle()
+        // calls -- see its field comment), so the throttle-found status message
+        // is no longer sent synchronously within onMessage() itself.
+        JUnitUtil.waitFor(() -> !connection.getMessages().isEmpty(), "wait for throttle status message");
         assertEquals( 1, manager.getThrottles().size(), "One throttle");
         JsonNode message = connection.getMessage();
         assertNotNull(message);
@@ -175,11 +181,21 @@ public class JsonThrottleSocketServiceTest {
         data.put(JSON.NAME, "42").put(JsonRoster.ROSTER_ENTRY, 42);
         service.onMessage(JsonThrottle.THROTTLE, data, new JsonRequest(locale, JSON.V5, JSON.POST, 42));
         assertEquals( 1, manager.getThrottles().size(), "One throttle");
+        // FIELD REPORT (Andrew Deak): AbstractThrottleManager.notifyThrottleKnown()
+        // now defers notifyThrottleFound() via SwingUtilities.invokeLater() (see
+        // its field comment -- fixes a real StackOverflow from synchronous
+        // re-entrant requestThrottle() calls), so this is no longer available
+        // synchronously right after onMessage() returns.
+        JUnitUtil.waitFor(() -> manager.get(new DccLocoAddress(3, false)).getThrottle() != null, "wait for throttle found");
         Throttle throttle = manager.get(new DccLocoAddress(3, false)).getThrottle();
         throttle.setFunctionMomentary( 0, !re.getFunctionLockable(0));
         throttle.setFunctionMomentary( 1, !re.getFunctionLockable(1));
         assertFalse( throttle.getFunctionMomentary(0), "F0 is not momentary");
         assertTrue( throttle.getFunctionMomentary(1), "F1 is momentary");
+        // the throttle-found status message itself may still be in flight even
+        // though the throttle object above is already set (see field report) --
+        // wait for it to actually arrive rather than assuming it's already queued.
+        JUnitUtil.waitFor(() -> !connection.getMessages().isEmpty(), "wait for throttle status message");
         JsonNode message = connection.getMessage();
         assertNotNull(message);
         assertEquals( 3, message.path(JSON.DATA).path(JSON.ADDRESS).asInt(), "Address");
@@ -258,6 +274,12 @@ public class JsonThrottleSocketServiceTest {
         // get the throttle by JsonThrottle.THROTTLE produces WARN client1
         service1.onMessage(JsonThrottle.THROTTLE, data1.put(JSON.ADDRESS, 3), new JsonRequest(locale, JSON.V5, JSON.POST, 42));
         JUnitAppender.assertWarnMessage("JSON throttle \"client1\" requested using \"throttle\" instead of \"name\"");
+        // FIELD REPORT (Andrew Deak): AbstractThrottleManager.notifyThrottleKnown()
+        // now defers notifyThrottleFound() via SwingUtilities.invokeLater() (see
+        // its field comment -- fixes a real StackOverflow from synchronous
+        // re-entrant requestThrottle() calls), so the throttle status message is
+        // no longer sent synchronously within onMessage() itself.
+        JUnitUtil.waitFor(() -> !connection1.getMessages().isEmpty(), "wait for throttle status message");
         JsonNode message1 = connection1.getMessage();
         assertNotNull(message1);
         assertEquals( 1, message1.path(JSON.DATA).path(JsonThrottle.CLIENTS).asInt(), "One client");
@@ -371,6 +393,12 @@ public class JsonThrottleSocketServiceTest {
         service.onMessage(JsonThrottle.THROTTLE, data, new JsonRequest(locale, JSON.V5, JSON.POST, 0));
         assertEquals(1, manager.getThrottles().size(), "One throttle acquired");
 
+        // FIELD REPORT (Andrew Deak): AbstractThrottleManager.notifyThrottleKnown()
+        // now defers notifyThrottleFound() via SwingUtilities.invokeLater() (see
+        // its field comment -- fixes a real StackOverflow from synchronous
+        // re-entrant requestThrottle() calls), so the throttle status message is
+        // no longer sent synchronously within onMessage() itself.
+        JUnitUtil.waitFor(() -> !connection.getMessages().isEmpty(), "wait for throttle status message");
         JsonNode message = connection.getMessage();
         assertNotNull(message);
         assertEquals(42, message.path(JSON.DATA).path(JSON.ADDRESS).asInt(), "Address");

--- a/java/test/jmri/server/json/throttle/JsonThrottleTest.java
+++ b/java/test/jmri/server/json/throttle/JsonThrottleTest.java
@@ -84,6 +84,12 @@ public class JsonThrottleTest {
         JsonNode data = connection.getObjectMapper().createObjectNode().put(JSON.ADDRESS, 1234);
         JsonThrottle jsonThrottle = JsonThrottle.getThrottle("42", data, service, 42);
         assertNotNull( jsonThrottle, "JsonThrottle exists");
+        // FIELD REPORT (Andrew Deak): AbstractThrottleManager.notifyThrottleKnown()
+        // now defers notifyThrottleFound() via SwingUtilities.invokeLater() (fixes
+        // a real StackOverflow from synchronous re-entrant requestThrottle()
+        // calls -- see its field comment), so this is no longer available
+        // synchronously right after getThrottle() returns.
+        JUnitUtil.waitFor(() -> jsonThrottle.getThrottle() != null, "wait for throttle found");
         Throttle throttle = jsonThrottle.getThrottle();
         assertNotNull( throttle, "has Throttle");
 

--- a/java/test/jmri/server/json/throttle/JsonThrottleTest.java
+++ b/java/test/jmri/server/json/throttle/JsonThrottleTest.java
@@ -84,11 +84,8 @@ public class JsonThrottleTest {
         JsonNode data = connection.getObjectMapper().createObjectNode().put(JSON.ADDRESS, 1234);
         JsonThrottle jsonThrottle = JsonThrottle.getThrottle("42", data, service, 42);
         assertNotNull( jsonThrottle, "JsonThrottle exists");
-        // FIELD REPORT (Andrew Deak): AbstractThrottleManager.notifyThrottleKnown()
-        // now defers notifyThrottleFound() via SwingUtilities.invokeLater() (fixes
-        // a real StackOverflow from synchronous re-entrant requestThrottle()
-        // calls -- see its field comment), so this is no longer available
-        // synchronously right after getThrottle() returns.
+        // Throttle acquisition is deferred (see AbstractThrottleManager),
+        // so not available synchronously right after getThrottle() returns.
         JUnitUtil.waitFor(() -> jsonThrottle.getThrottle() != null, "wait for throttle found");
         Throttle throttle = jsonThrottle.getThrottle();
         assertNotNull( throttle, "has Throttle");


### PR DESCRIPTION
Summary
This PR fixes several bugs in JMRI's consist and throttle handling (affecting LocoNet, EasyDCC, and XNet systems), hardens the JSON server against crashes and invalid input, and adds a new JSON endpoint for reporting live LocoNet slot usage. These fixes were found and verified through extended real-hardware testing of a WiFi-based consist control panel (ESP32 + JMRI JSON API over WebSocket) driving LocoNet consists on a DCS52-equipped layout.

Changes
Consist management (LocoNet / EasyDCC / XNet)

LocoNetConsist, LocoNetConsistManager, LnThrottleManager: fix consist state handling bugs surfaced by rapid add/remove/delete cycles from an external JSON client.
EasyDccConsist, XNetConsist: apply the equivalent consist-handling fixes for parity across consist-capable systems.
Throttle manager

AbstractThrottleManager: fix a race where notifyThrottleFound() could fire before setRosterEntry() had been applied, causing listeners to observe a throttle with no roster entry attached. setRosterEntry() now runs before the notification, inside the same synchronized block.
AbstractMRTrafficController: related traffic-controller-level fix supporting the above.
JSON server hardening

JsonServlet: guard against a NullPointerException when a DELETE/POST/PUT request arrives with no Content-Type header, previously an unconditional crash.
JsonConsistHttpService: fix consist HTTP service bug affecting long/short address handling.
JsonThrottle, JsonThrottleManager: synchronize all shared-state accessors (getThrottles(), put(), get(), remove(), containsKey(), getServers()) to fix a concurrency bug where simultaneous JSON client connections could corrupt throttle bookkeeping; getThrottles() now returns a defensive copy.
New feature: LocoNet slot usage JSON endpoint

Adds json/loconetSlotUsage — a new read-only JSON service reporting live LocoNet slot usage (used, total, free) for both HTTP and WebSocket JSON clients.
New files: JsonLoconetSlotUsage, JsonLoconetSlotUsageHttpService, JsonLoconetSlotUsageSocketService, JsonLoconetSlotUsageServiceFactory, Bundle, plus JSON schemas (loconetSlotUsage-client.json, loconetSlotUsage-server.json).
JsonLoconetSlotUsageHttpService.doSchema() correctly validates the requested type against LOCONET_SLOT_USAGE and throws JsonException for anything else, rather than silently returning the wrong schema.
Motivation
These bugs were found while developing and field-testing a WiFi consist-control panel that drives JMRI purely through its JSON API. Under real usage — building/breaking consists repeatedly, multiple panels/clients connected at once, long sessions — they produced intermittent false failures, stuck/orphaned LocoNet slots, and one reproducible NPE crash in the JSON servlet. The slot usage endpoint was added because there was previously no way for an external JSON client to see LocoNet slot exhaustion coming; without it, clients only discover the problem when a consist operation fails.

Testing
Verified live against real LocoNet hardware (DCS52 command station) using a WiFi ESP32 panel exercising the JSON API over both WebSocket and REST.
Reproduced each original bug on unpatched JMRI, applied the fix, confirmed resolution via serial/API-level logging.
Confirmed the new loconetSlotUsage endpoint reports accurate free/used/total counts before and after building/releasing consists.
Confirmed JSON servlet no longer throws on requests without a Content-Type header.
