### PR TITLE
Add ESP32Node CMRI serial node type, and enable auto-reconnect for CMRI/NCE network connections

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -33,6 +33,12 @@
         <h4>C/MRI</h4>
             <ul>
                 <li>Extend the possible reply length to support very large SUSIC installs.</li>
+                <li>Added a new node type, <strong>ESP32Node</strong>, for self-contained
+                    ESP32-based CMRI-over-WiFi nodes using MCP23017 I/O expander chips.</li>
+                <li>Network (TCP) connections now automatically attempt to reconnect if the
+                    connection is lost, instead of requiring a manual reconnect.</li>
+                <li>Fixed the direction the bit pattern moves in the CMRI diagnostic Output
+                    Test window, which was displaying right to left instead of left to right.</li>
             </ul>
 
         <h4>DCC++ and DCC-EX</h4>
@@ -137,7 +143,8 @@
 
         <h4>NCE</h4>
             <ul>
-                <li></li>
+                <li>Network (TCP) connections now automatically attempt to reconnect if the
+                    connection is lost, instead of requiring a manual reconnect.</li>
             </ul>
 
         <h4>Oak Tree</h4>

--- a/java/src/jmri/jmrix/cmri/serial/SerialNode.java
+++ b/java/src/jmri/jmrix/cmri/serial/SerialNode.java
@@ -60,10 +60,13 @@ public class SerialNode extends AbstractNode {
     public static final int ESP32NODE = 5;      // ESP32Node: self-contained ESP32 CMRI-over-WiFi node,
                                                  // 8 MCP23017 I2C expanders (0x20-0x27), 16 bytes of
                                                  // output/input, no onboard I/O of its own -- unlike
-                                                 // CPNODE/CPMEGA, so its cards are numbered starting at
-                                                 // 0 with no reserved onboard byte offset. See DiagnosticFrame
-                                                 // and NodeConfigManagerFrame for where CPNODE's onboard
-                                                 // offset lives; ESP32NODE deliberately does not use it.
+                                                 // CPNODE/CPMEGA, its cardTypeLocation[] array has no
+                                                 // reserved onboard-byte slots (index 0 IS the first real
+                                                 // card), but user-facing "Card N" numbers displayed in
+                                                 // DiagnosticFrame/NodeConfigManagerFrame are still 1-based
+                                                 // (Card 1 = 0x20/A) via a small +1 display offset there,
+                                                 // matching how people naturally count cards -- a smaller,
+                                                 // separate offset from CPNODE's +2 (2 onboard output bytes).
 
     public static final int NDP_USICSUSIC24 = 78; // 'N' USIC/SUSIC 24 bit cards
     public static final int NDP_USICSUSIC32 = 88; // 'X' USIC/SUSIC 32 bit cards

--- a/java/src/jmri/jmrix/cmri/serial/SerialNode.java
+++ b/java/src/jmri/jmrix/cmri/serial/SerialNode.java
@@ -57,12 +57,20 @@ public class SerialNode extends AbstractNode {
     public static final int USIC_SUSIC = 2;     // USIC/SUSIC node type
     public static final int CPNODE = 3;         // cpNode Control Point (Arduino) node type  c2
     public static final int CPMEGA = 4;         // Open Source Node (OSN)  e.g Mega2560 R3 c2
+    public static final int ESP32NODE = 5;      // ESP32Node: self-contained ESP32 CMRI-over-WiFi node,
+                                                 // 8 MCP23017 I2C expanders (0x20-0x27), 16 bytes of
+                                                 // output/input, no onboard I/O of its own -- unlike
+                                                 // CPNODE/CPMEGA, so its cards are numbered starting at
+                                                 // 0 with no reserved onboard byte offset. See DiagnosticFrame
+                                                 // and NodeConfigManagerFrame for where CPNODE's onboard
+                                                 // offset lives; ESP32NODE deliberately does not use it.
 
     public static final int NDP_USICSUSIC24 = 78; // 'N' USIC/SUSIC 24 bit cards
     public static final int NDP_USICSUSIC32 = 88; // 'X' USIC/SUSIC 32 bit cards
     public static final int NDP_SMINI       = 77; // 'M' SMINI      24 bit cards
     public static final int NDP_CPNODE      = 67; // 'C' CPNODE      8 bit cards
     public static final int NDP_CPMEGA      = 79; // 'O' CPMEGA      8 bit cards
+    public static final int NDP_ESP32NODE   = 69; // 'E' ESP32Node   8 bit cards
 
     public static final byte INPUT_CARD = 1;    // USIC/SUSIC input card type for specifying location
     public static final byte OUTPUT_CARD = 2;   // USIC/SUSIC output card type for specifying location
@@ -315,6 +323,10 @@ public class SerialNode extends AbstractNode {
           case CPMEGA:    if(result<1)  //c2
                             warn("CPMEGA node with "+result+" INPUT cards");
           break;
+          case ESP32NODE: // no minimum -- all 16 ports default to OUTPUT and can be
+                           // reconfigured to INPUT (or NOT CONNECTED) individually,
+                           // unlike CPNODE/CPMEGA which always have fixed onboard bytes
+          break;
           default:
           break;
         }
@@ -361,6 +373,10 @@ public class SerialNode extends AbstractNode {
            case CPMEGA:     //c2
            if(result<1)
              warn("CPMEGA node with "+result+" OUTPUT cards");
+           break;
+           case ESP32NODE:
+           if(result<1)
+             warn("ESP32Node with "+result+" OUTPUT cards");
            break;
            default:
          }
@@ -458,6 +474,33 @@ public class SerialNode extends AbstractNode {
             cardTypeLocation[6] = NO_CARD;
             cardTypeLocation[7] = NO_CARD;
             for (int i=8;i<MAXCARDLOCATIONBYTES;i++)
+            {
+             cardTypeLocation[i] = NO_CARD;
+            }
+          break;
+
+          case ESP32NODE:
+            nodeType = type;
+            bitsPerCard = 8;
+
+            // ESP32Node has NO onboard I/O of its own (unlike CPNODE's 2 input +
+            // 2 output onboard bytes, or CPMEGA's 1 onboard input byte) -- it is a
+            // self-contained ESP32 board whose only I/O comes from up to 8 external
+            // MCP23017 I2C expanders at addresses 0x20-0x27, 2 bytes (ports A/B)
+            // each = 16 real cards. All 16 default to OUTPUT here (matching the
+            // firmware's own default of every IOX port starting as OUTPUT); the
+            // node-config UI lets the user change individual cards to INPUT or
+            // NOT CONNECTED afterward, same as CPNODE/CPMEGA's IOX expansion cards.
+            // Because there's no reserved onboard offset, card 0 in this array IS
+            // the first real card (chip at 0x20, port A) -- no "+2"-style skip is
+            // needed anywhere this type is handled (see DiagnosticFrame,
+            // NodeConfigManagerFrame, which special-case CPNODE's onboard offset
+            // and must NOT apply it to ESP32NODE).
+            for (int i=0;i<16;i++)
+            {
+             cardTypeLocation[i] = OUTPUT_CARD;
+            }
+            for (int i=16;i<MAXCARDLOCATIONBYTES;i++)
             {
              cardTypeLocation[i] = NO_CARD;
             }
@@ -955,6 +998,8 @@ public class SerialNode extends AbstractNode {
             break;
             case CPMEGA:      initBytes[0] = NDP_CPMEGA;  // 'O'   c2
             break;
+            case ESP32NODE:   initBytes[0] = NDP_ESP32NODE;  // 'E'
+            break;
 
             default:
         }
@@ -1094,6 +1139,48 @@ public class SerialNode extends AbstractNode {
          *  <NDP><dH><dL><cpOPTS1><cpOPTS2><cpNI><cpNO> <rfe 8>
          */
            case CPMEGA:
+                          nInitBytes = 3;
+                           // -------------------------
+                           // Pack the two option bytes
+                           // -------------------------
+                           for (int i=0,j=0;i<2;i++,j+=8)
+                           {
+                              code = cpnodeOptions[j];
+                              code = code + (cpnodeOptions[j+1]*2);
+                              code = code + (cpnodeOptions[j+2]*4);
+                              code = code + (cpnodeOptions[j+3]*8);
+                              code = code + (cpnodeOptions[j+4]*16);
+                              code = code + (cpnodeOptions[j+5]*32);
+                              code = code + (cpnodeOptions[j+6]*64);
+                              code = code + (cpnodeOptions[j+7]*128);
+                              initBytes[nInitBytes] = (byte)code;
+                              nInitBytes++;
+                           }
+                           // -------------------------------------
+                           // Configured input and output byte count
+                           // -------------------------------------
+                           initBytes[nInitBytes++] = (byte)numInputCards();
+                           initBytes[nInitBytes++] = (byte)numOutputCards();
+
+                           // --------------------------
+                           // future to be defined bytes
+                           // --------------------------
+                           for (int i=nInitBytes; i<INITMSGLEN+1; i++)
+                           {
+                            initBytes[i] = (byte)0xFF;
+                            nInitBytes++;
+                           }
+
+            break;
+
+         /* ESP32Node specific part of initialization byte array -- same layout as
+          * CPNODE/CPMEGA (options bytes + I/O counts); ESP32Node just has no
+          * onboard-reserved cards, so numInputCards()/numOutputCards() report
+          * purely user-configured MCP23017 ports.
+          *    0   1   2    3        4        5     6     7 - 12
+          *  <NDP><dH><dL><cpOPTS1><cpOPTS2><cpNI><cpNO> <rfe 8>
+          */
+           case ESP32NODE:
                           nInitBytes = 3;
                            // -------------------------
                            // Pack the two option bytes

--- a/java/src/jmri/jmrix/cmri/serial/assignment/ListFrame.java
+++ b/java/src/jmri/jmrix/cmri/serial/assignment/ListFrame.java
@@ -287,6 +287,15 @@ public class ListFrame extends jmri.util.JmriJFrame {
                 nodeInfoText.setText("CPMEGA - " + bitsPerCard + " " + Bundle.getMessage("BitsPerCard")
                         + ", " + numInputBits + " " + Bundle.getMessage("InputBitsAnd") + " "
                         + numOutputBits + " " + Bundle.getMessage("OutputBits"));
+            } else if (type == SerialNode.ESP32NODE) {
+                int bitsPerCard = selNode.getNumBitsPerCard();
+                int numInputCards = selNode.numInputCards();
+                int numOutputCards = selNode.numOutputCards();
+                numInputBits = bitsPerCard * numInputCards;
+                numOutputBits = bitsPerCard * numOutputCards;
+                nodeInfoText.setText("ESP32Node - " + bitsPerCard + " " + Bundle.getMessage("BitsPerCard")
+                        + ", " + numInputBits + " " + Bundle.getMessage("InputBitsAnd") + " "
+                        + numOutputBits + " " + Bundle.getMessage("OutputBits"));
             }
 
 // here insert code for new types of C/MRI nodes

--- a/java/src/jmri/jmrix/cmri/serial/cmrinetmanager/CMRInetManagerFrame.java
+++ b/java/src/jmri/jmrix/cmri/serial/cmrinetmanager/CMRInetManagerFrame.java
@@ -405,7 +405,7 @@ public class CMRInetManagerFrame extends jmri.util.JmriJFrame {
     }
     
     private String[] pollListColumnsNames = {"Poll Seq", "Enabled", "Node", "Type", "Status", "Description"};
-    private String[] nodeTypes = {"--", "SMINI", "SUSIC", "CPNODE", "PiNODE"};
+    private String[] nodeTypes = {"--", "SMINI", "SUSIC", "CPNODE", "CPMEGA", "ESP32Node"};
     private String[] pollStatus = {"ERROR", "IDLE", "POLLING", "TIMEOUT", "INIT"};
     
     private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(CMRInetManagerFrame.class);

--- a/java/src/jmri/jmrix/cmri/serial/diagnostic/DiagnosticFrame.java
+++ b/java/src/jmri/jmrix/cmri/serial/diagnostic/DiagnosticFrame.java
@@ -728,12 +728,19 @@ public class DiagnosticFrame extends jmri.util.JmriJFrame implements jmri.jmrix.
             statusText1.setVisible(true);
             return (false);
         }
-        // ESP32Node has no onboard-reserved cards, but its cards are still
-        // numbered 1-based (Card 1 = 0x20/A) to match how people naturally
-        // count cards -- so like CPNODE's +2, everywhere ESP32Node looks up
-        // a raw cardTypeLocation array index it adds 1 to the user-typed
-        // card number, just a smaller offset since there's no onboard I/O.
-        if (isESP32NODE && (!testNode.isOutputCard(outCardNum+1))) {
+        // ESP32Node's typed Out Card field is 1-based (Card 1 = the first real
+        // card, 0x20/A) to match its on-screen "Card N" label -- unlike
+        // CPNODE's field above, which is 0-based internally even though its
+        // label shows +2. So the typed number converts to a raw
+        // cardTypeLocation index via -1, not +2 or +1. Card 1 typed -> raw
+        // index 0. Guard against 0 or negative input first (raw index -1
+        // would be an ArrayIndexOutOfBoundsException, not just "not a card").
+        if (isESP32NODE && (outCardNum < 1)) {
+            statusText1.setText(Bundle.getMessage("DiagnosticError6"));
+            statusText1.setVisible(true);
+            return (false);
+        }
+        if (isESP32NODE && (!testNode.isOutputCard(outCardNum-1))) {
             statusText1.setText(Bundle.getMessage("DiagnosticError6"));
             statusText1.setVisible(true);
             return (false);
@@ -794,7 +801,7 @@ public class DiagnosticFrame extends jmri.util.JmriJFrame implements jmri.jmrix.
         if (testNodeType == SerialNode.CPNODE)
          begOutByte = (testNode.getOutputCardIndex(outCardNum+2)) * portsPerCard;
         else if (testNodeType == SerialNode.ESP32NODE)
-         begOutByte = (testNode.getOutputCardIndex(outCardNum+1)) * portsPerCard;
+         begOutByte = (testNode.getOutputCardIndex(outCardNum-1)) * portsPerCard;
         else
          begOutByte = (testNode.getOutputCardIndex(outCardNum)) * portsPerCard;
 
@@ -1293,11 +1300,11 @@ public class DiagnosticFrame extends jmri.util.JmriJFrame implements jmri.jmrix.
         }
         else if (testNodeType == SerialNode.ESP32NODE)
         {
-            if (!testNode.isOutputCard(outCardNum+1)) {
+            if ((outCardNum < 1) || (!testNode.isOutputCard(outCardNum-1))) {
              statusText1.setText(Bundle.getMessage("DiagnosticError6"));
              return;
             }
-            begOutByte = (testNode.getOutputCardIndex(outCardNum+1)) * portsPerCard;
+            begOutByte = (testNode.getOutputCardIndex(outCardNum-1)) * portsPerCard;
         }
         else
         {

--- a/java/src/jmri/jmrix/cmri/serial/diagnostic/DiagnosticFrame.java
+++ b/java/src/jmri/jmrix/cmri/serial/diagnostic/DiagnosticFrame.java
@@ -932,7 +932,18 @@ public class DiagnosticFrame extends jmri.util.JmriJFrame implements jmri.jmrix.
                             }
                         }
                     }
-                    statusText2.setText(st.reverse().toString()); //statusText2
+                    // Was st.reverse().toString() -- that reversed the WHOLE
+                    // string char-by-char, which flipped bit order within
+                    // each byte to MSB-left/LSB-right AND (for multi-byte
+                    // cards) reversed the order the byte-groups themselves
+                    // appeared in. As curOutBit climbed 0->7, the "1" in the
+                    // reversed string moved right-to-left, not left-to-right.
+                    // Dropping the reversal displays the string exactly as
+                    // built above: bit0 leftmost within each byte (ascending,
+                    // matching the convention used elsewhere in this project),
+                    // byte begOutByte's group leftmost for multi-byte cards --
+                    // so the walking-bit test now visibly sweeps left to right.
+                    statusText2.setText(st.toString()); //statusText2
                     statusText2.setVisible(true);
                     // update bit pattern for next entry
                     curOutBit++;

--- a/java/src/jmri/jmrix/cmri/serial/diagnostic/DiagnosticFrame.java
+++ b/java/src/jmri/jmrix/cmri/serial/diagnostic/DiagnosticFrame.java
@@ -706,9 +706,7 @@ public class DiagnosticFrame extends jmri.util.JmriJFrame implements jmri.jmrix.
             return (false);
         }
         // Check for consistency with Node definition
-        // ESP32Node has no onboard-reserved cards (unlike CPNODE below), so it
-        // takes the same un-offset, direct-index validation path as USIC_SUSIC.
-        if (isUSIC_SUSIC || isESP32NODE) {
+        if (isUSIC_SUSIC) {
             if ((outCardNum < 0) || (outCardNum >= numCards)) {
                 statusText1.setText(Bundle.getMessage("DiagnosticError5", Integer.toString(numCards - 1)));
                 statusText1.setVisible(true);
@@ -726,6 +724,16 @@ public class DiagnosticFrame extends jmri.util.JmriJFrame implements jmri.jmrix.
             return (false);
         }
         if (isCPNODE && (!testNode.isOutputCard(outCardNum+2))) {
+            statusText1.setText(Bundle.getMessage("DiagnosticError6"));
+            statusText1.setVisible(true);
+            return (false);
+        }
+        // ESP32Node has no onboard-reserved cards, but its cards are still
+        // numbered 1-based (Card 1 = 0x20/A) to match how people naturally
+        // count cards -- so like CPNODE's +2, everywhere ESP32Node looks up
+        // a raw cardTypeLocation array index it adds 1 to the user-typed
+        // card number, just a smaller offset since there's no onboard I/O.
+        if (isESP32NODE && (!testNode.isOutputCard(outCardNum+1))) {
             statusText1.setText(Bundle.getMessage("DiagnosticError6"));
             statusText1.setVisible(true);
             return (false);
@@ -783,10 +791,12 @@ public class DiagnosticFrame extends jmri.util.JmriJFrame implements jmri.jmrix.
         // complete initialization of output card
         portsPerCard = (testNode.getNumBitsPerCard()) / 8;
 
-        if (testNodeType != SerialNode.CPNODE)        
-         begOutByte = (testNode.getOutputCardIndex(outCardNum)) * portsPerCard;
+        if (testNodeType == SerialNode.CPNODE)
+         begOutByte = (testNode.getOutputCardIndex(outCardNum+2)) * portsPerCard;
+        else if (testNodeType == SerialNode.ESP32NODE)
+         begOutByte = (testNode.getOutputCardIndex(outCardNum+1)) * portsPerCard;
         else
-         begOutByte = (testNode.getOutputCardIndex(outCardNum+2)) * portsPerCard;        
+         begOutByte = (testNode.getOutputCardIndex(outCardNum)) * portsPerCard;
 
         endOutByte = begOutByte + portsPerCard - 1;
         nOutBytes = numOutputCards * portsPerCard;
@@ -1273,21 +1283,29 @@ public class DiagnosticFrame extends jmri.util.JmriJFrame implements jmri.jmrix.
         }
         outCardNum = Integer.parseInt(writeCardField.getText());        
         
-        if (testNodeType != SerialNode.CPNODE)   
-        {
-            if (!testNode.isOutputCard(outCardNum)) {
-             statusText1.setText(Bundle.getMessage("DiagnosticError6"));
-             return;                          
-            }
-            begOutByte = (testNode.getOutputCardIndex(outCardNum)) * portsPerCard;
-        }
-        else
+        if (testNodeType == SerialNode.CPNODE)
         {
             if (!testNode.isOutputCard(outCardNum+2)) {
              statusText1.setText(Bundle.getMessage("DiagnosticError6"));
-             return;   
+             return;
             }
-            begOutByte = (testNode.getOutputCardIndex(outCardNum+2)) * portsPerCard; 
+            begOutByte = (testNode.getOutputCardIndex(outCardNum+2)) * portsPerCard;
+        }
+        else if (testNodeType == SerialNode.ESP32NODE)
+        {
+            if (!testNode.isOutputCard(outCardNum+1)) {
+             statusText1.setText(Bundle.getMessage("DiagnosticError6"));
+             return;
+            }
+            begOutByte = (testNode.getOutputCardIndex(outCardNum+1)) * portsPerCard;
+        }
+        else
+        {
+            if (!testNode.isOutputCard(outCardNum)) {
+             statusText1.setText(Bundle.getMessage("DiagnosticError6"));
+             return;
+            }
+            begOutByte = (testNode.getOutputCardIndex(outCardNum)) * portsPerCard;
         }
         // Zero the output buffer
         int zero = (invertWriteButton.isSelected()) ? -1:0; 

--- a/java/src/jmri/jmrix/cmri/serial/diagnostic/DiagnosticFrame.java
+++ b/java/src/jmri/jmrix/cmri/serial/diagnostic/DiagnosticFrame.java
@@ -52,6 +52,7 @@ public class DiagnosticFrame extends jmri.util.JmriJFrame implements jmri.jmrix.
     protected boolean isSMINI = false;
     protected boolean isUSIC_SUSIC = true;
     protected boolean isCPNODE = false;
+    protected boolean isESP32NODE = false;
     // Here add other node types
     protected int numOutputCards = 2;
     protected int numInputCards = 1;
@@ -593,6 +594,22 @@ public class DiagnosticFrame extends jmri.util.JmriJFrame implements jmri.jmrix.
                   numIOXOutputCards= 0;
                   nodeText1.setText("CPMEGA - " + bitsPerCard + " " + Bundle.getMessage("BitsPerCard"));
                 break;
+                case SerialNode.ESP32NODE:
+                  // No onboard cards at all (unlike CPNODE's 2+2), so unlike CPNODE's
+                  // "numOutputCards - 2" here, IOX counts equal the raw counts directly.
+                  bitsPerCard = testNode.getNumBitsPerCard();
+                  numInputCards = testNode.numInputCards();
+                  numOutputCards = testNode.numOutputCards();
+                  numIOXInputCards = numInputCards;
+                  numIOXOutputCards= numOutputCards;
+                  if(numInputCards > 1) s1 = "s";
+                  if(numOutputCards > 1) s2 = "s";
+                  nodeText1.setText("  ESP32Node - " + bitsPerCard + " " +Bundle.getMessage("BitsPerCard"));
+                  nodeText2.setText(numInputCards + " " + Bundle.getMessage("InputCard") + s1 +
+                                    ", " + numOutputCards + " " + Bundle.getMessage("OutputCard") + s2 +
+                                    "  IOX: " + numIOXInputCards + " " + Bundle.getMessage("InputsTitle") +
+                                    ", " + numIOXOutputCards + " " + Bundle.getMessage("OutputsTitle"));
+                break;
                 default:
                   nodeText1.setText("Unknown Node Type "+testNodeType);
                 break;            
@@ -673,6 +690,7 @@ public class DiagnosticFrame extends jmri.util.JmriJFrame implements jmri.jmrix.
         isSMINI = (type == SerialNode.SMINI);
         isUSIC_SUSIC = (type == SerialNode.USIC_SUSIC);
         isCPNODE = (type == SerialNode.CPNODE);
+        isESP32NODE = (type == SerialNode.ESP32NODE);
         // Here insert code for other type nodes
         // initialize numInputCards, numOutputCards, and numCards
         numOutputCards = testNode.numOutputCards();
@@ -688,7 +706,9 @@ public class DiagnosticFrame extends jmri.util.JmriJFrame implements jmri.jmrix.
             return (false);
         }
         // Check for consistency with Node definition
-        if (isUSIC_SUSIC) {
+        // ESP32Node has no onboard-reserved cards (unlike CPNODE below), so it
+        // takes the same un-offset, direct-index validation path as USIC_SUSIC.
+        if (isUSIC_SUSIC || isESP32NODE) {
             if ((outCardNum < 0) || (outCardNum >= numCards)) {
                 statusText1.setText(Bundle.getMessage("DiagnosticError5", Integer.toString(numCards - 1)));
                 statusText1.setVisible(true);

--- a/java/src/jmri/jmrix/cmri/serial/networkdriver/NetworkDriverAdapter.java
+++ b/java/src/jmri/jmrix/cmri/serial/networkdriver/NetworkDriverAdapter.java
@@ -17,6 +17,19 @@ public class NetworkDriverAdapter extends SerialNetworkPortAdapter {
     public NetworkDriverAdapter() {
         super(new CMRISystemConnectionMemo());
         setManufacturer(jmri.jmrix.cmri.CMRIConnectionTypeList.CMRI);
+        // Auto-reconnect: AbstractPortController already implements a full
+        // reconnect framework (exponential backoff, reconnectMaxAttempts/
+        // reconnectMaxInterval loaded from the saved connection XML) that
+        // AbstractMRTrafficController.receiveLoop() already calls into
+        // automatically whenever the read loop exits abnormally (e.g. this
+        // node's ESP32 rebooting and dropping the TCP connection) -- but that
+        // framework is a no-op unless allowConnectionRecovery is explicitly
+        // turned on, which the CMRI network driver never did. LocoNet-over-TCP
+        // and DCC++ network already enable this the same way; CMRI just never
+        // had this line. See resetupConnection() below for the other half of
+        // the fix -- restarting the traffic controller's threads once
+        // reconnected.
+        allowConnectionRecovery = true;
     }
 
     /**
@@ -31,6 +44,21 @@ public class NetworkDriverAdapter extends SerialNetworkPortAdapter {
         tc.connectPort(this);
 
         getSystemConnectionMemo().configureManagers();
+    }
+
+    /**
+     * Called once a reconnect attempt succeeds (this.connect() returned
+     * without throwing). The traffic controller's transmit/receive threads
+     * were already torn down when the connection was lost (see
+     * AbstractMRTrafficController.recovery()/disconnectPort()), so they need
+     * to be started again against the fresh socket streams -- connectPort()
+     * does both (re-reads getInputStream()/getOutputStream() from this
+     * adapter and spawns new transmit/receive threads), the same call
+     * configure() made for the original connection.
+     */
+    @Override
+    protected void resetupConnection() {
+        getSystemConnectionMemo().getTrafficController().connectPort(this);
     }
 
     // private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(NetworkDriverAdapter.class);

--- a/java/src/jmri/jmrix/cmri/serial/networkdriver/configurexml/ConnectionConfigXml.java
+++ b/java/src/jmri/jmrix/cmri/serial/networkdriver/configurexml/ConnectionConfigXml.java
@@ -144,7 +144,8 @@ public class ConnectionConfigXml extends AbstractNetworkConnectionConfigXml {
             log.debug("Node {} NET Options Written = {}", node.nodeAddress, value);
 
             // cpNode Options  Classic CMRI nodes do not have options
-            if (node.getNodeType() == SerialNode.CPNODE || node.getNodeType() == SerialNode.CPMEGA) {
+            if (node.getNodeType() == SerialNode.CPNODE || node.getNodeType() == SerialNode.CPMEGA
+                    || node.getNodeType() == SerialNode.ESP32NODE) {
                 value = new StringBuilder();
                 for (int i = 0; i < SerialNode.NUMCPNODEOPTS; i++) {
                     value.append(Integer.toHexString((node.getcpnodeOpts(i) & 0xF)));
@@ -286,7 +287,7 @@ public class ConnectionConfigXml extends AbstractNetworkConnectionConfigXml {
                 node.setCardTypeLocation(j, (ctl.charAt(j) - '0'));
             }
 
-            if (type == SerialNode.CPNODE || type == SerialNode.CPMEGA) {
+            if (type == SerialNode.CPNODE || type == SerialNode.CPMEGA || type == SerialNode.ESP32NODE) {
                 // cpNode Options
                 if (findParmValue(n, "cpnodeoptions") != null) {
                     opts = findParmValue(n, "cpnodeoptions");

--- a/java/src/jmri/jmrix/cmri/serial/nodeconfigmanager/NodeConfigManagerFrame.java
+++ b/java/src/jmri/jmrix/cmri/serial/nodeconfigmanager/NodeConfigManagerFrame.java
@@ -762,7 +762,7 @@ public class NodeConfigManagerFrame extends jmri.util.JmriJFrame {
     private String[] nodeTableColumnsNames
             = {"Address", "   Type", "Bits per Card", "IN Cards", "OUT Cards", "IN Bits", "OUT Bits", " ", "  Description"};
 
-    private String[] nodeTableTypes = {"--", "SMINI", "SUSIC", "CPNODE", "CPMEGA"};
+    private String[] nodeTableTypes = {"--", "SMINI", "SUSIC", "CPNODE", "CPMEGA", "ESP32Node"};
 
     /*
      * ----------------------------------------------------------
@@ -821,6 +821,7 @@ public class NodeConfigManagerFrame extends jmri.util.JmriJFrame {
         nodeTypeBox.addItem("USIC_SUSIC");
         nodeTypeBox.addItem("CPNODE");
         nodeTypeBox.addItem("CPMEGA");
+        nodeTypeBox.addItem("ESP32Node");
 
         /*
          * Here add code for other types of nodes
@@ -874,6 +875,7 @@ public class NodeConfigManagerFrame extends jmri.util.JmriJFrame {
                     panelnetOptBox.setVisible(true);
                     panelnodeOpt.setVisible(true);
                     nodeType = SerialNode.CPNODE;
+                    cpNodeOnboard = 4;
                     onBoardBytesText.setText(Bundle.getMessage("LabelOnBoardBytes") + " 2 Bytes");
                 } else if (s.equals("CPMEGA")) {
                     panel2.setVisible(false);
@@ -889,7 +891,24 @@ public class NodeConfigManagerFrame extends jmri.util.JmriJFrame {
                     panelnetOptBox.setVisible(true);
                     panelnodeOpt.setVisible(true);
                     nodeType = SerialNode.CPMEGA;
+                    cpNodeOnboard = 4;
                     onBoardBytesText.setText(Bundle.getMessage("LabelOnBoardBytes") + " 8 Bytes");
+                } else if (s.equals("ESP32Node")) {
+                    panel2.setVisible(false);
+                    panel2a.setVisible(false);
+                    panel2b.setVisible(true);   // IOX-style card grid -- ALL 16 cards, no onboard reservation
+                    panel2c.setVisible(false);  // no separate onboard-byte grid -- ESP32Node has no onboard I/O
+                    cardSizeText.setVisible(true);
+                    cardSizeBox.setVisible(false);
+                    cardSize8Box.setVisible(true);
+                    panelnodeDescBox.setVisible(true);
+                    panelnodeDesc.setVisible(true);
+                    panelnetOpt.setVisible(true);
+                    panelnetOptBox.setVisible(true);
+                    panelnodeOpt.setVisible(true);
+                    nodeType = SerialNode.ESP32NODE;
+                    cpNodeOnboard = 0;
+                    onBoardBytesText.setText(Bundle.getMessage("LabelOnBoardBytes") + " None -- 8 MCP23017 chips (0x20-0x27), 16 bytes");
                 }
                 /*
                  * Here add code for other types of nodes
@@ -1435,6 +1454,22 @@ public class NodeConfigManagerFrame extends jmri.util.JmriJFrame {
                 cbx_cpnodeopt_BIT15.setSelected(curNode.iscpnodeBit(SerialNode.optbitNode_BIT15));
                 break;
 
+            // ESP32Node
+            case SerialNode.ESP32NODE:
+                nodeTypeBox.setSelectedItem("ESP32Node");
+                bitsPerCard = 8;
+                cardSize8Box.setSelectedItem(Bundle.getMessage("CardSize8"));
+                cpNodeOnboard = 0;
+                onBoardBytesText.setText(Bundle.getMessage("LabelOnBoardBytes") + " None -- 8 MCP23017 chips (0x20-0x27), 16 bytes");
+
+                // ESP32Node Options -- same option bits as CPNODE/CPMEGA
+                cbx_cpnodeopt_SENDEOT.setSelected(curNode.iscpnodeBit(SerialNode.optbitNode_SENDEOT));
+                cbx_cpnodeopt_BIT1.setSelected(false);
+                cbx_cpnodeopt_BIT2.setSelected(false);
+                cbx_cpnodeopt_BIT8.setSelected(curNode.iscpnodeBit(SerialNode.optbitNode_BIT8));
+                cbx_cpnodeopt_BIT15.setSelected(curNode.iscpnodeBit(SerialNode.optbitNode_BIT15));
+                break;
+
             default:
                 log.error("Unknown Node Type {}", nodeType);
                 break;
@@ -1496,6 +1531,9 @@ public class NodeConfigManagerFrame extends jmri.util.JmriJFrame {
         } else if (nodeType == SerialNode.CPMEGA) {
             panel2c.setVisible(true);
             panel2b.setVisible(false);
+        } else if (nodeType == SerialNode.ESP32NODE) {
+            panel2c.setVisible(false);
+            panel2b.setVisible(true);
         }
 
     }
@@ -1876,6 +1914,42 @@ public class NodeConfigManagerFrame extends jmri.util.JmriJFrame {
 
                 break;
 
+            // ESP32Node -- no onboard bytes at all (cpNodeOnboard=0, see the
+            // ActionListener above), so every one of the 16 cards comes from
+            // cardType[] with no skip, unlike CPNODE (skips 4) or CPMEGA
+            // (onboard bytes handled separately, IOX skips 8).
+            case SerialNode.ESP32NODE:
+                // set number of bits per card
+                bitsPerCard = 8;
+                curNode.setNumBitsPerCard(bitsPerCard);
+                numInput = 0;
+                numOutput = 0;
+
+                for (int i = 0; i < 64; i++) {
+                    if ("No Card".equals(cardType[i])) {
+                        curNode.setCardTypeByAddress(i, SerialNode.NO_CARD);
+                    } else if ("Input Card".equals(cardType[i])) {
+                        curNode.setCardTypeByAddress(i, SerialNode.INPUT_CARD);
+                        numInput++;
+                    } else if ("Output Card".equals(cardType[i])) {
+                        curNode.setCardTypeByAddress(i, SerialNode.OUTPUT_CARD);
+                        numOutput++;
+                    } else {
+                        log.error("Unexpected card type - {}", cardType[i]);
+                    }
+                }
+
+                // Set the node option bits.  Some are moved from the CMRInet options
+                curNode.setOptNet_AUTOPOLL(1);  // Default node to be polled
+
+                curNode.setOptNode_SENDEOT(cbx_cpnodeopt_SENDEOT.isSelected() ? 1 : 0);
+                curNode.setOptNode_USECMRIX(cbx_cmrinetopt_USECMRIX.isSelected() ? 1 : 0); // Copy from CMRInet
+                curNode.setOptNode_USEBCC(cbx_cmrinetopt_USEBCC.isSelected() ? 1 : 0);     // Copy from CMRInet
+                curNode.setOptNode_BIT8(cbx_cpnodeopt_BIT8.isSelected() ? 1 : 0);
+                curNode.setOptNode_BIT15(cbx_cpnodeopt_BIT15.isSelected() ? 1 : 0);
+
+                break;
+
             default:
                 log.error("Unexpected node type in setNodeParameters- {}", Integer.toString(nodeType));
                 break;
@@ -2145,6 +2219,14 @@ public class NodeConfigManagerFrame extends jmri.util.JmriJFrame {
                     }
                 }
                 break;
+            case SerialNode.ESP32NODE:
+                for (int j = 0; j < 64; j++) {
+                    if ((cardType[j].equals(Bundle.getMessage("CardTypeOutput")))
+                            || (cardType[j].equals(Bundle.getMessage("CardTypeInput")))) {
+                        numCards++;
+                    }
+                }
+                break;
 
             // here add code for other types of nodes
             default:
@@ -2375,9 +2457,14 @@ public class NodeConfigManagerFrame extends jmri.util.JmriJFrame {
         public Object getValueAt(int r, int c) {
             String[] cdPort = {"  A", "  B"};
             String val = "     ";
+            // ESP32Node has no onboard-reserved cards (unlike CPNODE's 2 onboard
+            // OUTPUT bytes, which is why the diagnostic dialog and this label both
+            // add 2 for CPNODE) -- so its Card column starts at 0, matching its
+            // cardTypeLocation array index directly, with no offset at all.
+            int cardLabelOffset = (nodeType == SerialNode.ESP32NODE) ? 0 : 2;
             switch (c) {
                 case CARD_COLUMN:
-                    val = Integer.toString(r+2);
+                    val = Integer.toString(r+cardLabelOffset);
                     return "   " + val;
                 case CARDNUM_COLUMN:
                     int i = r / 2;

--- a/java/src/jmri/jmrix/cmri/serial/nodeconfigmanager/NodeConfigManagerFrame.java
+++ b/java/src/jmri/jmrix/cmri/serial/nodeconfigmanager/NodeConfigManagerFrame.java
@@ -2459,9 +2459,11 @@ public class NodeConfigManagerFrame extends jmri.util.JmriJFrame {
             String val = "     ";
             // ESP32Node has no onboard-reserved cards (unlike CPNODE's 2 onboard
             // OUTPUT bytes, which is why the diagnostic dialog and this label both
-            // add 2 for CPNODE) -- so its Card column starts at 0, matching its
-            // cardTypeLocation array index directly, with no offset at all.
-            int cardLabelOffset = (nodeType == SerialNode.ESP32NODE) ? 0 : 2;
+            // add 2 for CPNODE) -- but it's still numbered 1-based (Card 1 = first
+            // real card) to match how people naturally count cards, hence +1 here
+            // (cpNodeOnboard, the actual array-index skip used below for cardType[],
+            // stays 0 for ESP32Node -- this offset is display-only).
+            int cardLabelOffset = (nodeType == SerialNode.ESP32NODE) ? 1 : 2;
             switch (c) {
                 case CARD_COLUMN:
                     val = Integer.toString(r+cardLabelOffset);

--- a/java/src/jmri/jmrix/cmri/serial/nodeiolist/NodeIOListFrame.java
+++ b/java/src/jmri/jmrix/cmri/serial/nodeiolist/NodeIOListFrame.java
@@ -264,6 +264,11 @@ public class NodeIOListFrame extends jmri.util.JmriJFrame {
                 numOutputBits = bitsPerCard * numOutputCards;
                 nodeType = "CPMEGA - ";
                 break;
+            case SerialNode.ESP32NODE:
+                numInputBits = bitsPerCard * numInputCards;
+                numOutputBits = bitsPerCard * numOutputCards;
+                nodeType = "ESP32Node - ";
+                break;
             default:
                 break;
         }

--- a/java/src/jmri/jmrix/cmri/serial/serialdriver/configurexml/ConnectionConfigXml.java
+++ b/java/src/jmri/jmrix/cmri/serial/serialdriver/configurexml/ConnectionConfigXml.java
@@ -134,7 +134,8 @@ public class ConnectionConfigXml extends AbstractSerialConnectionConfigXml {
             log.debug("Node {} NET Options Written = {}", node.nodeAddress, value);
 
             // cpNode Options  Classic CMRI nodes do not have options
-            if (node.getNodeType() == SerialNode.CPNODE || node.getNodeType() == SerialNode.CPMEGA) {
+            if (node.getNodeType() == SerialNode.CPNODE || node.getNodeType() == SerialNode.CPMEGA
+                    || node.getNodeType() == SerialNode.ESP32NODE) {
                 value = new StringBuilder();
                 for (int i = 0; i < SerialNode.NUMCPNODEOPTS; i++) {
                     value.append(Integer.toHexString((node.getcpnodeOpts(i) & 0xF)));
@@ -287,7 +288,7 @@ public class ConnectionConfigXml extends AbstractSerialConnectionConfigXml {
                 node.setCardTypeLocation(j, (ctl.charAt(j) - '0'));
             }
 
-            if (type == SerialNode.CPNODE || type == SerialNode.CPMEGA) {
+            if (type == SerialNode.CPNODE || type == SerialNode.CPMEGA || type == SerialNode.ESP32NODE) {
                 // cpNode Options
                 if (findParmValue(n, "cpnodeoptions") != null) {
                     opts = findParmValue(n, "cpnodeoptions");

--- a/java/src/jmri/jmrix/cmri/serial/serialmon/SerialMonFrame.java
+++ b/java/src/jmri/jmrix/cmri/serial/serialmon/SerialMonFrame.java
@@ -205,6 +205,7 @@ public class SerialMonFrame extends jmri.jmrix.AbstractMonFrame implements Seria
 
                         case SerialNode.NDP_CPNODE: // CPNODE
                         case SerialNode.NDP_CPMEGA: // CPMEGA
+                        case SerialNode.NDP_ESP32NODE: // ESP32Node -- same init payload layout as CPNODE/CPMEGA
                             if (len>=5)
                             {
                                 sb.append(" DL=");

--- a/java/src/jmri/jmrix/nce/networkdriver/NetworkDriverAdapter.java
+++ b/java/src/jmri/jmrix/nce/networkdriver/NetworkDriverAdapter.java
@@ -22,6 +22,15 @@ public class NetworkDriverAdapter extends NceNetworkPortController {
         // the default is 2006 or later
         options.put(option2Name, new Option("Command Station EPROM", new String[]{"2006 or later", "2004 or earlier"}));
         setManufacturer(jmri.jmrix.nce.NceConnectionTypeList.NCE);
+        // Auto-reconnect: same fix applied to CMRI's network driver -- the
+        // generic reconnect framework in AbstractPortController (exponential
+        // backoff, reconnectMaxAttempts/reconnectMaxInterval loaded from the
+        // saved connection XML) is already triggered automatically by
+        // AbstractMRTrafficController.receiveLoop() whenever the read loop
+        // exits abnormally, but it no-ops unless allowConnectionRecovery is
+        // explicitly turned on -- which NCE's network driver never did.
+        // See resetupConnection() below for the other half of the fix.
+        allowConnectionRecovery = true;
     }
 
     /**
@@ -49,6 +58,19 @@ public class NetworkDriverAdapter extends NceNetworkPortController {
         tc.connectPort(this);
 
         this.getSystemConnectionMemo().configureManagers();
+    }
+
+    /**
+     * Called once a reconnect attempt succeeds. The traffic controller's
+     * transmit/receive threads were torn down when the connection was lost
+     * (AbstractMRTrafficController.recovery() calls disconnectPort() before
+     * attempting reconnection), so they need to be started again against the
+     * fresh socket streams -- connectPort() does both, the same call
+     * configure() made for the original connection.
+     */
+    @Override
+    protected void resetupConnection() {
+        getSystemConnectionMemo().getNceTrafficController().connectPort(this);
     }
 
 }


### PR DESCRIPTION
Description:

## Summary

This PR does two independent things, both arising from building a self-contained ESP32 CMRI-over-WiFi node:

1. Adds a new CMRI serial node type, ESP32Node - a fifth type alongside SMINI, USIC_SUSIC, CPNODE, and CPMEGA.
2. Enables JMRI's existing (but dormant) connection-recovery framework for CMRI and NCE network connections, plus a couple of small, unrelated bugs found along the way.

Happy to split this into separate PRs (node-type addition vs. reconnect fixes vs. the diagnostic display fix) if that's easier to review - let me know.

All commits verified with `ant compile` (JDK 17) - BUILD SUCCESSFUL, no new warnings, at each step.

---

## 1. New ESP32Node node type

Represents a self-contained ESP32 board with 8 MCP23017 I2C expanders at addresses 0x20-0x27 (16 I/O bytes total) and no onboard I/O of its own - unlike CPNODE (2 onboard input + 2 onboard output bytes) or CPMEGA (1 onboard input byte, up to 8 onboard bytes total).

Because CPNODE's onboard bytes push its expansion cards to start at Card 3 (a hardcoded +2 offset scattered across DiagnosticFrame and NodeConfigManagerFrame), ESP32Node needed its own path: its cards are numbered starting at Card 1 directly against cardTypeLocation[], with a +1/-1 offset distinct from CPNODE's +2 (see the second commit below for why this needed a follow-up fix).

Files touched:
- SerialNode.java - type constant, setNodeType(), init packet (reuses CPNODE/CPMEGA's cpnodeOptions payload layout)
- nodeconfigmanager/NodeConfigManagerFrame.java - dropdown entry, reuses the existing CPnodeConfigModel 16-row IOX assignment grid with a parameterized onboard-card offset
- diagnostic/DiagnosticFrame.java - Output Test dialog support
- serialmon/SerialMonFrame.java - traffic monitor decoding for the new init-message type character
- assignment/ListFrame.java, nodeiolist/NodeIOListFrame.java, cmrinetmanager/CMRInetManagerFrame.java - node-type display labels
- Both configurexml/ConnectionConfigXml.java (serial and network drivers) - XML persistence for cpnodeOptions

Also fixed in passing: CMRInetManagerFrame's node-type label array had a pre-existing typo, "PiNODE" where it should say "CPMEGA".

### Follow-up fixes to the above (found via live hardware testing)

- 1-based card numbering - the first version numbered cards 0-based; changed to 1-based (Card 1 = first card) to match how people naturally count.
- Out Card field off-by-two - the Output Test dialog's typed "Out Card" field initially copied CPNODE's internal +2 offset pattern, but CPNODE's field is 0-based while ESP32Node's was meant to be 1-based (matching its label) - so typing "1" was landing on Card 3. Fixed the sign (-1 instead of +1) across all three places that read the typed value, with a bounds check added since -1 on invalid input would otherwise throw ArrayIndexOutOfBoundsException.

---

## 2. Auto-reconnect for CMRI and NCE network (TCP) connections

AbstractPortController already implements a complete reconnect framework - exponential backoff, reconnectMaxAttempts/reconnectMaxInterval already round-tripped through the saved connection XML - and AbstractMRTrafficController.receiveLoop() already calls into it automatically whenever the read loop exits abnormally (e.g. the far end of a TCP connection dropping). But it's a no-op unless allowConnectionRecovery is explicitly turned on, and neither CMRI's nor NCE's network driver ever did that (LocoNet-over-TCP and DCC++ network already do).

Practical effect before this fix: a CMRI or NCE network connection just stays dead after the remote device drops (e.g. an ESP32 CMRI node rebooting), even though reconnectMaxAttempts="100" sits right there in the saved connection XML, unused.

Fix, applied identically to both cmri/serial/networkdriver/NetworkDriverAdapter.java and nce/networkdriver/NetworkDriverAdapter.java:
1. allowConnectionRecovery = true in the constructor, matching the pattern LnTcpDriverAdapter already uses.
2. An overridden resetupConnection() that calls connectPort(this) again once a reconnect succeeds - necessary because the traffic controller's transmit/receive threads are torn down when the connection is lost (AbstractMRTrafficController.recovery() calls disconnectPort() before attempting reconnection), so a live socket alone isn't enough to resume normal operation.

---

## 3. Diagnostic Output Test: status pattern direction

Small, unrelated bug found while testing #1: the printed bit pattern under "Port A, Bit N is ON" in the Output Test dialog was built bit0-leftmost, then reversed (st.reverse()) before display. As the walking-bit test stepped through bits 0->7, the "1" in the displayed pattern moved right to left - and for multi-byte cards, the reversal also flipped the order the per-byte groups appeared in.

Fix: dropped the .reverse() call. The string as originally built already has the correct layout (bit0 leftmost, first byte's group leftmost for multi-byte cards), so the test now visibly sweeps left to right.

---

## Testing

- All changes compiled clean against current master (ant compile, JDK 17).
- ESP32Node card numbering, the Out Card field fix, and the diagnostic pattern direction were verified against real ESP32 hardware running a matching CMRI-over-WiFi firmware (serial log cross-referenced against JMRI's own diagnostic output at each step).
- CMRI/NCE auto-reconnect has not yet been soak-tested against a real dropped connection over an extended period - happy to do more of that before merge if useful.
