### PR TITLE
D&H PD-Series and minor fixes

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -280,7 +280,8 @@
 
         <h4>Doehler &amp; Haas</h4>
             <ul>
-                <li></li>
+                <li>PD series disabled until an update 3.15+ is available</li>
+                <li>Added a "replacement" function for some decoders</li>
             </ul>
 
         <h4>ESU</h4>

--- a/xml/decoders/CT_Elektronik_DCX_new2.xml
+++ b/xml/decoders/CT_Elektronik_DCX_new2.xml
@@ -14,7 +14,7 @@
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" showEmptyPanes="no" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
   <version author="Nigel Cliffe" version="1.9" lastUpdated="2017/6/16"/> 
 
-  <!-- <version author="ronald@wirkuhns.de" version="1.8" lastUpdated="2016/5/12"/> -->
+  <!-- <version author="Ronald Kuhn" version="1.8" lastUpdated="2016/5/12"/> -->
   <!-- <version author="ncliffe@btinternet.com" version="1.7" lastUpdated="2009/9/01"/> -->
   <!-- <version author="ncliffe@btinternet.com" version="1.6" lastUpdated="2009/4/02"/> -->
   <!-- <version author="ncliffe@btinternet.com" version="1.5" lastUpdated="2009/3/12"/> -->

--- a/xml/decoders/Doehler_Haass_fw1.06-07_SD10-16-18-21-22A.xml
+++ b/xml/decoders/Doehler_Haass_fw1.06-07_SD10-16-18-21-22A.xml
@@ -16,12 +16,12 @@
 <!--  Firmware 1.08.027 and 1.09.117 identified by the 1.07 models, which have no definition of their own  -->
 <version version="1.1" author="Pierre Billon" lastUpdated="20210312"/>
 <!--  Added update paths to newest fw 1.12.050 -->
-<version version="1" author="Ronald Kuhn, ronald@wirkuhns.de" lastUpdated="2016-12-14"/>
+<version version="1" author="Ronald Kuhn" lastUpdated="2016-12-14"/>
 <!-- 1 2016/07/10 Creation
     Decoder template for the Doehler & Haass combo sound decoder
     with Firmware v1.06 and 1.07.
 -->
-<version version="1.1" author="Ronald Kuhn, ronald@wirkuhns.de" lastUpdated="2020-04-28"/>
+<version version="1.1" author="Ronald Kuhn" lastUpdated="2020-04-28"/>
 <!--
     small correction for CV153 - wasn't on a pane
 -->

--- a/xml/decoders/Doehler_Haass_fw1.10_SD10-16-18-21-22A.xml
+++ b/xml/decoders/Doehler_Haass_fw1.10_SD10-16-18-21-22A.xml
@@ -14,7 +14,7 @@
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" showEmptyPanes="no" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
 <version version="1.1" author="Pierre Billon" lastUpdated="20210312"/>
 <!--  Added update paths to newest fw 1.12.050 -->
-<version version="1" author="Ronald Kuhn, ronald@wirkuhns.de" lastUpdated="2020-05-02"/>
+<version version="1" author="Ronald Kuhn" lastUpdated="2020-05-02"/>
 <!-- Creation
     Decoder template for the Doehler & Haass combo sound decoder
     with Firmware v1.10

--- a/xml/decoders/Doehler_Haass_fw1.11_SD10-16-18-21-22A.xml
+++ b/xml/decoders/Doehler_Haass_fw1.11_SD10-16-18-21-22A.xml
@@ -16,7 +16,7 @@
 <!--  Firmware 1.11.069 now identified  -->
 <version version="1.1" author="Pierre Billon" lastUpdated="20210312"/>
 <!--  Added update paths to newest fw 1.12.050 -->
-<version version="1" author="Ronald Kuhn, ronald@wirkuhns.de" lastUpdated="2020-05-02"/>
+<version version="1" author="Ronald Kuhn" lastUpdated="2020-05-02"/>
 <!-- Creation
     Decoder template for the Doehler & Haass combo sound decoder
     with Firmware v1.11

--- a/xml/decoders/Doehler_Haass_fw1.12_SD05-10-16-18-21-22A.xml
+++ b/xml/decoders/Doehler_Haass_fw1.12_SD05-10-16-18-21-22A.xml
@@ -12,7 +12,7 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" showEmptyPanes="no" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
-  <version version="1.2" author="Ronald Kuhn, ronald@wirkuhns.de" lastUpdated="20230731"/>
+  <version version="1.2" author="Ronald Kuhn" lastUpdated="20230731"/>
   <!--  Added update paths to newest fw 1.13.112 -->
   <version version="1.1" author="Pierre Billon" lastUpdated="20210312"/>
   <!--  Fixed/added low and high versionIDs (should be 050, not 098 for this firmware

--- a/xml/decoders/Doehler_Haass_fw1.15_SH05-10A.xml
+++ b/xml/decoders/Doehler_Haass_fw1.15_SH05-10A.xml
@@ -14,7 +14,7 @@
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" showEmptyPanes="no" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
   <version version="2" author="Pierre Billon" lastUpdated="20260727"/>
   <!--  Corrected the SH05A and SH10A model comments  -->
-  <version version="1" author="Ronald Kuhn, ronald@wirkuhns.de" lastUpdated="20230720"/>
+  <version version="1" author="Ronald Kuhn" lastUpdated="20230720"/>
   <!--  Creation, based on Doehler_Haass_susi_sd_fw1.14_SH05-10A.xml
         -->
   <decoder>

--- a/xml/decoders/Doehler_Haass_fw3.06-07_DH05-10C_12-16-18-21-22A_PD12A.xml
+++ b/xml/decoders/Doehler_Haass_fw3.06-07_DH05-10C_12-16-18-21-22A_PD12A.xml
@@ -22,7 +22,7 @@
   <!--  Added update paths to newest fw 3.12.050 -->
   <version version="4" author="Alain Le Marchand" lastUpdated="2019-07-28"/>
   <!--  Simplified productID for PD05 and PD12: no more version indicated -->
-    <version version="3" author="Ronald Kuhn, ronald@wirkuhns.de" lastUpdated="2016-12-14"/>
+    <version version="3" author="Ronald Kuhn" lastUpdated="2016-12-14"/>
   <!--  New Firmware 3.06 and 3.07 with new CV's and added translation to german -->
   <version version="2" author="Pierre Billon" lastUpdated="20151018"/>
   <!--  Merged DH05C, DH10C, DH12A, DH16A, DH18A, DH21A, DH22A def files (same CV characteristics) -->

--- a/xml/decoders/Doehler_Haass_fw3.06-07_FH05B-22A.xml
+++ b/xml/decoders/Doehler_Haass_fw3.06-07_FH05B-22A.xml
@@ -18,7 +18,7 @@
         -->
   <version version="3" author="Pierre Billon" lastUpdated="20210308"/>
 <!--  Added update paths to newest fw 3.12.050 -->
-  <version version="2" author="Ronald Kuhn, ronald@wirkuhns.de" lastUpdated="2016-12-14"/>
+  <version version="2" author="Ronald Kuhn" lastUpdated="2016-12-14"/>
   <!--  (new firmware 3.06 and 3.07).
         -->
   <version version="1" author="Pierre Billon" lastUpdated="20150306"/>

--- a/xml/decoders/Doehler_Haass_fw3.08-09_DH05-10C_12-16-18-21-22A_PD05-12A.xml
+++ b/xml/decoders/Doehler_Haass_fw3.08-09_DH05-10C_12-16-18-21-22A_PD05-12A.xml
@@ -26,7 +26,7 @@
   <!--  Add PD05A -->
   <version version="4" author="Alain Le Marchand" lastUpdated="2018-02-04"/>
   <!--  New Firmware 3.08 and 3.09 with new CV65 -->
-  <version version="3" author="Ronald Kuhn, ronald@wirkuhns.de" lastUpdated="2016-12-14"/>
+  <version version="3" author="Ronald Kuhn" lastUpdated="2016-12-14"/>
   <!--  New Firmware 3.06 and 3.07 with new CV's and added translation to german -->
   <version version="2" author="Pierre Billon" lastUpdated="20151018"/>
   <!--  Merged DH05C, DH10C, DH12A, DH16A, DH18A, DH21A, DH22A def files (same CV characteristics) -->

--- a/xml/decoders/Doehler_Haass_fw3.10-11_FH05B-18-22A.xml
+++ b/xml/decoders/Doehler_Haass_fw3.10-11_FH05B-18-22A.xml
@@ -24,10 +24,10 @@
         -->
   <version version="4" author="Pierre Billon" lastUpdated="20210308"/>
   <!--  Added update paths to newest fw 3.12.050 -->
-  <version version="3" author="Ronald Kuhn, ronald@wirkuhns.de" lastUpdated="2020-05-05"/>
+  <version version="3" author="Ronald Kuhn" lastUpdated="2020-05-05"/>
   <!--  (new firmware 3.10 and 3.11 and including of FH18A)
         -->
-  <version version="2" author="Ronald Kuhn, ronald@wirkuhns.de" lastUpdated="2016-12-14"/>
+  <version version="2" author="Ronald Kuhn" lastUpdated="2016-12-14"/>
   <!--  (new firmware 3.06 and 3.07).
         -->
   <version version="1" author="Pierre Billon" lastUpdated="20150306"/>

--- a/xml/decoders/Doehler_Haass_fw3.10_DH05-10C_12-16-18-21-22A_PD05-12A.xml
+++ b/xml/decoders/Doehler_Haass_fw3.10_DH05-10C_12-16-18-21-22A_PD05-12A.xml
@@ -37,7 +37,7 @@
         -->
   <version version="4" author="Alain Le Marchand" lastUpdated="2018-02-04"/>
   <!--  New Firmware 3.08 and 3.09 with new CV65 -->
-  <version version="3" author="Ronald Kuhn, ronald@wirkuhns.de" lastUpdated="2016-12-14"/>
+  <version version="3" author="Ronald Kuhn" lastUpdated="2016-12-14"/>
   <!--  New Firmware 3.06 and 3.07 with new CV's and added translation to german -->
   <version version="2" author="Pierre Billon" lastUpdated="20151018"/>
   <!--  Merged DH05C, DH10C, DH12A, DH16A, DH18A, DH21A, DH22A def files (same CV characteristics) -->

--- a/xml/decoders/Doehler_Haass_fw3.11_DH05-10C_12-16-18-21-22A_PD05-12A.xml
+++ b/xml/decoders/Doehler_Haass_fw3.11_DH05-10C_12-16-18-21-22A_PD05-12A.xml
@@ -39,7 +39,7 @@
         -->
   <version version="4" author="Alain Le Marchand" lastUpdated="2018-02-04"/>
   <!--  New Firmware 3.08 and 3.09 with new CV65 -->
-  <version version="3" author="Ronald Kuhn, ronald@wirkuhns.de" lastUpdated="2016-12-14"/>
+  <version version="3" author="Ronald Kuhn" lastUpdated="2016-12-14"/>
   <!--  New Firmware 3.06 and 3.07 with new CV's and added translation to german -->
   <version version="2" author="Pierre Billon" lastUpdated="20151018"/>
   <!--  Merged DH05C, DH10C, DH12A, DH16A, DH18A, DH21A, DH22A def files (same CV characteristics) -->

--- a/xml/decoders/Doehler_Haass_fw3.12_DH05-10C_12-16-18-21-22A_PD05-12A.xml
+++ b/xml/decoders/Doehler_Haass_fw3.12_DH05-10C_12-16-18-21-22A_PD05-12A.xml
@@ -19,9 +19,9 @@
         - CV112 is no longer offered on the FH* series or the PD05A, and carries the
           documented default of 15. Now from cv112_fw3.12-3.14.xml.
         -->
-  <version version="1.8" author="Ronald Kuhn, ronald@wirkuhns.de" lastUpdated="20230731"/>
+  <version version="1.8" author="Ronald Kuhn" lastUpdated="20230731"/>
   <!--  Added update paths to newest fw 3.13.053 -->
-  <version version="1.7" author="Ronald Kuhn, ronald@wirkuhns.de" lastUpdated="20230721"/>
+  <version version="1.7" author="Ronald Kuhn" lastted="20230721"/>
   <!--  change file for CV13 because PD05A does not support analog  -->
   <version version="1.6" author="Alain Le Marchand, AlanUS.forum@gmail.com" lastUpdated="20220416"/>
   <!--  Added PD10MU definition -->

--- a/xml/decoders/Doehler_Haass_fw3.12_DH05-10C_12-16-18-21-22A_PD05-12A.xml
+++ b/xml/decoders/Doehler_Haass_fw3.12_DH05-10C_12-16-18-21-22A_PD05-12A.xml
@@ -21,7 +21,7 @@
         -->
   <version version="1.8" author="Ronald Kuhn" lastUpdated="20230731"/>
   <!--  Added update paths to newest fw 3.13.053 -->
-  <version version="1.7" author="Ronald Kuhn" lastted="20230721"/>
+  <version version="1.7" author="Ronald Kuhn" lastUpdated="20230721"/>
   <!--  change file for CV13 because PD05A does not support analog  -->
   <version version="1.6" author="Alain Le Marchand, AlanUS.forum@gmail.com" lastUpdated="20220416"/>
   <!--  Added PD10MU definition -->

--- a/xml/decoders/Doehler_Haass_fw3.12_FH05B-18-22A.xml
+++ b/xml/decoders/Doehler_Haass_fw3.12_FH05B-18-22A.xml
@@ -19,7 +19,7 @@
         - CV112 is no longer offered on the FH* series or the PD05A, and carries the
           documented default of 15. Now from cv112_fw3.12-3.14.xml.
         -->
-  <version version="1.2" author="Ronald Kuhn, ronald@wirkuhns.de" lastUpdated="20230731"/>
+  <version version="1.2" author="Ronald Kuhn" lastUpdated="20230731"/>
   <!--  Added update paths to newest fw 3.13.053 -->
   <version version="1.1" author="Pierre Billon" lastUpdated="20210312"/>
   <!--  Removed Firmware pane (outdated since fw 3.06 and

--- a/xml/decoders/Doehler_Haass_fw3.13_DH05-22B_PD05-21A.xml
+++ b/xml/decoders/Doehler_Haass_fw3.13_DH05-22B_PD05-21A.xml
@@ -12,6 +12,8 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" showEmptyPanes="no" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
+  <version version="1.2" author="Ronald Kuhn" lastUpdated="20260828"/>
+  <!-- replacementModel added and small change, mail address deleted -->
   <version version="1.1" author="Pierre Billon" lastUpdated="20260725"/>
   <!--  Firmware 3.13 completed and corrected:
         - Added CV401-412 function swapping, documented by D&amp;H since firmware 3.12 or earlier
@@ -29,7 +31,7 @@
         - CV112 is no longer offered on the FH* series or the PD05A, which the D&amp;H CV table
           marks it as not relevant for, and it carries the documented default of 15.
         -->
-  <version version="1.0" author="Ronald Kuhn, ronald@wirkuhns.de" lastUpdated="20230720"/>
+  <version version="1.0" author="Ronald Kuhn" lastUpdated="20230720"/>
   <!--  Creation (new firmware 3.13.053).
         Based on Doehler_Haass_fw3.12_DH05-10C_12-16-18-21-22A_PD05-12A.xml
         added new Decoder Generation DH*B
@@ -37,7 +39,7 @@
   <!--  change file for CV13 because PD05A does not support analog, added PD06A, PD18A and PD21A and Decoder 2nd generation  -->
   <decoder>
     <family name="Train Decoders (2023)" mfg="Doehler und Haass">
-      <model model="DH05C (firmware 3.13.053+)" lowVersionID="53" highVersionID="53" numOuts="6" numFns="16" productID="52" comment="DH05C-0 / DH05C-1 / DH05C-3 with update from May 2020" maxInputVolts="18V" maxMotorCurrent="0.5A" maxTotalCurrent="0.5A" connector="Wires/NEM651">
+      <model model="DH05C (firmware 3.13.053+)" replacementModel="DH05C (firmware 3.14.095+)" replacementFamily="query:Train Decoders (firmware 3.14+)" lowVersionID="53" highVersionID="53" numOuts="6" numFns="16" productID="52" comment="DH05C-0 / DH05C-1 / DH05C-3 with update from May 2023" maxInputVolts="18V" maxMotorCurrent="0.5A" maxTotalCurrent="0.5A" connector="Wires/NEM651">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum frontal</label>
@@ -79,7 +81,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="DH05C Gen. 2 (firmware 3.13.053+)" lowVersionID="53" highVersionID="53" numOuts="8" numFns="16" productID="52" comment="DH05C-0 / DH05C-1 / DH05C-3 2nd Generation with update from May 2020" maxInputVolts="30V" maxMotorCurrent="0.5A" maxTotalCurrent="0.5A" connector="Wires/NEM651">
+      <model model="DH05C Gen. 2 (firmware 3.13.053+)" replacementModel="DH05C Gen. 2 (firmware 3.14.095+)" replacementFamily="query:Train Decoders (firmware 3.14+)" lowVersionID="53" highVersionID="53" numOuts="8" numFns="16" productID="52" comment="DH05C-0 / DH05C-1 / DH05C-3 2nd Generation with update from May 2023" maxInputVolts="30V" maxMotorCurrent="0.5A" maxTotalCurrent="0.5A" connector="Wires/NEM651">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum frontal</label>
@@ -121,7 +123,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="DH06A (firmware 3.13.053+)" lowVersionID="53" highVersionID="53" numOuts="3" numFns="16" productID="60" comment="DH06A for Köf with no analog support, with update from May 2020" maxInputVolts="30V" maxMotorCurrent="0.3A" maxTotalCurrent="0.3A">
+      <model model="DH06A (firmware 3.13.053+)" replacementModel="DH06A (firmware 3.14.095+)" replacementFamily="query:Train Decoders (firmware 3.14+)" lowVersionID="53" highVersionID="53" numOuts="3" numFns="16" productID="60" comment="DH06A for Köf with no analog support, with update from May 2023" maxInputVolts="30V" maxMotorCurrent="0.3A" maxTotalCurrent="0.3A">
         <output name="1" label="Front|Light" maxcurrent="20mA"/>
         <output name="2" label="Rear|Light" maxcurrent="20mA"/>
         <output name="3" label="Onboard|LED" maxcurrent="20mA"/>
@@ -136,7 +138,7 @@
           <protocol>selectrix</protocol>
         </protocols>
       </model>
-      <model model="DH06A Gen. 2 (firmware 3.13.053+)" lowVersionID="53" highVersionID="53" numOuts="3" numFns="16" productID="60" comment="DH06A for Köf with no analog support, with update from May 2020" maxInputVolts="30V" maxMotorCurrent="0.3A" maxTotalCurrent="0.3A">
+      <model model="DH06A Gen. 2 (firmware 3.13.053+)" replacementModel="DH06A Gen. 2 (firmware 3.14.095+)" replacementFamily="query:Train Decoders (firmware 3.14+)" lowVersionID="53" highVersionID="53" numOuts="3" numFns="16" productID="60" comment="DH06A for Köf with no analog support, with update from May 2023" maxInputVolts="30V" maxMotorCurrent="0.3A" maxTotalCurrent="0.3A">
         <output name="1" label="Front|Light" maxcurrent="20mA"/>
         <output name="2" label="Rear|Light" maxcurrent="20mA"/>
         <output name="3" label="Onboard|LED" maxcurrent="20mA"/>
@@ -151,7 +153,7 @@
           <protocol>selectrix</protocol>
         </protocols>
       </model>
-      <model model="DH10C (firmware 3.13.053+)" lowVersionID="53" highVersionID="53" numOuts="6" numFns="16" productID="102" comment="DH10C-0 / DH10C-1 / DH10C-3 with update from May 2020" maxInputVolts="30V" maxMotorCurrent="1A" maxTotalCurrent="1A" connector="Wires/NEM651">
+      <model model="DH10C (firmware 3.13.053+)" replacementModel="DH10C (firmware 3.14.095+)" replacementFamily="query:Train Decoders (firmware 3.14+)" lowVersionID="53" highVersionID="53" numOuts="6" numFns="16" productID="102" comment="DH10C-0 / DH10C-1 / DH10C-3 with update from May 2023" maxInputVolts="30V" maxMotorCurrent="1A" maxTotalCurrent="1A" connector="Wires/NEM651">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum Frontal</label>
@@ -193,7 +195,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="DH10C Gen. 2 (firmware 3.13.053+)" lowVersionID="53" highVersionID="53" numOuts="8" numFns="16" productID="102" comment="DH10C-0 / DH10C-1 / DH10C-3 2nd Generation with update from May 2020" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="Wires/NEM651">
+      <model model="DH10C Gen. 2 (firmware 3.13.053+)" replacementModel="DH10C Gen. 2 (firmware 3.14.095+)" replacementFamily="query:Train Decoders (firmware 3.14+)" lowVersionID="53" highVersionID="53" numOuts="8" numFns="16" productID="102" comment="DH10C-0 / DH10C-1 / DH10C-3 2nd Generation with update from May 2023" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="Wires/NEM651">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum Frontal</label>
@@ -235,7 +237,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="DH12A (firmware 3.13.053+)" lowVersionID="53" highVersionID="53" numOuts="6" numFns="16" productID="120" comment="DH12A with update from May 2020" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="PluX12">
+      <model model="DH12A (firmware 3.13.053+)" replacementModel="DH12A (firmware 3.14.095+)" replacementFamily="query:Train Decoders (firmware 3.14+)" lowVersionID="53" highVersionID="53" numOuts="6" numFns="16" productID="120" comment="DH12A with update from May 2023" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="PluX12">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum frontal</label>
@@ -275,7 +277,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="DH14B (firmware 3.13.053+)" lowVersionID="53" highVersionID="53" numOuts="6" numFns="16" productID="141" comment="DH14B with update from May 2020" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="other">
+      <model model="DH14B (firmware 3.13.053+)" replacementModel="DH14B (firmware 3.14.095+)" replacementFamily="query:Train Decoders (firmware 3.14+)" lowVersionID="53" highVersionID="53" numOuts="6" numFns="16" productID="141" comment="DH14B with update from May 2023" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="other">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum frontal</label>
@@ -315,7 +317,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="DH16A (firmware 3.13.053+)" lowVersionID="53" highVersionID="53" numOuts="6" numFns="16" productID="160" comment="DH16A-0 /DH16A-1 /DH16A-2 /DH16A-3 with update from May 2020" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="PluX16">
+      <model model="DH16A (firmware 3.13.053+)" replacementModel="DH16A (firmware 3.14.095+)" replacementFamily="query:Train Decoders (firmware 3.14+)" lowVersionID="53" highVersionID="53" numOuts="6" numFns="16" productID="160" comment="DH16A-0 /DH16A-1 /DH16A-2 /DH16A-3 with update from May 2023" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="PluX16">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum Frontal</label>
@@ -355,7 +357,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="DH16A Gen. 2 (firmware 3.13.053+)" lowVersionID="53" highVersionID="53" numOuts="6" numFns="16" productID="160" comment="DH16A-0 /DH16A-1 /DH16A-2 /DH16A-3 with update from May 2020" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="PluX16">
+      <model model="DH16A Gen. 2 (firmware 3.13.053+)" replacementModel="DH16A Gen. 2 (firmware 3.14.095+)" replacementFamily="query:Train Decoders (firmware 3.14+)" lowVersionID="53" highVersionID="53" numOuts="6" numFns="16" productID="160" comment="DH16A-0 /DH16A-1 /DH16A-2 /DH16A-3 with update from May 2023" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="PluX16">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum Frontal</label>
@@ -395,7 +397,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="DH18A (firmware 3.13.053+)" lowVersionID="53" highVersionID="53" numOuts="8" numFns="16" productID="180" comment="DH18A with update from May 2020" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="Next18">
+      <model model="DH18A (firmware 3.13.053+)" replacementModel="DH18A (firmware 3.14.095+)" replacementFamily="query:Train Decoders (firmware 3.14+)" lowVersionID="53" highVersionID="53" numOuts="8" numFns="16" productID="180" comment="DH18A with update from May 2023" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="Next18">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum Frontal</label>
@@ -443,7 +445,7 @@
             <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="DH18A Gen. 2 (firmware 3.13.053+)" lowVersionID="53" highVersionID="53" numOuts="8" numFns="16" productID="180" comment="DH18A with update from May 2020" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="Next18">
+      <model model="DH18A Gen. 2 (firmware 3.13.053+)" replacementModel="DH18A Gen. 2 (firmware 3.14.095+)" replacementFamily="query:Train Decoders (firmware 3.14+)" lowVersionID="53" highVersionID="53" numOuts="8" numFns="16" productID="180" comment="DH18A with update from May 2023" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="Next18">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum Frontal</label>
@@ -491,7 +493,7 @@
             <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="DH21A (firmware 3.13.053+)" lowVersionID="53" highVersionID="53" numOuts="8" numFns="16" productID="200" comment="DH21A with update from May 2020" maxInputVolts="30V" maxMotorCurrent="2A" maxTotalCurrent="2A" connector="21MTC">
+      <model model="DH21A (firmware 3.13.053+)" replacementModel="DH21A (firmware 3.14.095+)" replacementFamily="query:Train Decoders (firmware 3.14+)" lowVersionID="53" highVersionID="53" numOuts="8" numFns="16" productID="200" comment="DH21A with update from May 2023" maxInputVolts="30V" maxMotorCurrent="2A" maxTotalCurrent="2A" connector="21MTC">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum frontal</label>
@@ -539,7 +541,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="DH21A Gen. 2 (firmware 3.13.053+)" lowVersionID="53" highVersionID="53" numOuts="8" numFns="16" productID="200" comment="DH21A with update from May 2020" maxInputVolts="30V" maxMotorCurrent="2A" maxTotalCurrent="2A" connector="21MTC">
+      <model model="DH21A Gen. 2 (firmware 3.13.053+)" replacementModel="DH21A Gen. 2 (firmware 3.14.095+)" replacementFamily="query:Train Decoders (firmware 3.14+)" lowVersionID="53" highVersionID="53" numOuts="8" numFns="16" productID="200" comment="DH21A with update from May 2023" maxInputVolts="30V" maxMotorCurrent="2A" maxTotalCurrent="2A" connector="21MTC">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum frontal</label>
@@ -587,7 +589,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="DH21B (firmware 3.13.053+)" lowVersionID="53" highVersionID="53" numOuts="10" numFns="16" productID="201" comment="DH21B" maxInputVolts="30V" maxMotorCurrent="2A" maxTotalCurrent="2A" connector="21MTC">
+      <model model="DH21B (firmware 3.13.053+)" replacementModel="DH21B (firmware 3.14.095+)" replacementFamily="query:Train Decoders (firmware 3.14+)" lowVersionID="53" highVersionID="53" numOuts="10" numFns="16" productID="201" comment="DH21B with update from May 2023" maxInputVolts="30V" maxMotorCurrent="2A" maxTotalCurrent="2A" connector="21MTC">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum frontal</label>
@@ -643,7 +645,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="DH22A (firmware 3.13.053+)" lowVersionID="53" highVersionID="53" numOuts="8" numFns="16" productID="202" comment="DH22A with update from May 2020" maxInputVolts="30V" maxMotorCurrent="2A" maxTotalCurrent="2A" connector="PluX22">
+      <model model="DH22A (firmware 3.13.053+)" replacementModel="DH22A (firmware 3.14.095+)" replacementFamily="query:Train Decoders (firmware 3.14+)" lowVersionID="53" highVersionID="53" numOuts="8" numFns="16" productID="202" comment="DH22A with update from May 2023" maxInputVolts="30V" maxMotorCurrent="2A" maxTotalCurrent="2A" connector="PluX22">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum Frontal</label>
@@ -691,7 +693,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="DH22A Gen. 2 (firmware 3.13.053+)" lowVersionID="53" highVersionID="53" numOuts="8" numFns="16" productID="202" comment="DH22A with update from May 2020" maxInputVolts="30V" maxMotorCurrent="2A" maxTotalCurrent="2A" connector="PluX22">
+      <model model="DH22A Gen. 2 (firmware 3.13.053+)" replacementModel="DH22A Gen. 2 (firmware 3.14.095+)" replacementFamily="query:Train Decoders (firmware 3.14+)" lowVersionID="53" highVersionID="53" numOuts="8" numFns="16" productID="202" comment="DH22A with update from May 2023" maxInputVolts="30V" maxMotorCurrent="2A" maxTotalCurrent="2A" connector="PluX22">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum Frontal</label>
@@ -739,7 +741,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="DH22B (firmware 3.13.053+)" lowVersionID="53" highVersionID="53" numOuts="10" numFns="16" productID="203" comment="DH22B" maxInputVolts="30V" maxMotorCurrent="2A" maxTotalCurrent="2A" connector="PluX22">
+      <model model="DH22B (firmware 3.13.053+)" replacementModel="DH22B (firmware 3.14.095+)" replacementFamily="query:Train Decoders (firmware 3.14+)" lowVersionID="53" highVersionID="53" numOuts="10" numFns="16" productID="203" comment="DH22B with update from May 2023" maxInputVolts="30V" maxMotorCurrent="2A" maxTotalCurrent="2A" connector="PluX22">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum Frontal</label>
@@ -795,7 +797,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="DH24A (firmware 3.13.053+)" lowVersionID="53" highVersionID="53" numOuts="13" numFns="16" productID="204" comment="DH24A, 24-pin E24 direct plug. AUX10-12 cannot be mapped on this firmware (CV101-103 exist from firmware 3.15)" maxInputVolts="30V" maxMotorCurrent="0.7A" maxTotalCurrent="1.5A" connector="E24">
+      <model model="DH24A (firmware 3.13.053+)" replacementModel="DH24A (firmware 3.14.095+)" replacementFamily="query:Train Decoders (firmware 3.14+)" lowVersionID="53" highVersionID="53" numOuts="13" numFns="16" productID="204" comment="DH24A, 24-pin E24 direct plug. AUX10-12 cannot be mapped on this firmware (CV101-103 exist from firmware 3.15)" maxInputVolts="30V" maxMotorCurrent="0.7A" maxTotalCurrent="1.5A" connector="E24">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum Frontal</label>
@@ -863,7 +865,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="DHSP10A (firmware 3.13.053+)" lowVersionID="53" highVersionID="53" numOuts="8" numFns="16" productID="110" comment="DHSP10A-0 / -1 / -2 / -3 / -4, with integrated buffer capacitor (16 V, 470 uF)" maxInputVolts="30V" maxMotorCurrent="0.7A" maxTotalCurrent="1.5A" connector="Wires/NEM651">
+      <model model="DHSP10A (firmware 3.13.053+)" replacementModel="DHSP10A (firmware 3.14.095+)" replacementFamily="query:Train Decoders (firmware 3.14+)" lowVersionID="53" highVersionID="53" numOuts="8" numFns="16" productID="110" comment="DHSP10A-0 / -1 / -2 / -3 / -4, with integrated buffer capacitor (16 V, 470 uF)" maxInputVolts="30V" maxMotorCurrent="0.7A" maxTotalCurrent="1.5A" connector="Wires/NEM651">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum Frontal</label>
@@ -911,7 +913,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="PD05A (firmware 3.13.053+)" lowVersionID="53" highVersionID="53" numOuts="2" numFns="16" productID="131" comment="PD05A-0 / PD05A-2 / PD05A-3 with update from May 2020" maxInputVolts="30V" maxMotorCurrent="0.5A" maxTotalCurrent="0.5A" connector="Wires/NEM651">
+      <model model="PD05A (firmware 3.13.053+)" replacementModel="PD05A (firmware 3.14.095+)" replacementFamily="query:Train Decoders (firmware 3.14+)" lowVersionID="53" highVersionID="53" numOuts="2" numFns="16" productID="131" comment="PD05A-0 / PD05A-2 / PD05A-3 with update from May 2023" maxInputVolts="30V" maxMotorCurrent="0.5A" maxTotalCurrent="0.5A" connector="Wires/NEM651">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum Frontal</label>
@@ -934,7 +936,7 @@
           <protocol>selectrix</protocol>
         </protocols>
       </model>
-      <model model="PD05A Gen. 2 (firmware 3.13.053+)" lowVersionID="53" highVersionID="53" numOuts="2" numFns="16" productID="131" comment="PD05A-0 / PD05A-2 / PD05A-3 with update from May 2020" maxInputVolts="30V" maxMotorCurrent="0.5A" maxTotalCurrent="0.5A" connector="Wires/NEM651">
+      <model model="PD05A Gen. 2 (firmware 3.13.053+)" replacementModel="PD05A Gen. 2 (firmware 3.14.095+)" replacementFamily="query:Train Decoders (firmware 3.14+)" lowVersionID="53" highVersionID="53" numOuts="2" numFns="16" productID="131" comment="PD05A-0 / PD05A-2 / PD05A-3 with update from May 2023" maxInputVolts="30V" maxMotorCurrent="0.5A" maxTotalCurrent="0.5A" connector="Wires/NEM651">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum Frontal</label>
@@ -957,7 +959,7 @@
           <protocol>selectrix</protocol>
         </protocols>
       </model>
-      <model model="PD06A (firmware 3.13.053+)" lowVersionID="53" highVersionID="53" numOuts="4" numFns="16" productID="132" comment="PD06A-0 / PD06A-3" maxInputVolts="18V" maxMotorCurrent="0.2A/6V" maxTotalCurrent="0.5A" connector="Wires">
+      <model model="PD06A (firmware 3.13.053+)" replacementModel="PD06A (firmware 3.14.095+)" replacementFamily="query:Train Decoders (firmware 3.14+)" lowVersionID="53" highVersionID="53" numOuts="4" numFns="16" productID="132" comment="PD06A-0 / PD06A-3 with update from May 2023" maxInputVolts="18V" maxMotorCurrent="0.2A/6V" maxTotalCurrent="0.5A" connector="Wires">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum Frontal</label>
@@ -988,7 +990,7 @@
           <protocol>selectrix</protocol>
         </protocols>
       </model>
-      <model model="PD10MU (firmware 3.13.053+)" lowVersionID="53" highVersionID="53" numOuts="4" numFns="16" productID="130" comment="PD10MU-3 / PD10MU-4 commissioned by DM-Toys" maxInputVolts="30V" maxMotorCurrent="1A" maxTotalCurrent="1A" connector="Wires/NEM651">
+      <model model="PD10MU (firmware 3.13.053+)" replacementModel="PD10MU (firmware 3.14.095+)" replacementFamily="query:Train Decoders (firmware 3.14+)" lowVersionID="53" highVersionID="53" numOuts="4" numFns="16" productID="130" comment="PD10MU-3 / PD10MU-4 commissioned by DM-Toys" maxInputVolts="30V" maxMotorCurrent="1A" maxTotalCurrent="1A" connector="Wires/NEM651">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum Frontal</label>
@@ -1018,7 +1020,7 @@
           <protocol>dcc</protocol>
         </protocols>
       </model>
-      <model model="PD12A (firmware 3.13.053+)" lowVersionID="53" highVersionID="53" numOuts="4" numFns="16" productID="130" comment="PD12A-0 / PD12A-2 / PD12A-3 / PD12A-4 with update from May 2020" maxInputVolts="30V" maxMotorCurrent="1A" maxTotalCurrent="1A" connector="PluX12">
+      <model model="PD12A (firmware 3.13.053+)" replacementModel="PD12A (firmware 3.14.095+)" replacementFamily="query:Train Decoders (firmware 3.14+)" lowVersionID="53" highVersionID="53" numOuts="4" numFns="16" productID="130" comment="PD12A-0 / PD12A-2 / PD12A-3 / PD12A-4 with update from May 2023" maxInputVolts="30V" maxMotorCurrent="1A" maxTotalCurrent="1A" connector="PluX12">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum Frontal</label>
@@ -1048,7 +1050,7 @@
           <protocol>dcc</protocol>
         </protocols>
       </model>
-      <model model="PD18A (firmware 3.13.053+)" lowVersionID="53" highVersionID="53" numOuts="4" numFns="16" productID="134" comment="PD18A" maxInputVolts="30V" maxMotorCurrent="1A" maxTotalCurrent="1A" connector="Next18">
+      <model model="PD18A (firmware 3.13.053+)" replacementModel="PD18A (firmware 3.14.095+)" replacementFamily="query:Train Decoders (firmware 3.14+)" lowVersionID="53" highVersionID="53" numOuts="4" numFns="16" productID="134" comment="PD18A with update from May 2023" maxInputVolts="30V" maxMotorCurrent="1A" maxTotalCurrent="1A" connector="Next18">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum Frontal</label>
@@ -1078,7 +1080,7 @@
           <protocol>dcc</protocol>
         </protocols>
       </model>
-      <model model="PD18MU (firmware 3.13.053+)" lowVersionID="53" highVersionID="53" numOuts="4" numFns="16" productID="134" comment="PD18MU" maxInputVolts="30V" maxMotorCurrent="1A" maxTotalCurrent="1A" connector="Next18">
+      <model model="PD18MU (firmware 3.13.053+)" replacementModel="PD18MU (firmware 3.14.095+)" replacementFamily="query:Train Decoders (firmware 3.14+)" lowVersionID="53" highVersionID="53" numOuts="4" numFns="16" productID="134" comment="PD18MU commissioned by DM-Toys" maxInputVolts="30V" maxMotorCurrent="1A" maxTotalCurrent="1A" connector="Next18">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum Frontal</label>
@@ -1108,7 +1110,7 @@
           <protocol>dcc</protocol>
         </protocols>
       </model>
-      <model model="PD21A (firmware 3.13.053+)" lowVersionID="53" highVersionID="53" numOuts="4" numFns="16" productID="133" comment="PD21A-4" maxInputVolts="30V" maxMotorCurrent="1A" maxTotalCurrent="1A" connector="21MTC">
+      <model model="PD21A (firmware 3.13.053+)" replacementModel="PD21A (firmware 3.14.095+)" replacementFamily="query:Train Decoders (firmware 3.14+)" lowVersionID="53" highVersionID="53" numOuts="4" numFns="16" productID="133" comment="PD21A-4 with update from May 2023" maxInputVolts="30V" maxMotorCurrent="1A" maxTotalCurrent="1A" connector="21MTC">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum Frontal</label>

--- a/xml/decoders/Doehler_Haass_fw3.13_FH05B-22A.xml
+++ b/xml/decoders/Doehler_Haass_fw3.13_FH05B-22A.xml
@@ -12,6 +12,8 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" showEmptyPanes="no" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
+  <version version="1.2" author="Ronald Kuhn" lastUpdated="20260828"/>
+  <!-- replacementModel added and small change, mail address deleted -->
   <version version="1.1" author="Pierre Billon" lastUpdated="20260725"/>
   <!--  Firmware 3.13 completed and corrected:
         - Added CV401-412 function swapping, documented by D&amp;H since firmware 3.12 or earlier
@@ -27,13 +29,13 @@
         - CV112 is no longer offered on the FH* series, which the D&amp;H CV table marks it as not
           relevant for, and it carries the documented default of 15.
         -->
-  <version version="1.0" author="Ronald Kuhn, ronald@wirkuhns.de" lastUpdated="20230720"/>
+  <version version="1.0" author="Ronald Kuhn" lastUpdated="20230720"/>
   <!--  Creation (new firmware 3.13.053).
         Based on Doehler_Haass_fw3.12_FH05B-18-22A.xml
         -->
   <decoder>
     <family name="Function Decoders (2023)" mfg="Doehler und Haass">
-      <model model="FH05B (firmware 3.13.053+)" lowVersionID="53" highVersionID="53" numOuts="6" numFns="16" productID="41" comment="FH05B-0 / FH05B-1 / FH05B-3 with update from May 2020" maxInputVolts="30V" maxTotalCurrent="0.5A" connector="Wires/NEM651">
+      <model model="FH05B (firmware 3.13.053+)" replacementModel="FH05B (firmware 3.14.095+)" replacementFamily="query:Function Decoders (firmware 3.14+)" lowVersionID="53" highVersionID="53" numOuts="6" numFns="16" productID="41" comment="FH05B-0 / FH05B-1 / FH05B-3 with update from May 2023" maxInputVolts="30V" maxTotalCurrent="0.5A" connector="Wires/NEM651">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum Frontal</label>
@@ -75,7 +77,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="FH16A (firmware 3.13.053+)" lowVersionID="53" highVersionID="53" numOuts="8" numFns="16" productID="150" comment="FH16A-4, PluX16 direct plug" maxInputVolts="30V" maxTotalCurrent="1.5A" connector="PluX16">
+      <model model="FH16A (firmware 3.13.053+)" replacementModel="FH16A (firmware 3.14.095+)" replacementFamily="query:Function Decoders (firmware 3.14+)" lowVersionID="53" highVersionID="53" numOuts="8" numFns="16" productID="150" comment="FH16A-4, PluX16 direct plug" maxInputVolts="30V" maxTotalCurrent="1.5A" connector="PluX16">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum Frontal</label>
@@ -123,7 +125,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="FH18A (firmware 3.13.053+)" lowVersionID="53" highVersionID="53" numOuts="8" numFns="18" productID="170" comment="FH18A with update from May 2020" maxInputVolts="30V" maxTotalCurrent="1.0A" connector="Next18">
+      <model model="FH18A (firmware 3.13.053+)" replacementModel="FH18A (firmware 3.14.095+)" replacementFamily="query:Function Decoders (firmware 3.14+)" lowVersionID="53" highVersionID="53" numOuts="8" numFns="18" productID="170" comment="FH18A with update from May 2023" maxInputVolts="30V" maxTotalCurrent="1.0A" connector="Next18">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum Frontal</label>
@@ -171,7 +173,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="FH22A (firmware 3.13.053+)" lowVersionID="53" highVersionID="53" numOuts="8" numFns="18" productID="192" comment="FH22A with update from May 2020" maxInputVolts="30V" maxTotalCurrent="2.0A" connector="PluX22">
+      <model model="FH22A (firmware 3.13.053+)" replacementModel="FH22A (firmware 3.14.095+)" replacementFamily="query:Function Decoders (firmware 3.14+)" lowVersionID="53" highVersionID="53" numOuts="8" numFns="18" productID="192" comment="FH22A with update from May 2023" maxInputVolts="30V" maxTotalCurrent="2.0A" connector="PluX22">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum Frontal</label>

--- a/xml/decoders/Doehler_Haass_fw3.14_DH05-24A_PD05-21A.xml
+++ b/xml/decoders/Doehler_Haass_fw3.14_DH05-24A_PD05-21A.xml
@@ -12,6 +12,8 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" showEmptyPanes="no" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
+  <version version="1.1" author="Ronald Kuhn" lastUpdated="20260828"/>
+  <!-- replacementModel added and small change, mail address deleted -->
   <version version="1" author="Pierre Billon" lastUpdated="20260725"/>
   <!--  Creation (new firmware 3.14.095).
         Based on Doehler_Haass_fw3.13_DH05-22B_PD05-21A.xml
@@ -24,7 +26,7 @@
         -->
   <decoder>
     <family name="Train Decoders (firmware 3.14+)" mfg="Doehler und Haass">
-      <model model="DH05C (firmware 3.14.095+)" lowVersionID="95" highVersionID="95" numOuts="6" numFns="16" productID="52" comment="DH05C-0 / DH05C-1 / DH05C-3 with update from May 2020" maxInputVolts="18V" maxMotorCurrent="0.5A" maxTotalCurrent="0.5A" connector="Wires/NEM651">
+      <model model="DH05C (firmware 3.14.095+)" replacementModel="DH05C (firmware 3.15.016+)" replacementFamily="query:Train Decoders (firmware 3.15+)" lowVersionID="95" highVersionID="95" numOuts="6" numFns="16" productID="52" comment="DH05C-0 / DH05C-1 / DH05C-3 with update from September 2025" maxInputVolts="18V" maxMotorCurrent="0.5A" maxTotalCurrent="0.5A" connector="Wires/NEM651">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum frontal</label>
@@ -66,7 +68,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="DH05C Gen. 2 (firmware 3.14.095+)" lowVersionID="95" highVersionID="95" numOuts="8" numFns="16" productID="52" comment="DH05C-0 / DH05C-1 / DH05C-3 2nd Generation with update from May 2020" maxInputVolts="30V" maxMotorCurrent="0.5A" maxTotalCurrent="0.5A" connector="Wires/NEM651">
+      <model model="DH05C Gen. 2 (firmware 3.14.095+)" replacementModel="DH05C Gen. 2 (firmware 3.15.016+)" replacementFamily="query:Train Decoders (firmware 3.15+)" lowVersionID="95" highVersionID="95" numOuts="8" numFns="16" productID="52" comment="DH05C-0 / DH05C-1 / DH05C-3 2nd Generation with update from September 2025" maxInputVolts="30V" maxMotorCurrent="0.5A" maxTotalCurrent="0.5A" connector="Wires/NEM651">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum frontal</label>
@@ -108,7 +110,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="DH06A (firmware 3.14.095+)" lowVersionID="95" highVersionID="95" numOuts="3" numFns="16" productID="60" comment="DH06A for Köf with no analog support, with update from May 2020" maxInputVolts="30V" maxMotorCurrent="0.3A" maxTotalCurrent="0.3A">
+      <model model="DH06A (firmware 3.14.095+)" replacementModel="DH06A (firmware 3.15.016+)" replacementFamily="query:Train Decoders (firmware 3.15+)" lowVersionID="95" highVersionID="95" numOuts="3" numFns="16" productID="60" comment="DH06A for Köf with no analog support, with update from September 2025" maxInputVolts="30V" maxMotorCurrent="0.3A" maxTotalCurrent="0.3A">
         <output name="1" label="Front|Light" maxcurrent="20mA"/>
         <output name="2" label="Rear|Light" maxcurrent="20mA"/>
         <output name="3" label="Onboard|LED" maxcurrent="20mA"/>
@@ -123,7 +125,7 @@
           <protocol>selectrix</protocol>
         </protocols>
       </model>
-      <model model="DH06A Gen. 2 (firmware 3.14.095+)" lowVersionID="95" highVersionID="95" numOuts="3" numFns="16" productID="60" comment="DH06A for Köf with no analog support, with update from May 2020" maxInputVolts="30V" maxMotorCurrent="0.3A" maxTotalCurrent="0.3A">
+      <model model="DH06A Gen. 2 (firmware 3.14.095+)" replacementModel="DH06A Gen. 2 (firmware 3.15.016+)" replacementFamily="query:Train Decoders (firmware 3.15+)" lowVersionID="95" highVersionID="95" numOuts="3" numFns="16" productID="60" comment="DH06A for Köf with no analog support, with update from September 2025" maxInputVolts="30V" maxMotorCurrent="0.3A" maxTotalCurrent="0.3A">
         <output name="1" label="Front|Light" maxcurrent="20mA"/>
         <output name="2" label="Rear|Light" maxcurrent="20mA"/>
         <output name="3" label="Onboard|LED" maxcurrent="20mA"/>
@@ -138,7 +140,7 @@
           <protocol>selectrix</protocol>
         </protocols>
       </model>
-      <model model="DH10C (firmware 3.14.095+)" lowVersionID="95" highVersionID="95" numOuts="6" numFns="16" productID="102" comment="DH10C-0 / DH10C-1 / DH10C-3 with update from May 2020" maxInputVolts="30V" maxMotorCurrent="1A" maxTotalCurrent="1A" connector="Wires/NEM651">
+      <model model="DH10C (firmware 3.14.095+)" replacementModel="DH10C (firmware 3.15.016+)" replacementFamily="query:Train Decoders (firmware 3.15+)" lowVersionID="95" highVersionID="95" numOuts="6" numFns="16" productID="102" comment="DH10C-0 / DH10C-1 / DH10C-3 with update from September 2025" maxInputVolts="30V" maxMotorCurrent="1A" maxTotalCurrent="1A" connector="Wires/NEM651">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum Frontal</label>
@@ -180,7 +182,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="DH10C Gen. 2 (firmware 3.14.095+)" lowVersionID="95" highVersionID="95" numOuts="8" numFns="16" productID="102" comment="DH10C-0 / DH10C-1 / DH10C-3 2nd Generation with update from May 2020" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="Wires/NEM651">
+      <model model="DH10C Gen. 2 (firmware 3.14.095+)" replacementModel="DH10C Gen. 2 (firmware 3.15.016+)" replacementFamily="query:Train Decoders (firmware 3.15+)" lowVersionID="95" highVersionID="95" numOuts="8" numFns="16" productID="102" comment="DH10C-0 / DH10C-1 / DH10C-3 2nd Generation with update from September 2025" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="Wires/NEM651">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum Frontal</label>
@@ -222,7 +224,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="DH12A (firmware 3.14.095+)" lowVersionID="95" highVersionID="95" numOuts="6" numFns="16" productID="120" comment="DH12A with update from May 2020" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="PluX12">
+      <model model="DH12A (firmware 3.14.095+)" replacementModel="DH12A (firmware 3.15.016+)" replacementFamily="query:Train Decoders (firmware 3.15+)" lowVersionID="95" highVersionID="95" numOuts="6" numFns="16" productID="120" comment="DH12A with update from September 2025" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="PluX12">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum frontal</label>
@@ -262,7 +264,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="DH14B (firmware 3.14.095+)" lowVersionID="95" highVersionID="95" numOuts="6" numFns="16" productID="141" comment="DH14B with update from May 2020" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="other">
+      <model model="DH14B (firmware 3.14.095+)" replacementModel="DH14B (firmware 3.15.016+)" replacementFamily="query:Train Decoders (firmware 3.15+)" lowVersionID="95" highVersionID="95" numOuts="6" numFns="16" productID="141" comment="DH14B with update from September 2025" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="other">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum frontal</label>
@@ -302,7 +304,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="DH16A (firmware 3.14.095+)" lowVersionID="95" highVersionID="95" numOuts="6" numFns="16" productID="160" comment="DH16A-0 /DH16A-1 /DH16A-2 /DH16A-3 with update from May 2020" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="PluX16">
+      <model model="DH16A (firmware 3.14.095+)" replacementModel="DH16A (firmware 3.15.016+)" replacementFamily="query:Train Decoders (firmware 3.15+)" lowVersionID="95" highVersionID="95" numOuts="6" numFns="16" productID="160" comment="DH16A-0 /DH16A-1 /DH16A-2 /DH16A-3 with update from September 2025" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="PluX16">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum Frontal</label>
@@ -342,7 +344,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="DH16A Gen. 2 (firmware 3.14.095+)" lowVersionID="95" highVersionID="95" numOuts="6" numFns="16" productID="160" comment="DH16A-0 /DH16A-1 /DH16A-2 /DH16A-3 with update from May 2020" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="PluX16">
+      <model model="DH16A Gen. 2 (firmware 3.14.095+)" replacementModel="DH16A Gen. 2 (firmware 3.15.016+)" replacementFamily="query:Train Decoders (firmware 3.15+)" lowVersionID="95" highVersionID="95" numOuts="6" numFns="16" productID="160" comment="DH16A-0 /DH16A-1 /DH16A-2 /DH16A-3 with update from September 2025" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="PluX16">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum Frontal</label>
@@ -382,7 +384,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="DH18A (firmware 3.14.095+)" lowVersionID="95" highVersionID="95" numOuts="8" numFns="16" productID="180" comment="DH18A with update from May 2020" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="Next18">
+      <model model="DH18A (firmware 3.14.095+)" replacementModel="DH18A (firmware 3.15.016+)" replacementFamily="query:Train Decoders (firmware 3.15+)" lowVersionID="95" highVersionID="95" numOuts="8" numFns="16" productID="180" comment="DH18A with update from September 2025" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="Next18">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum Frontal</label>
@@ -430,7 +432,7 @@
             <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="DH18A Gen. 2 (firmware 3.14.095+)" lowVersionID="95" highVersionID="95" numOuts="8" numFns="16" productID="180" comment="DH18A with update from May 2020" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="Next18">
+      <model model="DH18A Gen. 2 (firmware 3.14.095+)" replacementModel="DH18A Gen. 2 (firmware 3.15.016+)" replacementFamily="query:Train Decoders (firmware 3.15+)" lowVersionID="95" highVersionID="95" numOuts="8" numFns="16" productID="180" comment="DH18A with update from September 2025" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="Next18">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum Frontal</label>
@@ -478,7 +480,7 @@
             <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="DH21A (firmware 3.14.095+)" lowVersionID="95" highVersionID="95" numOuts="8" numFns="16" productID="200" comment="DH21A with update from May 2020" maxInputVolts="30V" maxMotorCurrent="2A" maxTotalCurrent="2A" connector="21MTC">
+      <model model="DH21A (firmware 3.14.095+)" replacementModel="DH21A (firmware 3.15.016+)" replacementFamily="query:Train Decoders (firmware 3.15+)" lowVersionID="95" highVersionID="95" numOuts="8" numFns="16" productID="200" comment="DH21A with update from September 2025" maxInputVolts="30V" maxMotorCurrent="2A" maxTotalCurrent="2A" connector="21MTC">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum frontal</label>
@@ -526,7 +528,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="DH21A Gen. 2 (firmware 3.14.095+)" lowVersionID="95" highVersionID="95" numOuts="8" numFns="16" productID="200" comment="DH21A with update from May 2020" maxInputVolts="30V" maxMotorCurrent="2A" maxTotalCurrent="2A" connector="21MTC">
+      <model model="DH21A Gen. 2 (firmware 3.14.095+)" replacementModel="DH21A Gen. 2 (firmware 3.15.016+)" replacementFamily="query:Train Decoders (firmware 3.15+)" lowVersionID="95" highVersionID="95" numOuts="8" numFns="16" productID="200" comment="DH21A with update from September 2025" maxInputVolts="30V" maxMotorCurrent="2A" maxTotalCurrent="2A" connector="21MTC">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum frontal</label>
@@ -574,7 +576,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="DH21B (firmware 3.14.095+)" lowVersionID="95" highVersionID="95" numOuts="10" numFns="16" productID="201" comment="DH21B" maxInputVolts="30V" maxMotorCurrent="2A" maxTotalCurrent="2A" connector="21MTC">
+      <model model="DH21B (firmware 3.14.095+)" replacementModel="DH21B (firmware 3.15.016+)" replacementFamily="query:Train Decoders (firmware 3.15+)" lowVersionID="95" highVersionID="95" numOuts="10" numFns="16" productID="201" comment="DH21B" maxInputVolts="30V" maxMotorCurrent="2A" maxTotalCurrent="2A" connector="21MTC">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum frontal</label>
@@ -630,7 +632,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="DH22A (firmware 3.14.095+)" lowVersionID="95" highVersionID="95" numOuts="8" numFns="16" productID="202" comment="DH22A with update from May 2020" maxInputVolts="30V" maxMotorCurrent="2A" maxTotalCurrent="2A" connector="PluX22">
+      <model model="DH22A (firmware 3.14.095+)" replacementModel="DH22A (firmware 3.15.016+)" replacementFamily="query:Train Decoders (firmware 3.15+)" lowVersionID="95" highVersionID="95" numOuts="8" numFns="16" productID="202" comment="DH22A with update from September 2025" maxInputVolts="30V" maxMotorCurrent="2A" maxTotalCurrent="2A" connector="PluX22">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum Frontal</label>
@@ -678,7 +680,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="DH22A Gen. 2 (firmware 3.14.095+)" lowVersionID="95" highVersionID="95" numOuts="8" numFns="16" productID="202" comment="DH22A with update from May 2020" maxInputVolts="30V" maxMotorCurrent="2A" maxTotalCurrent="2A" connector="PluX22">
+      <model model="DH22A Gen. 2 (firmware 3.14.095+)" replacementModel="DH22A Gen. 2 (firmware 3.15.016+)" replacementFamily="query:Train Decoders (firmware 3.15+)" lowVersionID="95" highVersionID="95" numOuts="8" numFns="16" productID="202" comment="DH22A with update from September 2025" maxInputVolts="30V" maxMotorCurrent="2A" maxTotalCurrent="2A" connector="PluX22">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum Frontal</label>
@@ -726,7 +728,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="DH22B (firmware 3.14.095+)" lowVersionID="95" highVersionID="95" numOuts="10" numFns="16" productID="203" comment="DH22B" maxInputVolts="30V" maxMotorCurrent="2A" maxTotalCurrent="2A" connector="PluX22">
+      <model model="DH22B (firmware 3.14.095+)" replacementModel="DH22B (firmware 3.15.016+)" replacementFamily="query:Train Decoders (firmware 3.15+)" lowVersionID="95" highVersionID="95" numOuts="10" numFns="16" productID="203" comment="DH22B" maxInputVolts="30V" maxMotorCurrent="2A" maxTotalCurrent="2A" connector="PluX22">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum Frontal</label>
@@ -782,7 +784,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="DH24A (firmware 3.14.095+)" lowVersionID="95" highVersionID="95" numOuts="13" numFns="16" productID="204" comment="DH24A, 24-pin E24 direct plug. AUX10-12 cannot be mapped on this firmware (CV101-103 exist from firmware 3.15)" maxInputVolts="30V" maxMotorCurrent="0.7A" maxTotalCurrent="1.5A" connector="E24">
+      <model model="DH24A (firmware 3.14.095+)" replacementModel="DH24A (firmware 3.15.016+)" replacementFamily="query:Train Decoders (firmware 3.15+)" lowVersionID="95" highVersionID="95" numOuts="13" numFns="16" productID="204" comment="DH24A, 24-pin E24 direct plug. AUX10-12 cannot be mapped on this firmware (CV101-103 exist from firmware 3.15)" maxInputVolts="30V" maxMotorCurrent="0.7A" maxTotalCurrent="1.5A" connector="E24">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum Frontal</label>
@@ -850,7 +852,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="DHSP10A (firmware 3.14.095+)" lowVersionID="95" highVersionID="95" numOuts="8" numFns="16" productID="110" comment="DHSP10A-0 / -1 / -2 / -3 / -4, with integrated buffer capacitor (16 V, 470 uF)" maxInputVolts="30V" maxMotorCurrent="0.7A" maxTotalCurrent="1.5A" connector="Wires/NEM651">
+      <model model="DHSP10A (firmware 3.14.095+)" replacementModel="DHSP10A (firmware 3.15.016+)" replacementFamily="query:Train Decoders (firmware 3.15+)" lowVersionID="95" highVersionID="95" numOuts="8" numFns="16" productID="110" comment="DHSP10A-0 / -1 / -2 / -3 / -4, with integrated buffer capacitor (16 V, 470 uF)" maxInputVolts="30V" maxMotorCurrent="0.7A" maxTotalCurrent="1.5A" connector="Wires/NEM651">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum Frontal</label>
@@ -898,7 +900,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="PD05A (firmware 3.14.095+)" lowVersionID="95" highVersionID="95" numOuts="2" numFns="16" productID="131" comment="PD05A-0 / PD05A-2 / PD05A-3 with update from May 2020" maxInputVolts="30V" maxMotorCurrent="0.5A" maxTotalCurrent="0.5A" connector="Wires/NEM651">
+      <model model="PD05A (firmware 3.14.095+)" lowVersionID="95" highVersionID="95" numOuts="2" numFns="16" productID="131" comment="PD05A-0 / PD05A-2 / PD05A-3 with update from September 2025" maxInputVolts="30V" maxMotorCurrent="0.5A" maxTotalCurrent="0.5A" connector="Wires/NEM651">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum Frontal</label>
@@ -921,7 +923,7 @@
           <protocol>selectrix</protocol>
         </protocols>
       </model>
-      <model model="PD05A Gen. 2 (firmware 3.14.095+)" lowVersionID="95" highVersionID="95" numOuts="2" numFns="16" productID="131" comment="PD05A-0 / PD05A-2 / PD05A-3 with update from May 2020" maxInputVolts="30V" maxMotorCurrent="0.5A" maxTotalCurrent="0.5A" connector="Wires/NEM651">
+      <model model="PD05A Gen. 2 (firmware 3.14.095+)" lowVersionID="95" highVersionID="95" numOuts="2" numFns="16" productID="131" comment="PD05A-0 / PD05A-2 / PD05A-3 with update from September 2025" maxInputVolts="30V" maxMotorCurrent="0.5A" maxTotalCurrent="0.5A" connector="Wires/NEM651">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum Frontal</label>
@@ -944,7 +946,7 @@
           <protocol>selectrix</protocol>
         </protocols>
       </model>
-      <model model="PD06A (firmware 3.14.095+)" lowVersionID="95" highVersionID="95" numOuts="4" numFns="16" productID="132" comment="PD06A-0 / PD06A-3" maxInputVolts="18V" maxMotorCurrent="0.2A/6V" maxTotalCurrent="0.5A" connector="Wires">
+      <model model="PD06A (firmware 3.14.095+)" lowVersionID="95" highVersionID="95" numOuts="4" numFns="16" productID="132" comment="PD06A-0 / PD06A-3 with update from September 2025" maxInputVolts="18V" maxMotorCurrent="0.2A/6V" maxTotalCurrent="0.5A" connector="Wires">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum Frontal</label>
@@ -1005,7 +1007,7 @@
           <protocol>dcc</protocol>
         </protocols>
       </model>
-      <model model="PD12A (firmware 3.14.095+)" lowVersionID="95" highVersionID="95" numOuts="4" numFns="16" productID="130" comment="PD12A-0 / PD12A-2 / PD12A-3 / PD12A-4 with update from May 2020" maxInputVolts="30V" maxMotorCurrent="1A" maxTotalCurrent="1A" connector="PluX12">
+      <model model="PD12A (firmware 3.14.095+)" lowVersionID="95" highVersionID="95" numOuts="4" numFns="16" productID="130" comment="PD12A-0 / PD12A-2 / PD12A-3 / PD12A-4 with update from September 2025" maxInputVolts="30V" maxMotorCurrent="1A" maxTotalCurrent="1A" connector="PluX12">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum Frontal</label>
@@ -1035,7 +1037,7 @@
           <protocol>dcc</protocol>
         </protocols>
       </model>
-      <model model="PD18A (firmware 3.14.095+)" lowVersionID="95" highVersionID="95" numOuts="4" numFns="16" productID="134" comment="PD18A" maxInputVolts="30V" maxMotorCurrent="1A" maxTotalCurrent="1A" connector="Next18">
+      <model model="PD18A (firmware 3.14.095+)" lowVersionID="95" highVersionID="95" numOuts="4" numFns="16" productID="134" comment="PD18A with update from September 2025" maxInputVolts="30V" maxMotorCurrent="1A" maxTotalCurrent="1A" connector="Next18">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum Frontal</label>
@@ -1065,7 +1067,7 @@
           <protocol>dcc</protocol>
         </protocols>
       </model>
-      <model model="PD18MU (firmware 3.14.095+)" lowVersionID="95" highVersionID="95" numOuts="4" numFns="16" productID="134" comment="PD18MU" maxInputVolts="30V" maxMotorCurrent="1A" maxTotalCurrent="1A" connector="Next18">
+      <model model="PD18MU (firmware 3.14.095+)" lowVersionID="95" highVersionID="95" numOuts="4" numFns="16" productID="134" comment="PD18MU commissioned by DM-Toys" maxInputVolts="30V" maxMotorCurrent="1A" maxTotalCurrent="1A" connector="Next18">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum Frontal</label>
@@ -1095,7 +1097,7 @@
           <protocol>dcc</protocol>
         </protocols>
       </model>
-      <model model="PD21A (firmware 3.14.095+)" lowVersionID="95" highVersionID="95" numOuts="4" numFns="16" productID="133" comment="PD21A-4" maxInputVolts="30V" maxMotorCurrent="1A" maxTotalCurrent="1A" connector="21MTC">
+      <model model="PD21A (firmware 3.14.095+)" lowVersionID="95" highVersionID="95" numOuts="4" numFns="16" productID="133" comment="PD21A-4 with update from September 2025" maxInputVolts="30V" maxMotorCurrent="1A" maxTotalCurrent="1A" connector="21MTC">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum Frontal</label>

--- a/xml/decoders/Doehler_Haass_fw3.14_FH05B-22A.xml
+++ b/xml/decoders/Doehler_Haass_fw3.14_FH05B-22A.xml
@@ -12,6 +12,8 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" showEmptyPanes="no" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
+  <version version="1.1" author="Ronald Kuhn" lastUpdated="20260828"/>
+  <!-- replacementModel added and small change -->
   <version version="1" author="Pierre Billon" lastUpdated="20260725"/>
   <!--  Creation (new firmware 3.14.095).
         Based on Doehler_Haass_fw3.13_FH05B-22A.xml
@@ -23,7 +25,7 @@
         -->
   <decoder>
     <family name="Function Decoders (firmware 3.14+)" mfg="Doehler und Haass">
-      <model model="FH05B (firmware 3.14.095+)" lowVersionID="95" highVersionID="95" numOuts="6" numFns="16" productID="41" comment="FH05B-0 / FH05B-1 / FH05B-3 with update from May 2020" maxInputVolts="30V" maxTotalCurrent="0.5A" connector="Wires/NEM651">
+      <model model="FH05B (firmware 3.14.095+)" replacementModel="FH05B (firmware 3.15.016+)" replacementFamily="query:Function Decoders (firmware 3.15+)" lowVersionID="95" highVersionID="95" numOuts="6" numFns="16" productID="41" comment="FH05B-0 / FH05B-1 / FH05B-3 with update from September 2025" maxInputVolts="30V" maxTotalCurrent="0.5A" connector="Wires/NEM651">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum Frontal</label>
@@ -65,7 +67,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="FH16A (firmware 3.14.095+)" lowVersionID="95" highVersionID="95" numOuts="8" numFns="16" productID="150" comment="FH16A-4, PluX16 direct plug" maxInputVolts="30V" maxTotalCurrent="1.5A" connector="PluX16">
+      <model model="FH16A (firmware 3.14.095+)" replacementModel="FH16A (firmware 3.15.016+)" replacementFamily="query:Function Decoders (firmware 3.15+)" lowVersionID="95" highVersionID="95" numOuts="8" numFns="16" productID="150" comment="FH16A-4, PluX16 direct plug with update from September 2025" maxInputVolts="30V" maxTotalCurrent="1.5A" connector="PluX16">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum Frontal</label>
@@ -113,7 +115,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="FH18A (firmware 3.14.095+)" lowVersionID="95" highVersionID="95" numOuts="8" numFns="18" productID="170" comment="FH18A with update from May 2020" maxInputVolts="30V" maxTotalCurrent="1.0A" connector="Next18">
+      <model model="FH18A (firmware 3.14.095+)" replacementModel="FH05B (firmware 3.15.016+)" replacementFamily="query:Function Decoders (firmware 3.15+)" lowVersionID="95" highVersionID="95" numOuts="8" numFns="18" productID="170" comment="FH18A with update from September 2025" maxInputVolts="30V" maxTotalCurrent="1.0A" connector="Next18">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum Frontal</label>
@@ -161,7 +163,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="FH22A (firmware 3.14.095+)" lowVersionID="95" highVersionID="95" numOuts="8" numFns="18" productID="192" comment="FH22A with update from May 2020" maxInputVolts="30V" maxTotalCurrent="2.0A" connector="PluX22">
+      <model model="FH22A (firmware 3.14.095+)" replacementModel="FH18A (firmware 3.15.016+)" replacementFamily="query:Function Decoders (firmware 3.15+)" lowVersionID="95" highVersionID="95" numOuts="8" numFns="18" productID="192" comment="FH22A with update from September 2025" maxInputVolts="30V" maxTotalCurrent="2.0A" connector="PluX22">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum Frontal</label>

--- a/xml/decoders/Doehler_Haass_fw3.15_DH05-24A_PD05-21A.xml
+++ b/xml/decoders/Doehler_Haass_fw3.15_DH05-24A_PD05-21A.xml
@@ -12,6 +12,8 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" showEmptyPanes="no" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
+  <version version="1.1" author="Ronald Kuhn" lastUpdated="20260828"/>
+  <!-- PD series disabled until an update is available  -->
   <version version="1" author="Pierre Billon" lastUpdated="20260725"/>
   <!--  Creation (new firmware 3.15.016).
         Based on Doehler_Haass_fw3.14_DH05-24A_PD05-21A.xml
@@ -900,6 +902,8 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
+
+<!-- deactivated until an update is available
       <model model="PD05A (firmware 3.15.016+)" lowVersionID="16" highVersionID="16" numOuts="2" numFns="16" productID="131" comment="PD05A-0 / PD05A-2 / PD05A-3 with update from May 2020" maxInputVolts="30V" maxMotorCurrent="0.5A" maxTotalCurrent="0.5A" connector="Wires/NEM651">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
@@ -1127,6 +1131,8 @@
           <protocol>dcc</protocol>
         </protocols>
       </model>
+-->
+
     </family>
     <programming direct="yes" paged="yes" register="yes" ops="yes"/>
     <variables>

--- a/xml/decoders/Doehler_Haass_susi_sd_SH10A.xml
+++ b/xml/decoders/Doehler_Haass_susi_sd_SH10A.xml
@@ -14,10 +14,10 @@
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" showEmptyPanes="no" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
   <version version="8" author="Pierre Billon" lastUpdated="20210308"/>
   <!--  Added update paths to newest fw 1.14.050 -->
-  <version version="7" author="Ronald Kuhn, ronald@wirkuhns.de" lastUpdated="2020-05-05"/>
+  <version version="7" author="Ronald Kuhn" lastUpdated="2020-05-05"/>
   <!-- Added fw version 1.10+, 1.11+, 1.12+, and 1.13+
     -->
-  <version version="6" author="Ronald Kuhn, ronald@wirkuhns.de" lastUpdated="2016-12-14"/>
+  <version version="6" author="Ronald Kuhn" lastUpdated="2016-12-14"/>
   <!-- Added fw version 1.08+ and 1.09+
     -->
   <version version="5" author="Pierre Billon" lastUpdated="20151229"/>

--- a/xml/decoders/Doehler_Haass_susi_sd_fw1.14_SH05-10A.xml
+++ b/xml/decoders/Doehler_Haass_susi_sd_fw1.14_SH05-10A.xml
@@ -14,7 +14,7 @@
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" showEmptyPanes="no" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
   <version version="2" author="Pierre Billon" lastUpdated="20260727"/>
   <!--  Corrected the SH05A model comment  -->
-  <version version="1.1" author="Ronald Kuhn, ronald@wirkuhns.de" lastUpdated="20230731"/>
+  <version version="1.1" author="Ronald Kuhn" lastUpdated="20230731"/>
   <!--  Added update paths to newest fw 1.15.112 -->
   <version version="1" author="Pierre Billon" lastUpdated="20210312"/>
   <!--  Creation, based on Doehler_Haass_susi_sd_SH10A.xml

--- a/xml/decoders/Kuehn_5Moto.xml
+++ b/xml/decoders/Kuehn_5Moto.xml
@@ -15,9 +15,9 @@
   <version author="peter.brandenburg@t-online.de" version="1" lastUpdated="2006/01/30"/>
   <version author="Alain Le Marchand" version="2" lastUpdated="2014/03/02"/>
   <version author="Alain Le Marchand" version="3" lastUpdated="2014/07/20"/>
-  <version author="ronald@wirkuhns.de" version="4" lastUpdated="2016/05/07"/>
+  <version author="Ronald Kuhn" version="4" lastUpdated="2016/05/07"/>
   <version author="Alain Le Marchand" version="5" lastUpdated="2018/12/203"/>
-  <version author="ronald@wirkuhns.de" version="6" lastUpdated="2024/04/05"/>
+  <version author="Ronald Kuhn" version="6" lastUpdated="2024/04/05"/>
   <!-- Version 2 - Fixed manufacturer label from "Kuehn" to "Kuehn Ing." as per current decoderIndex.xml file (Alain Le Marchand) -->
   <!-- Version 3 - Refactoring (xinclude and standard panes) + fix CV55 interpretation (Alain Le Marchand) -->
   <!-- Version 3.1 - add translation (Enzo Fortuna) -->

--- a/xml/decoders/Kuehn_F060.xml
+++ b/xml/decoders/Kuehn_F060.xml
@@ -12,7 +12,7 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
-    <version author="ronald@wirkuhns.de" version="1" lastUpdated="2024/04/05"/>
+    <version author="Ronald Kuhn" version="1" lastUpdated="2024/04/05"/>
     <decoder>
     <family name="NMRA-DCC/Motorola" mfg="Kuehn Ing.">
     <model model="F060" numOuts="6" numFns="14" maxMotorCurrent="1.0 A" maxTotalCurrent="1.1 A">

--- a/xml/decoders/Kuehn_N45.xml
+++ b/xml/decoders/Kuehn_N45.xml
@@ -12,7 +12,7 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
-    <version author="ronald@wirkuhns.de" version="1" lastUpdated="2016/04/10"/>
+    <version author="Ronald Kuhn" version="1" lastUpdated="2016/04/10"/>
     <version author="Alain Le Marchand" version="2" lastUpdated="2018/12/23"/>
     <version author="Alain Le Marchand" version="3" lastUpdated="2019/01/09"/>
     <!-- Version 2 - Clarify CV55 name and tooltip + added Reset (Alain Le Marchand) -->

--- a/xml/decoders/Zimo_Unified_software_MX620v31.xml
+++ b/xml/decoders/Zimo_Unified_software_MX620v31.xml
@@ -12,7 +12,7 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
-  <version author="ronald@wirkuhns.de" version="2" lastUpdated="2016/05/06"/>
+  <version author="Ronald Kuhn" version="2" lastUpdated="2016/05/06"/>
   <!-- add translation to german in splitted files -->
   <version author="Mark Waters mark16w-jmri@yahoo.co.uk" version="1" lastUpdated="20121202"/>
   <!-- This decoder configuration file is based on the Zimo_MX640_v9.xml                     -->

--- a/xml/decoders/Zimo_Unified_software_MX621v31.5.xml
+++ b/xml/decoders/Zimo_Unified_software_MX621v31.5.xml
@@ -12,9 +12,9 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
-  <version author="ronald@wirkuhns.de" version="3" lastUpdated="2017/09/24"/>
+  <version author="Ronald Kuhn" version="3" lastUpdated="2017/09/24"/>
   <!-- add new CV=20 by FW 31.5 for extended consist adress -->
-  <version author="ronald@wirkuhns.de" version="2" lastUpdated="2016/05/06"/>
+  <version author="Ronald Kuhn" version="2" lastUpdated="2016/05/06"/>
   <!-- add translation to german in splitted files -->
   <version author="Mark Waters mark16w-jmri@yahoo.co.uk" version="1" lastUpdated="20121202"/>
   <!-- This decoder configuration file is based on the Zimo_MX640_v9.xml                     -->

--- a/xml/decoders/Zimo_Unified_software_MX621v31.xml
+++ b/xml/decoders/Zimo_Unified_software_MX621v31.xml
@@ -12,7 +12,7 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
-  <version author="ronald@wirkuhns.de" version="2" lastUpdated="2016/05/06"/>
+  <version author="Ronald Kuhn" version="2" lastUpdated="2016/05/06"/>
   <!-- add translation to german in splitted files -->
   <version author="Mark Waters mark16w-jmri@yahoo.co.uk" version="1" lastUpdated="20121202"/>
   <!-- This decoder configuration file is based on the Zimo_MX640_v9.xml                     -->

--- a/xml/decoders/Zimo_Unified_software_MX630v31.xml
+++ b/xml/decoders/Zimo_Unified_software_MX630v31.xml
@@ -12,7 +12,7 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
-  <version author="ronald@wirkuhns.de" version="2" lastUpdated="2016/05/06"/>
+  <version author="Ronald Kuhn" version="2" lastUpdated="2016/05/06"/>
   <!-- add translation to german in splitted files -->
   <version author="Mark Waters mark16w-jmri@yahoo.co.uk" version="1" lastUpdated="20121202"/>
   <!-- This decoder configuration file is based on the Zimo_MX640_v9.xml                     -->

--- a/xml/decoders/Zimo_Unified_software_v30_MX681.xml
+++ b/xml/decoders/Zimo_Unified_software_v30_MX681.xml
@@ -13,7 +13,7 @@
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
   <version author="Pierre Billon" version="2" lastUpdated="2026/08/06"/>
-  <version author="ronald@wirkuhns.de" version="1" lastUpdated="2016/12/14"/>
+  <version author="Ronald Kuhn" version="1" lastUpdated="2016/12/14"/>
   <decoder>
     <family name="Zimo Function Decoders" mfg="Zimo">
       <model model="MX681 version 30+" lowVersionID="30" highVersionID="30" maxInputVolts="10-35V" maxTotalCurrent="0.7A" productID="228" formFactor="N" numOuts="6" numFns="14">

--- a/xml/decoders/Zimo_Unified_software_v31.5_MX681.xml
+++ b/xml/decoders/Zimo_Unified_software_v31.5_MX681.xml
@@ -13,8 +13,8 @@
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
   <version author="Pierre Billon" version="3" lastUpdated="2026/08/06"/>
-  <version author="ronald@wirkuhns.de" version="2" lastUpdated="2017/09/25"/>
-  <version author="ronald@wirkuhns.de" version="1" lastUpdated="2016/12/14"/>
+  <version author="Ronald Kuhn" version="2" lastUpdated="2017/09/25"/>
+  <version author="Ronald Kuhn" version="1" lastUpdated="2016/12/14"/>
   <decoder>
     <family name="Zimo Function Decoders" mfg="Zimo">
       <model model="MX681 version 31.5+" lowVersionID="31" highVersionID="31" maxInputVolts="10-35V" maxTotalCurrent="0.7A" productID="228" formFactor="N" numOuts="6" numFns="14">

--- a/xml/decoders/Zimo_Unified_software_v32_MX634.xml
+++ b/xml/decoders/Zimo_Unified_software_v32_MX634.xml
@@ -12,7 +12,7 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
-  <version author="ronald@wirkuhns.de" version="2" lastUpdated="2016/05/06"/>
+  <version author="Ronald Kuhn" version="2" lastUpdated="2016/05/06"/>
   <!-- add translation to german in splitted files -->
   <version author="Mark Waters mark16jmri@mybtinternet.com" version="1" lastUpdated="20150207"/>
   <!-- Based on the "2014 04 20" English version of the ZIMO "Small decoder manual	     -->

--- a/xml/decoders/Zimo_Unified_software_v32_MX649.xml
+++ b/xml/decoders/Zimo_Unified_software_v32_MX649.xml
@@ -12,9 +12,9 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
-  <version author="ronald@wirkuhns.de" version="3" lastUpdated="2019/05/01"/>
+  <version author="Ronald Kuhn" version="3" lastUpdated="2019/05/01"/>
   <!-- set highVersionID from 42 to 32 -->
-  <version author="ronald@wirkuhns.de" version="2" lastUpdated="2016/12/14"/>
+  <version author="Ronald Kuhn" version="2" lastUpdated="2016/12/14"/>
   <!-- add translation to german in splitted files -->
   <version author="Mark Waters mark16jmri@mybtinternet.com" version="1" lastUpdated="20160123"/>
   <!-- This decoder configuration file is based on the Zimo_MX640_v9.xml                     -->

--- a/xml/decoders/Zimo_Unified_software_v32_MX685.xml
+++ b/xml/decoders/Zimo_Unified_software_v32_MX685.xml
@@ -13,7 +13,7 @@
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
   <version author="Pierre Billon" version="2" lastUpdated="2026/08/06"/>
-  <version author="ronald@wirkuhns.de" version="1" lastUpdated="2016/12/14"/>
+  <version author="Ronald Kuhn" version="1" lastUpdated="2016/12/14"/>
   <decoder>
     <family name="Zimo Function Decoders" mfg="Zimo">
       <model model="MX685 version 32+" lowVersionID="32" highVersionID="40" maxInputVolts="10-35V" maxTotalCurrent="1.0A" productID="226" formFactor="N" numOuts="8" numFns="14">

--- a/xml/decoders/Zimo_Unified_software_v37_MX616.xml
+++ b/xml/decoders/Zimo_Unified_software_v37_MX616.xml
@@ -12,7 +12,7 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
-  <version author="Ronald Kuhn, ronald@wirkuhns.de" version="1.2" lastUpdated="20200502"/>
+  <version author="Ronald Kuhn" version="1.2" lastUpdated="20200502"/>
   <!-- v1.2,  added replacementModel for v39,  Ronald Kuhn, 02 May 2020 -->
   <!-- v1.3,  include CV's 190-191, Ulrich Gerlach 25 March 2023        --> 
   <version author="Ronald Kuhn   ronald@wirkuhns.de" version="1.1" lastUpdated="20190429"/>

--- a/xml/decoders/Zimo_Unified_software_v37_MX617.xml
+++ b/xml/decoders/Zimo_Unified_software_v37_MX617.xml
@@ -12,7 +12,7 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
-  <version author="Ronald Kuhn, ronald@wirkuhns.de" version="1.2" lastUpdated="20200319"/>
+  <version author="Ronald Kuhn" version="1.2" lastUpdated="20200319"/>
   <!-- v1.2,  added replacementModel for v39,  Ronald Kuhn, 02 May 2020 -->
   <!-- v1.3,  include CV's 190-191, Ulrich Gerlach 25 March 2023        --> 
   <version author="Ronald Kuhn   ronald@wirkuhns.de" version="1.1" lastUpdated="20190429"/>

--- a/xml/decoders/Zimo_Unified_software_v37_MX618.xml
+++ b/xml/decoders/Zimo_Unified_software_v37_MX618.xml
@@ -12,7 +12,7 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
-  <version author="Ronald Kuhn, ronald@wirkuhns.de" version="3" lastUpdated="20200502"/>
+  <version author="Ronald Kuhn" version="3" lastUpdated="20200502"/>
   <!-- v3.1,  added replacementModel for v39,  Ronald Kuhn, 02 May 2020 -->
   <!-- v3.2,  include CV's 190-191, Ulrich Gerlach 25 March 2023        --> 
   <version author="Ronald Kuhn ronald@wirkuhns.de" version="2" lastUpdated="20190422"/>

--- a/xml/decoders/Zimo_Unified_software_v37_MX620.xml
+++ b/xml/decoders/Zimo_Unified_software_v37_MX620.xml
@@ -12,10 +12,10 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
-  <version author="Ronald Kuhn, ronald@wirkuhns.de" version="2" lastUpdated="20200502"/>
+  <version author="Ronald Kuhn" version="2" lastUpdated="20200502"/>
   <!-- v2.1,  added replacementModel for v39,  Ronald Kuhn, 02 May 2020 -->
   <!-- v2.2,  include CV's 190-191, Ulrich Gerlach 25 March 2023        --> 
-  <version author="ronald@wirkuhns.de" version="1" lastUpdated="2019/04/25"/>
+  <version author="Ronald Kuhn" version="1" lastUpdated="2019/04/25"/>
   <!-- This decoder configuration file is based on other Zimo non-sound decoders             -->
   <!-- Tested on a MX620N, which reported v37.8 firmware and                                 -->
   <!-- decoderID 201 (which matches manuals), on 25 April 2019 (RK)                          -->

--- a/xml/decoders/Zimo_Unified_software_v37_MX622.xml
+++ b/xml/decoders/Zimo_Unified_software_v37_MX622.xml
@@ -12,10 +12,10 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
-  <version author="Ronald Kuhn, ronald@wirkuhns.de" version="3" lastUpdated="20200319"/>
+  <version author="Ronald Kuhn" version="3" lastUpdated="20200319"/>
   <!-- v3.1,  added replacementModel for v39,  Ronald Kuhn, 02 May 2020 -->
   <!-- v3.2,  include CV's 190-191, Ulrich Gerlach 25 March 2023        --> 
-  <version author="Ronald Kuhn, ronald@wirkuhns.de" version="2" lastUpdated="20190422"/>
+  <version author="Ronald Kuhn" version="2" lastUpdated="20190422"/>
   <!-- added FW v37-options                                                                  -->
   <!--                                                                                       -->
   <!--   File is not tested cause no decoder of this type is in my collection.               -->

--- a/xml/decoders/Zimo_Unified_software_v37_MX623.xml
+++ b/xml/decoders/Zimo_Unified_software_v37_MX623.xml
@@ -12,10 +12,10 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
-  <version author="Ronald Kuhn, ronald@wirkuhns.de" version="3" lastUpdated="20200319"/>
+  <version author="Ronald Kuhn" version="3" lastUpdated="20200319"/>
   <!-- v3.1,  added replacementModel for v39,  Ronald Kuhn, 02 May 2020 -->
   <!-- v3.2,  include CV's 190-191, Ulrich Gerlach 25 March 2023        --> 
-  <version author="Ronald Kuhn, ronald@wirkuhns.de" version="2" lastUpdated="20190422"/>
+  <version author="Ronald Kuhn" version="2" lastUpdated="20190422"/>
   <!-- added FW v37-options                                                                               -->
   <!--                                                                                       -->
   <!--   File is not tested cause no decoder of this type is in my collection.               -->

--- a/xml/decoders/Zimo_Unified_software_v37_MX630.xml
+++ b/xml/decoders/Zimo_Unified_software_v37_MX630.xml
@@ -12,7 +12,7 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
-  <version author="ronald@wirkuhns.de" version="1" lastUpdated="2019/04/25"/>
+  <version author="Ronald Kuhn" version="1" lastUpdated="2019/04/25"/>
   <!-- This decoder configuration file is based on other Zimo non-sound decoders             -->
   <!-- Tested on a MX630P16, which reported v37.8 firmware and                               -->
   <!-- decoderID 218 (which matches manuals), on 25 April 2019 (RK)                          -->

--- a/xml/decoders/Zimo_Unified_software_v37_MX633.xml
+++ b/xml/decoders/Zimo_Unified_software_v37_MX633.xml
@@ -12,7 +12,7 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
-  <version author="Ronald Kuhn, ronald@wirkuhns.de" version="2" lastUpdated="20190422"/>
+  <version author="Ronald Kuhn" version="2" lastUpdated="20190422"/>
   <!-- added FW v37-options                                                                               -->
   <!--                                                                                       -->
   <!--   File is not tested cause no decoder of this type is in my collection.               -->

--- a/xml/decoders/Zimo_Unified_software_v37_MX634.xml
+++ b/xml/decoders/Zimo_Unified_software_v37_MX634.xml
@@ -12,9 +12,9 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
-  <version author="ronald@wirkuhns.de" version="3" lastUpdated="2019/04/25"/>
+  <version author="Ronald Kuhn" version="3" lastUpdated="2019/04/25"/>
   <!-- added version 37 firmware capabilities, tested with MX634R with FW 37.8 -->
-  <version author="ronald@wirkuhns.de" version="2" lastUpdated="2016/05/06"/>
+  <version author="Ronald Kuhn" version="2" lastUpdated="2016/05/06"/>
   <!-- add translation to german in splitted files -->
   <version author="Mark Waters mark16jmri@mybtinternet.com" version="1" lastUpdated="20150207"/>
   <!-- Based on the "2014 04 20" English version of the ZIMO "Small decoder manual	     -->

--- a/xml/decoders/Zimo_Unified_software_v37_MX635.xml
+++ b/xml/decoders/Zimo_Unified_software_v37_MX635.xml
@@ -12,7 +12,7 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
-  <version author="Ronald Kuhn, ronald@wirkuhns.de" version="1" lastUpdated="20190423"/>
+  <version author="Ronald Kuhn" version="1" lastUpdated="20190423"/>
   <!-- Initial Version for that decoder with FW v37-options                                  -->
   <!-- Based on the "2014 04 20" English version of the ZIMO "Small decoder manual           -->
   <!--                                                                                       -->

--- a/xml/decoders/Zimo_Unified_software_v37_MX636.xml
+++ b/xml/decoders/Zimo_Unified_software_v37_MX636.xml
@@ -12,7 +12,7 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
-  <version author="Ronald Kuhn, ronald@wirkuhns.de" version="1" lastUpdated="20190423"/>
+  <version author="Ronald Kuhn" version="1" lastUpdated="20190423"/>
   <!-- Initial Version for that decoder with FW v37-options                                  -->
   <!--                                                                                       -->
   <!-- This decoder XML is meant to be used with the "Comprehensive" programmer format.      -->

--- a/xml/decoders/Zimo_Unified_software_v37_MX637.xml
+++ b/xml/decoders/Zimo_Unified_software_v37_MX637.xml
@@ -12,7 +12,7 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
-  <version author="Ronald Kuhn, ronald@wirkuhns.de" version="1" lastUpdated="20190423"/>
+  <version author="Ronald Kuhn" version="1" lastUpdated="20190423"/>
   <!-- Initial Version for that decoder with FW v37-options                                  -->
   <!--                                                                                       -->
   <!-- This decoder XML is meant to be used with the "Comprehensive" programmer format.      -->

--- a/xml/decoders/Zimo_Unified_software_v37_MX638.xml
+++ b/xml/decoders/Zimo_Unified_software_v37_MX638.xml
@@ -12,13 +12,13 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
-  <version author="ronald@wirkuhns.de" version="3" lastUpdated="2019/04/17"/>
+  <version author="Ronald Kuhn" version="3" lastUpdated="2019/04/17"/>
   <!-- added version 37 firmware capabilities                                                -->
   <!--                                                                                       -->
   <!--   File is not tested cause no decoder of this type is in my collection.               -->
   <!--   If you find any errors please contact me by mail.                                   -->
   <!--                                                                                       -->
-  <version author="ronald@wirkuhns.de" version="2" lastUpdated="2016/05/06"/>
+  <version author="Ronald Kuhn" version="2" lastUpdated="2016/05/06"/>
   <!-- add translation to german in splitted files                                           -->
   <version author="Mark Waters mark16jmri@mybtinternet.com" version="1" lastUpdated="20150207"/>
   <!-- Based on the "2014 04 20" English version of the ZIMO "Small decoder manual           -->

--- a/xml/decoders/Zimo_Unified_software_v39_MX60x-MX63x.xml
+++ b/xml/decoders/Zimo_Unified_software_v39_MX60x-MX63x.xml
@@ -12,7 +12,7 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
-  <version author="ronald@wirkuhns.de" version="1" lastUpdated="2020/05/02"/>
+  <version author="Ronald Kuhn" version="1" lastUpdated="2020/05/02"/>
   <!-- This decoder configuration file is based on other Zimo non-sound decoders             -->
   <!-- Tested on a MX630P16, which reported v37.8 firmware and                               -->
   <!-- decoderID 218 (which matches manuals), on 25 April 2019 (RK)                          -->
@@ -25,7 +25,7 @@
   <!-- variables on the proper pane of the Comprehensive programmer.                         -->
   <!-- V 1 new file for decoder with FW v37                                                  -->
   <!--                                                                                       -->
-  <version author="ronald@wirkuhns.de" version="1.1" lastUpdated="2020/02/24"/>
+  <version author="Ronald Kuhn" version="1.1" lastUpdated="2020/02/24"/>
   <!-- v1.1,  merged MX6xx-Non-Sound-Decoder and added version 39 firmware capabilities,  Ronald Kuhn, 22 April 2020 -->
   <!-- v1.2,  added replacement-options version 40 firmware capabilities,  Ronald Kuhn, 30 November 2021 -->
   <version author="Ronald Kuhn   ronald@wirkuhns.de" version="1.3" lastUpdated="2022/10/30"/>

--- a/xml/decoders/Zimo_Unified_software_v40_MX60x-MX63x.xml
+++ b/xml/decoders/Zimo_Unified_software_v40_MX60x-MX63x.xml
@@ -12,7 +12,7 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
-  <version author="ronald@wirkuhns.de" version="1" lastUpdated="2021/12/03"/>
+  <version author="Ronald Kuhn" version="1" lastUpdated="2021/12/03"/>
   <!-- This decoder configuration file is based on other Zimo non-sound decoders             -->
   <!-- Tested on a MX630P16, which reported v37.8 firmware and                               -->
   <!-- decoderID 218 (which matches manuals), on 25 April 2019 (RK)                          -->


### PR DESCRIPTION
Firmware version 3.15 is not available for the PD series. It has therefore been disabled here for the time being. The replacement function has been added for some models. Author mail address removed.