### PR TITLE
Two DecoderPro improvements

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -488,6 +488,10 @@
                 you could directly change the entry in the DecoderPro table to create
                 a duplicate. You can still edit the ID, but creating entries with
                 duplicate IDs are no longer allowed.</li>
+            <li>Fixed a bug introduced in JMRI 5.17.2 which would sometimes
+                cause DecoderPro to write incorrect output addresses to a DS64</li>
+            <li>You can now change the board ID of e.g. DS64 and similar boards in DecoderPro
+                as mentioned in the Basic panel for those.</li>
         </ul>
 
    <h3>Dispatcher</h3>

--- a/java/src/jmri/jmrit/symbolicprog/DecVariableValue.java
+++ b/java/src/jmri/jmrit/symbolicprog/DecVariableValue.java
@@ -300,7 +300,7 @@ public class DecVariableValue extends VariableValue
             }
             default:
                 JTextField value = new VarTextField(_value.getDocument(), _value.getText(), fieldLength(), this);
-                if (getReadOnly() || getInfoOnly()) {
+                if (getReadOnly()) {
                     value.setEditable(false);
                 }
                 reps.add(value);

--- a/java/src/jmri/jmrit/symbolicprog/SplitEnumVariableValue.java
+++ b/java/src/jmri/jmrit/symbolicprog/SplitEnumVariableValue.java
@@ -150,9 +150,22 @@ public class SplitEnumVariableValue extends VariableValue
 
         // have to do when list is complete
         for (int i = 0; i < cvCount; i++) {
-            cvList.get(i).thisCV.addPropertyChangeListener(this);
-            cvList.get(i).thisCV.setState(ValueState.FROMFILE);
+            var thisCV = cvList.get(i).thisCV;
+
+            // only add property listener once
+            boolean alreadyDone = false;
+            for (int j = 0; j < i; j++) {
+                if (thisCV.equals(cvList.get(j).thisCV) ) {
+                    alreadyDone = true;
+                    break;
+                }
+            }
+            if (! alreadyDone) {
+                thisCV.addPropertyChangeListener(this);
+            }
+            thisCV.setState(ValueState.FROMFILE);
         }
+
         treeNodes.addLast(new DefaultMutableTreeNode(""));
     }
 
@@ -256,7 +269,9 @@ public class SplitEnumVariableValue extends VariableValue
         }
         cv1.addPropertyChangeListener(this);
         cv1.setState(ValueState.FROMFILE);
-        cv2.addPropertyChangeListener(this);
+        if (! cv1.equals(cv2)) {  // only add listener once
+            cv2.addPropertyChangeListener(this);
+        }
         cv2.setState(ValueState.FROMFILE);
     }
 

--- a/java/src/jmri/jmrit/symbolicprog/SplitVariableValue.java
+++ b/java/src/jmri/jmrit/symbolicprog/SplitVariableValue.java
@@ -138,8 +138,20 @@ public class SplitVariableValue extends VariableValue
 
         // have to do when list is complete
         for (int i = 0; i < cvCount; i++) {
-            cvList.get(i).thisCV.addPropertyChangeListener(this);
-            cvList.get(i).thisCV.setState(ValueState.FROMFILE);
+            var thisCV = cvList.get(i).thisCV;
+
+            // only add property listener once
+            boolean alreadyDone = false;
+            for (int j = 0; j < i; j++) {
+                if (thisCV.equals(cvList.get(j).thisCV) ) {
+                    alreadyDone = true;
+                    break;
+                }
+            }
+            if (! alreadyDone) {
+                thisCV.addPropertyChangeListener(this);
+            }
+            thisCV.setState(ValueState.FROMFILE);
         }
     }
 
@@ -725,6 +737,7 @@ public class SplitVariableValue extends VariableValue
         log.debug("Variable={} source={}; property {} changed from {} to {}", _name, e.getSource().toString(), e.getPropertyName(), e.getOldValue(),e.getNewValue());
         // notification from CV; check for Value being changed
         if (e.getPropertyName().equals("Busy") && e.getNewValue().equals(Boolean.FALSE)) {
+            log.debug("*** Busy -> false transition from {}", e.getSource());
             // busy transitions drive the state
             if (_progState != IDLE) {
                 log.debug("Variable={} source={}; getState() = {}", _name, e.getSource().toString(), (cvList.get(Math.abs(_progState) - 1).thisCV).getState());
@@ -739,7 +752,7 @@ public class SplitVariableValue extends VariableValue
                     retry = 0;
                     if (Math.abs(_progState) < cvCount) {   // read next CV
                         _progState++;
-                        log.debug("Reading CV={}", cvList.get(Math.abs(_progState) - 1).cvName);
+                        log.debug("Reading CV={} with state {}", cvList.get(Math.abs(_progState) - 1).cvName, _progState);
                         (cvList.get(Math.abs(_progState) - 1).thisCV).read(_status);
                     } else {  // finally done, set not busy
                         log.debug("Variable={}; Busy goes false with success READING _progState {}", _name, _progState);

--- a/xml/decoders/Digitrax_DS64.xml
+++ b/xml/decoders/Digitrax_DS64.xml
@@ -499,24 +499,24 @@
 
 <!-- output addresses -->
 
-          <!-- same CV, leading zero for SplitVal bug-->
-          <variable item="Output 1 Address" CV="115.25.00,115.25.0" 
+          <!-- same CV -->
+          <variable item="Output 1 Address" CV="115.25.0,115.25.0" 
                 default="1" mask="XXXXXVVVVVVV VVVVXXXXXXXX">
             <splitVal min="1" max="2047" offset="1"/>
           </variable>
-          <!-- same CV, leading zero for SplitVal bug-->
-          <variable item="Output 2 Address" CV="115.25.00,115.25.0"
+          <!-- same CV -->
+          <variable item="Output 2 Address" CV="115.25.0,115.25.0"
                 default="1" mask="XXXXXVVVVVVVXXXXXXXXXXXXXXXX VVVVXXXXXXXXXXXXXXXXXXXXXXXX">
             <splitVal min="1" max="2047" offset="1"/>
           </variable>
 
-          <!-- same CV, leading zero for SplitVal bug-->
-          <variable item="Output 3 Address" CV="115.25.01,115.25.1" 
+          <!-- same CV -->
+          <variable item="Output 3 Address" CV="115.25.1,115.25.1" 
                 default="1" mask="XXXXXVVVVVVV VVVVXXXXXXXX">
             <splitVal min="1" max="2047" offset="1"/>
           </variable>
-          <!-- same CV, leading zero for SplitVal bug-->
-          <variable item="Output 4 Address" CV="115.25.01,115.25.1"
+          <!-- same CV -->
+          <variable item="Output 4 Address" CV="115.25.1,115.25.1"
                 default="1" mask="XXXXXVVVVVVVXXXXXXXXXXXXXXXX VVVVXXXXXXXXXXXXXXXXXXXXXXXX">
             <splitVal min="1" max="2047" offset="1"/>
           </variable>
@@ -537,8 +537,8 @@
                   </enumChoice>
               </enumVal>
           </variable>
-          <!-- same CV, leading zero for SplitVal bug-->
-          <variable item="Turnout 1 Address Route 1" CV="115.25.016,115.25.16" 
+          <!-- same CV -->
+          <variable item="Turnout 1 Address Route 1" CV="115.25.16,115.25.16" 
                 default="1" mask="XXXXXVVVVVVV VVVVXXXXXXXX">
             <qualifier>
                 <variableref>Turnout 1    Mode Route 1</variableref>
@@ -562,8 +562,8 @@
                   </enumChoice>
               </enumVal>
           </variable>
-          <!-- same CV, leading zero for SplitVal bug-->
-          <variable item="Turnout 2 Address Route 1" CV="115.25.016,115.25.16"
+          <!-- same CV -->
+          <variable item="Turnout 2 Address Route 1" CV="115.25.16,115.25.16"
                 default="1" mask="XXXXXVVVVVVVXXXXXXXXXXXXXXXX VVVVXXXXXXXXXXXXXXXXXXXXXXXX">
             <qualifier>
                 <variableref>Turnout 2    Mode Route 1</variableref>
@@ -587,8 +587,8 @@
                   </enumChoice>
               </enumVal>
           </variable>
-          <!-- same CV, leading zero for SplitVal bug-->
-          <variable item="Turnout 3 Address Route 1" CV="115.25.017,115.25.17" 
+          <!-- same CV -->
+          <variable item="Turnout 3 Address Route 1" CV="115.25.17,115.25.17" 
                 default="1" mask="XXXXXVVVVVVV VVVVXXXXXXXX">
             <qualifier>
                 <variableref>Turnout 3    Mode Route 1</variableref>
@@ -612,8 +612,8 @@
                   </enumChoice>
               </enumVal>
           </variable>
-          <!-- same CV, leading zero for SplitVal bug-->
-          <variable item="Turnout 4 Address Route 1" CV="115.25.017,115.25.17" 
+          <!-- same CV -->
+          <variable item="Turnout 4 Address Route 1" CV="115.25.17,115.25.17" 
                 default="1" mask="XXXXXVVVVVVVXXXXXXXXXXXXXXXX VVVVXXXXXXXXXXXXXXXXXXXXXXXX">
             <qualifier>
                 <variableref>Turnout 4    Mode Route 1</variableref>
@@ -637,8 +637,8 @@
                   </enumChoice>
               </enumVal>
           </variable>
-          <!-- same CV, leading zero for SplitVal bug-->
-          <variable item="Turnout 5 Address Route 1" CV="115.25.018,115.25.18" 
+          <!-- same CV -->
+          <variable item="Turnout 5 Address Route 1" CV="115.25.18,115.25.18" 
                 default="1" mask="XXXXXVVVVVVV VVVVXXXXXXXX">
             <qualifier>
                 <variableref>Turnout 5    Mode Route 1</variableref>
@@ -662,8 +662,8 @@
                   </enumChoice>
               </enumVal>
           </variable>
-          <!-- same CV, leading zero for SplitVal bug-->
-          <variable item="Turnout 6 Address Route 1" CV="115.25.018,115.25.18" 
+          <!-- same CV -->
+          <variable item="Turnout 6 Address Route 1" CV="115.25.18,115.25.18" 
                 default="1" mask="XXXXXVVVVVVVXXXXXXXXXXXXXXXX VVVVXXXXXXXXXXXXXXXXXXXXXXXX">
             <qualifier>
                 <variableref>Turnout 6    Mode Route 1</variableref>
@@ -687,8 +687,8 @@
                   </enumChoice>
               </enumVal>
           </variable>
-          <!-- same CV, leading zero for SplitVal bug-->
-          <variable item="Turnout 7 Address Route 1" CV="115.25.019,115.25.19" 
+          <!-- same CV -->
+          <variable item="Turnout 7 Address Route 1" CV="115.25.19,115.25.19" 
                 default="1" mask="XXXXXVVVVVVV VVVVXXXXXXXX">
             <qualifier>
                 <variableref>Turnout 7    Mode Route 1</variableref>
@@ -712,8 +712,8 @@
                   </enumChoice>
               </enumVal>
           </variable>
-          <!-- same CV, leading zero for SplitVal bug-->
-          <variable item="Turnout 8 Address Route 1" CV="115.25.019,115.25.19" 
+          <!-- same CV -->
+          <variable item="Turnout 8 Address Route 1" CV="115.25.19,115.25.19" 
                 default="1" mask="XXXXXVVVVVVVXXXXXXXXXXXXXXXX VVVVXXXXXXXXXXXXXXXXXXXXXXXX">
             <qualifier>
                 <variableref>Turnout 8    Mode Route 1</variableref>
@@ -739,8 +739,8 @@
                   </enumChoice>
               </enumVal>
           </variable>
-          <!-- same CV, leading zero for SplitVal bug-->
-          <variable item="Turnout 1 Address Route 2" CV="115.25.020,115.25.20" 
+          <!-- same CV -->
+          <variable item="Turnout 1 Address Route 2" CV="115.25.20,115.25.20" 
                 default="1" mask="XXXXXVVVVVVV VVVVXXXXXXXX">
             <qualifier>
                 <variableref>Turnout 1    Mode Route 2</variableref>
@@ -764,8 +764,8 @@
                   </enumChoice>
               </enumVal>
           </variable>
-          <!-- same CV, leading zero for SplitVal bug-->
-          <variable item="Turnout 2 Address Route 2" CV="115.25.020,115.25.20"
+          <!-- same CV -->
+          <variable item="Turnout 2 Address Route 2" CV="115.25.20,115.25.20"
                 default="1" mask="XXXXXVVVVVVVXXXXXXXXXXXXXXXX VVVVXXXXXXXXXXXXXXXXXXXXXXXX">
             <qualifier>
                 <variableref>Turnout 2    Mode Route 2</variableref>
@@ -789,8 +789,8 @@
                   </enumChoice>
               </enumVal>
           </variable>
-          <!-- same CV, leading zero for SplitVal bug-->
-          <variable item="Turnout 3 Address Route 2" CV="115.25.021,115.25.21" 
+          <!-- same CV -->
+          <variable item="Turnout 3 Address Route 2" CV="115.25.21,115.25.21" 
                 default="1" mask="XXXXXVVVVVVV VVVVXXXXXXXX">
             <qualifier>
                 <variableref>Turnout 3    Mode Route 2</variableref>
@@ -814,8 +814,8 @@
                   </enumChoice>
               </enumVal>
           </variable>
-          <!-- same CV, leading zero for SplitVal bug-->
-          <variable item="Turnout 4 Address Route 2" CV="115.25.021,115.25.21" 
+          <!-- same CV -->
+          <variable item="Turnout 4 Address Route 2" CV="115.25.21,115.25.21" 
                 default="1" mask="XXXXXVVVVVVVXXXXXXXXXXXXXXXX VVVVXXXXXXXXXXXXXXXXXXXXXXXX">
             <qualifier>
                 <variableref>Turnout 4    Mode Route 2</variableref>
@@ -839,8 +839,8 @@
                   </enumChoice>
               </enumVal>
           </variable>
-          <!-- same CV, leading zero for SplitVal bug-->
-          <variable item="Turnout 5 Address Route 2" CV="115.25.022,115.25.22" 
+          <!-- same CV -->
+          <variable item="Turnout 5 Address Route 2" CV="115.25.22,115.25.22" 
                 default="1" mask="XXXXXVVVVVVV VVVVXXXXXXXX">
             <qualifier>
                 <variableref>Turnout 5    Mode Route 2</variableref>
@@ -864,8 +864,8 @@
                   </enumChoice>
               </enumVal>
           </variable>
-          <!-- same CV, leading zero for SplitVal bug-->
-          <variable item="Turnout 6 Address Route 2" CV="115.25.022,115.25.22" 
+          <!-- same CV -->
+          <variable item="Turnout 6 Address Route 2" CV="115.25.22,115.25.22" 
                 default="1" mask="XXXXXVVVVVVVXXXXXXXXXXXXXXXX VVVVXXXXXXXXXXXXXXXXXXXXXXXX">
             <qualifier>
                 <variableref>Turnout 6    Mode Route 2</variableref>
@@ -889,8 +889,8 @@
                   </enumChoice>
               </enumVal>
           </variable>
-          <!-- same CV, leading zero for SplitVal bug-->
-          <variable item="Turnout 7 Address Route 2" CV="115.25.023,115.25.23" 
+          <!-- same CV -->
+          <variable item="Turnout 7 Address Route 2" CV="115.25.23,115.25.23" 
                 default="1" mask="XXXXXVVVVVVV VVVVXXXXXXXX">
             <qualifier>
                 <variableref>Turnout 7    Mode Route 2</variableref>
@@ -914,8 +914,8 @@
                   </enumChoice>
               </enumVal>
           </variable>
-          <!-- same CV, leading zero for SplitVal bug-->
-          <variable item="Turnout 8 Address Route 2" CV="115.25.023,115.25.23" 
+          <!-- same CV -->
+          <variable item="Turnout 8 Address Route 2" CV="115.25.23,115.25.23" 
                 default="1" mask="XXXXXVVVVVVVXXXXXXXXXXXXXXXX VVVVXXXXXXXXXXXXXXXXXXXXXXXX">
             <qualifier>
                 <variableref>Turnout 8    Mode Route 2</variableref>
@@ -941,8 +941,8 @@
                   </enumChoice>
               </enumVal>
           </variable>
-          <!-- same CV, leading zero for SplitVal bug-->
-          <variable item="Turnout 1 Address Route 3" CV="115.25.024,115.25.24" 
+          <!-- same CV -->
+          <variable item="Turnout 1 Address Route 3" CV="115.25.24,115.25.24" 
                 default="1" mask="XXXXXVVVVVVV VVVVXXXXXXXX">
             <qualifier>
                 <variableref>Turnout 1    Mode Route 3</variableref>
@@ -966,8 +966,8 @@
                   </enumChoice>
               </enumVal>
           </variable>
-          <!-- same CV, leading zero for SplitVal bug-->
-          <variable item="Turnout 2 Address Route 3" CV="115.25.024,115.25.24"
+          <!-- same CV -->
+          <variable item="Turnout 2 Address Route 3" CV="115.25.24,115.25.24"
                 default="1" mask="XXXXXVVVVVVVXXXXXXXXXXXXXXXX VVVVXXXXXXXXXXXXXXXXXXXXXXXX">
             <qualifier>
                 <variableref>Turnout 2    Mode Route 3</variableref>
@@ -991,8 +991,8 @@
                   </enumChoice>
               </enumVal>
           </variable>
-          <!-- same CV, leading zero for SplitVal bug-->
-          <variable item="Turnout 3 Address Route 3" CV="115.25.025,115.25.25" 
+          <!-- same CV -->
+          <variable item="Turnout 3 Address Route 3" CV="115.25.25,115.25.25" 
                 default="1" mask="XXXXXVVVVVVV VVVVXXXXXXXX">
             <qualifier>
                 <variableref>Turnout 3    Mode Route 3</variableref>
@@ -1016,8 +1016,8 @@
                   </enumChoice>
               </enumVal>
           </variable>
-          <!-- same CV, leading zero for SplitVal bug-->
-          <variable item="Turnout 4 Address Route 3" CV="115.25.025,115.25.25" 
+          <!-- same CV -->
+          <variable item="Turnout 4 Address Route 3" CV="115.25.25,115.25.25" 
                 default="1" mask="XXXXXVVVVVVVXXXXXXXXXXXXXXXX VVVVXXXXXXXXXXXXXXXXXXXXXXXX">
             <qualifier>
                 <variableref>Turnout 4    Mode Route 3</variableref>
@@ -1041,8 +1041,8 @@
                   </enumChoice>
               </enumVal>
           </variable>
-          <!-- same CV, leading zero for SplitVal bug-->
-          <variable item="Turnout 5 Address Route 3" CV="115.25.026,115.25.26" 
+          <!-- same CV -->
+          <variable item="Turnout 5 Address Route 3" CV="115.25.26,115.25.26" 
                 default="1" mask="XXXXXVVVVVVV VVVVXXXXXXXX">
             <qualifier>
                 <variableref>Turnout 5    Mode Route 3</variableref>
@@ -1066,8 +1066,8 @@
                   </enumChoice>
               </enumVal>
           </variable>
-          <!-- same CV, leading zero for SplitVal bug-->
-          <variable item="Turnout 6 Address Route 3" CV="115.25.026,115.25.26" 
+          <!-- same CV -->
+          <variable item="Turnout 6 Address Route 3" CV="115.25.26,115.25.26" 
                 default="1" mask="XXXXXVVVVVVVXXXXXXXXXXXXXXXX VVVVXXXXXXXXXXXXXXXXXXXXXXXX">
             <qualifier>
                 <variableref>Turnout 6    Mode Route 3</variableref>
@@ -1091,8 +1091,8 @@
                   </enumChoice>
               </enumVal>
           </variable>
-          <!-- same CV, leading zero for SplitVal bug-->
-          <variable item="Turnout 7 Address Route 3" CV="115.25.027,115.25.27" 
+          <!-- same CV -->
+          <variable item="Turnout 7 Address Route 3" CV="115.25.27,115.25.27" 
                 default="1" mask="XXXXXVVVVVVV VVVVXXXXXXXX">
             <qualifier>
                 <variableref>Turnout 7    Mode Route 3</variableref>
@@ -1116,8 +1116,8 @@
                   </enumChoice>
               </enumVal>
           </variable>
-          <!-- same CV, leading zero for SplitVal bug-->
-          <variable item="Turnout 8 Address Route 3" CV="115.25.027,115.25.27" 
+          <!-- same CV -->
+          <variable item="Turnout 8 Address Route 3" CV="115.25.27,115.25.27" 
                 default="1" mask="XXXXXVVVVVVVXXXXXXXXXXXXXXXX VVVVXXXXXXXXXXXXXXXXXXXXXXXX">
             <qualifier>
                 <variableref>Turnout 8    Mode Route 3</variableref>
@@ -1143,8 +1143,8 @@
                   </enumChoice>
               </enumVal>
           </variable>
-          <!-- same CV, leading zero for SplitVal bug-->
-          <variable item="Turnout 1 Address Route 4" CV="115.25.028,115.25.28" 
+          <!-- same CV -->
+          <variable item="Turnout 1 Address Route 4" CV="115.25.28,115.25.28" 
                 default="1" mask="XXXXXVVVVVVV VVVVXXXXXXXX">
             <qualifier>
                 <variableref>Turnout 1    Mode Route 4</variableref>
@@ -1168,8 +1168,8 @@
                   </enumChoice>
               </enumVal>
           </variable>
-          <!-- same CV, leading zero for SplitVal bug-->
-          <variable item="Turnout 2 Address Route 4" CV="115.25.028,115.25.28"
+          <!-- same CV -->
+          <variable item="Turnout 2 Address Route 4" CV="115.25.28,115.25.28"
                 default="1" mask="XXXXXVVVVVVVXXXXXXXXXXXXXXXX VVVVXXXXXXXXXXXXXXXXXXXXXXXX">
             <qualifier>
                 <variableref>Turnout 2    Mode Route 4</variableref>
@@ -1193,8 +1193,8 @@
                   </enumChoice>
               </enumVal>
           </variable>
-          <!-- same CV, leading zero for SplitVal bug-->
-          <variable item="Turnout 3 Address Route 4" CV="115.25.029,115.25.29" 
+          <!-- same CV -->
+          <variable item="Turnout 3 Address Route 4" CV="115.25.29,115.25.29" 
                 default="1" mask="XXXXXVVVVVVV VVVVXXXXXXXX">
             <qualifier>
                 <variableref>Turnout 3    Mode Route 4</variableref>
@@ -1218,8 +1218,8 @@
                   </enumChoice>
               </enumVal>
           </variable>
-          <!-- same CV, leading zero for SplitVal bug-->
-          <variable item="Turnout 4 Address Route 4" CV="115.25.029,115.25.29" 
+          <!-- same CV -->
+          <variable item="Turnout 4 Address Route 4" CV="115.25.29,115.25.29" 
                 default="1" mask="XXXXXVVVVVVVXXXXXXXXXXXXXXXX VVVVXXXXXXXXXXXXXXXXXXXXXXXX">
             <qualifier>
                 <variableref>Turnout 4    Mode Route 4</variableref>
@@ -1243,8 +1243,8 @@
                   </enumChoice>
               </enumVal>
           </variable>
-          <!-- same CV, leading zero for SplitVal bug-->
-          <variable item="Turnout 5 Address Route 4" CV="115.25.030,115.25.30" 
+          <!-- same CV -->
+          <variable item="Turnout 5 Address Route 4" CV="115.25.30,115.25.30" 
                 default="1" mask="XXXXXVVVVVVV VVVVXXXXXXXX">
             <qualifier>
                 <variableref>Turnout 5    Mode Route 4</variableref>
@@ -1268,8 +1268,8 @@
                   </enumChoice>
               </enumVal>
           </variable>
-          <!-- same CV, leading zero for SplitVal bug-->
-          <variable item="Turnout 6 Address Route 4" CV="115.25.030,115.25.30" 
+          <!-- same CV -->
+          <variable item="Turnout 6 Address Route 4" CV="115.25.30,115.25.30" 
                 default="1" mask="XXXXXVVVVVVVXXXXXXXXXXXXXXXX VVVVXXXXXXXXXXXXXXXXXXXXXXXX">
             <qualifier>
                 <variableref>Turnout 6    Mode Route 4</variableref>
@@ -1293,8 +1293,8 @@
                   </enumChoice>
               </enumVal>
           </variable>
-          <!-- same CV, leading zero for SplitVal bug-->
-          <variable item="Turnout 7 Address Route 4" CV="115.25.031,115.25.31" 
+          <!-- same CV -->
+          <variable item="Turnout 7 Address Route 4" CV="115.25.31,115.25.31" 
                 default="1" mask="XXXXXVVVVVVV VVVVXXXXXXXX">
             <qualifier>
                 <variableref>Turnout 7    Mode Route 4</variableref>
@@ -1318,8 +1318,8 @@
                   </enumChoice>
               </enumVal>
           </variable>
-          <!-- same CV, leading zero for SplitVal bug-->
-          <variable item="Turnout 8 Address Route 4" CV="115.25.031,115.25.31" 
+          <!-- same CV -->
+          <variable item="Turnout 8 Address Route 4" CV="115.25.31,115.25.31" 
                 default="1" mask="XXXXXVVVVVVVXXXXXXXXXXXXXXXX VVVVXXXXXXXXXXXXXXXXXXXXXXXX">
             <qualifier>
                 <variableref>Turnout 8    Mode Route 4</variableref>
@@ -1345,8 +1345,8 @@
                   </enumChoice>
               </enumVal>
           </variable>
-          <!-- same CV, leading zero for SplitVal bug-->
-          <variable item="Turnout 1 Address Route 5" CV="115.25.032,115.25.32" 
+          <!-- same CV -->
+          <variable item="Turnout 1 Address Route 5" CV="115.25.32,115.25.32" 
                 default="1" mask="XXXXXVVVVVVV VVVVXXXXXXXX">
             <qualifier>
                 <variableref>Turnout 1    Mode Route 5</variableref>
@@ -1370,8 +1370,8 @@
                   </enumChoice>
               </enumVal>
           </variable>
-          <!-- same CV, leading zero for SplitVal bug-->
-          <variable item="Turnout 2 Address Route 5" CV="115.25.032,115.25.32"
+          <!-- same CV -->
+          <variable item="Turnout 2 Address Route 5" CV="115.25.32,115.25.32"
                 default="1" mask="XXXXXVVVVVVVXXXXXXXXXXXXXXXX VVVVXXXXXXXXXXXXXXXXXXXXXXXX">
             <qualifier>
                 <variableref>Turnout 2    Mode Route 5</variableref>
@@ -1395,8 +1395,8 @@
                   </enumChoice>
               </enumVal>
           </variable>
-          <!-- same CV, leading zero for SplitVal bug-->
-          <variable item="Turnout 3 Address Route 5" CV="115.25.033,115.25.33" 
+          <!-- same CV -->
+          <variable item="Turnout 3 Address Route 5" CV="115.25.33,115.25.33" 
                 default="1" mask="XXXXXVVVVVVV VVVVXXXXXXXX">
             <qualifier>
                 <variableref>Turnout 3    Mode Route 5</variableref>
@@ -1420,8 +1420,8 @@
                   </enumChoice>
               </enumVal>
           </variable>
-          <!-- same CV, leading zero for SplitVal bug-->
-          <variable item="Turnout 4 Address Route 5" CV="115.25.033,115.25.33" 
+          <!-- same CV -->
+          <variable item="Turnout 4 Address Route 5" CV="115.25.33,115.25.33" 
                 default="1" mask="XXXXXVVVVVVVXXXXXXXXXXXXXXXX VVVVXXXXXXXXXXXXXXXXXXXXXXXX">
             <qualifier>
                 <variableref>Turnout 4    Mode Route 5</variableref>
@@ -1445,8 +1445,8 @@
                   </enumChoice>
               </enumVal>
           </variable>
-          <!-- same CV, leading zero for SplitVal bug-->
-          <variable item="Turnout 5 Address Route 5" CV="115.25.034,115.25.34" 
+          <!-- same CV -->
+          <variable item="Turnout 5 Address Route 5" CV="115.25.34,115.25.34" 
                 default="1" mask="XXXXXVVVVVVV VVVVXXXXXXXX">
             <qualifier>
                 <variableref>Turnout 5    Mode Route 5</variableref>
@@ -1470,8 +1470,8 @@
                   </enumChoice>
               </enumVal>
           </variable>
-          <!-- same CV, leading zero for SplitVal bug-->
-          <variable item="Turnout 6 Address Route 5" CV="115.25.034,115.25.34" 
+          <!-- same CV -->
+          <variable item="Turnout 6 Address Route 5" CV="115.25.34,115.25.34" 
                 default="1" mask="XXXXXVVVVVVVXXXXXXXXXXXXXXXX VVVVXXXXXXXXXXXXXXXXXXXXXXXX">
             <qualifier>
                 <variableref>Turnout 6    Mode Route 5</variableref>
@@ -1495,8 +1495,8 @@
                   </enumChoice>
               </enumVal>
           </variable>
-          <!-- same CV, leading zero for SplitVal bug-->
-          <variable item="Turnout 7 Address Route 5" CV="115.25.035,115.25.35" 
+          <!-- same CV -->
+          <variable item="Turnout 7 Address Route 5" CV="115.25.35,115.25.35" 
                 default="1" mask="XXXXXVVVVVVV VVVVXXXXXXXX">
             <qualifier>
                 <variableref>Turnout 7    Mode Route 5</variableref>
@@ -1520,8 +1520,8 @@
                   </enumChoice>
               </enumVal>
           </variable>
-          <!-- same CV, leading zero for SplitVal bug-->
-          <variable item="Turnout 8 Address Route 5" CV="115.25.035,115.25.35" 
+          <!-- same CV -->
+          <variable item="Turnout 8 Address Route 5" CV="115.25.35,115.25.35" 
                 default="1" mask="XXXXXVVVVVVVXXXXXXXXXXXXXXXX VVVVXXXXXXXXXXXXXXXXXXXXXXXX">
             <qualifier>
                 <variableref>Turnout 8    Mode Route 5</variableref>
@@ -1547,8 +1547,8 @@
                   </enumChoice>
               </enumVal>
           </variable>
-          <!-- same CV, leading zero for SplitVal bug-->
-          <variable item="Turnout 1 Address Route 6" CV="115.25.036,115.25.36" 
+          <!-- same CV -->
+          <variable item="Turnout 1 Address Route 6" CV="115.25.36,115.25.36" 
                 default="1" mask="XXXXXVVVVVVV VVVVXXXXXXXX">
             <qualifier>
                 <variableref>Turnout 1    Mode Route 6</variableref>
@@ -1572,8 +1572,8 @@
                   </enumChoice>
               </enumVal>
           </variable>
-          <!-- same CV, leading zero for SplitVal bug-->
-          <variable item="Turnout 2 Address Route 6" CV="115.25.036,115.25.36"
+          <!-- same CV -->
+          <variable item="Turnout 2 Address Route 6" CV="115.25.36,115.25.36"
                 default="1" mask="XXXXXVVVVVVVXXXXXXXXXXXXXXXX VVVVXXXXXXXXXXXXXXXXXXXXXXXX">
             <qualifier>
                 <variableref>Turnout 2    Mode Route 6</variableref>
@@ -1597,8 +1597,8 @@
                   </enumChoice>
               </enumVal>
           </variable>
-          <!-- same CV, leading zero for SplitVal bug-->
-          <variable item="Turnout 3 Address Route 6" CV="115.25.037,115.25.37" 
+          <!-- same CV -->
+          <variable item="Turnout 3 Address Route 6" CV="115.25.37,115.25.37" 
                 default="1" mask="XXXXXVVVVVVV VVVVXXXXXXXX">
             <qualifier>
                 <variableref>Turnout 3    Mode Route 6</variableref>
@@ -1622,8 +1622,8 @@
                   </enumChoice>
               </enumVal>
           </variable>
-          <!-- same CV, leading zero for SplitVal bug-->
-          <variable item="Turnout 4 Address Route 6" CV="115.25.037,115.25.37" 
+          <!-- same CV -->
+          <variable item="Turnout 4 Address Route 6" CV="115.25.37,115.25.37" 
                 default="1" mask="XXXXXVVVVVVVXXXXXXXXXXXXXXXX VVVVXXXXXXXXXXXXXXXXXXXXXXXX">
             <qualifier>
                 <variableref>Turnout 4    Mode Route 6</variableref>
@@ -1647,8 +1647,8 @@
                   </enumChoice>
               </enumVal>
           </variable>
-          <!-- same CV, leading zero for SplitVal bug-->
-          <variable item="Turnout 5 Address Route 6" CV="115.25.038,115.25.38" 
+          <!-- same CV -->
+          <variable item="Turnout 5 Address Route 6" CV="115.25.38,115.25.38" 
                 default="1" mask="XXXXXVVVVVVV VVVVXXXXXXXX">
             <qualifier>
                 <variableref>Turnout 5    Mode Route 6</variableref>
@@ -1672,8 +1672,8 @@
                   </enumChoice>
               </enumVal>
           </variable>
-          <!-- same CV, leading zero for SplitVal bug-->
-          <variable item="Turnout 6 Address Route 6" CV="115.25.038,115.25.38" 
+          <!-- same CV -->
+          <variable item="Turnout 6 Address Route 6" CV="115.25.38,115.25.38" 
                 default="1" mask="XXXXXVVVVVVVXXXXXXXXXXXXXXXX VVVVXXXXXXXXXXXXXXXXXXXXXXXX">
             <qualifier>
                 <variableref>Turnout 6    Mode Route 6</variableref>
@@ -1697,8 +1697,8 @@
                   </enumChoice>
               </enumVal>
           </variable>
-          <!-- same CV, leading zero for SplitVal bug-->
-          <variable item="Turnout 7 Address Route 6" CV="115.25.039,115.25.39" 
+          <!-- same CV -->
+          <variable item="Turnout 7 Address Route 6" CV="115.25.39,115.25.39" 
                 default="1" mask="XXXXXVVVVVVV VVVVXXXXXXXX">
             <qualifier>
                 <variableref>Turnout 7    Mode Route 6</variableref>
@@ -1722,8 +1722,8 @@
                   </enumChoice>
               </enumVal>
           </variable>
-          <!-- same CV, leading zero for SplitVal bug-->
-          <variable item="Turnout 8 Address Route 6" CV="115.25.039,115.25.39" 
+          <!-- same CV -->
+          <variable item="Turnout 8 Address Route 6" CV="115.25.39,115.25.39" 
                 default="1" mask="XXXXXVVVVVVVXXXXXXXXXXXXXXXX VVVVXXXXXXXXXXXXXXXXXXXXXXXX">
             <qualifier>
                 <variableref>Turnout 8    Mode Route 6</variableref>
@@ -1749,8 +1749,8 @@
                   </enumChoice>
               </enumVal>
           </variable>
-          <!-- same CV, leading zero for SplitVal bug-->
-          <variable item="Turnout 1 Address Route 7" CV="115.25.040,115.25.40" 
+          <!-- same CV -->
+          <variable item="Turnout 1 Address Route 7" CV="115.25.40,115.25.40" 
                 default="1" mask="XXXXXVVVVVVV VVVVXXXXXXXX">
             <qualifier>
                 <variableref>Turnout 1    Mode Route 7</variableref>
@@ -1774,8 +1774,8 @@
                   </enumChoice>
               </enumVal>
           </variable>
-          <!-- same CV, leading zero for SplitVal bug-->
-          <variable item="Turnout 2 Address Route 7" CV="115.25.040,115.25.40"
+          <!-- same CV -->
+          <variable item="Turnout 2 Address Route 7" CV="115.25.40,115.25.40"
                 default="1" mask="XXXXXVVVVVVVXXXXXXXXXXXXXXXX VVVVXXXXXXXXXXXXXXXXXXXXXXXX">
             <qualifier>
                 <variableref>Turnout 2    Mode Route 7</variableref>
@@ -1799,8 +1799,8 @@
                   </enumChoice>
               </enumVal>
           </variable>
-          <!-- same CV, leading zero for SplitVal bug-->
-          <variable item="Turnout 3 Address Route 7" CV="115.25.041,115.25.41" 
+          <!-- same CV -->
+          <variable item="Turnout 3 Address Route 7" CV="115.25.41,115.25.41" 
                 default="1" mask="XXXXXVVVVVVV VVVVXXXXXXXX">
             <qualifier>
                 <variableref>Turnout 3    Mode Route 7</variableref>
@@ -1824,8 +1824,8 @@
                   </enumChoice>
               </enumVal>
           </variable>
-          <!-- same CV, leading zero for SplitVal bug-->
-          <variable item="Turnout 4 Address Route 7" CV="115.25.041,115.25.41" 
+          <!-- same CV -->
+          <variable item="Turnout 4 Address Route 7" CV="115.25.41,115.25.41" 
                 default="1" mask="XXXXXVVVVVVVXXXXXXXXXXXXXXXX VVVVXXXXXXXXXXXXXXXXXXXXXXXX">
             <qualifier>
                 <variableref>Turnout 4    Mode Route 7</variableref>
@@ -1849,8 +1849,8 @@
                   </enumChoice>
               </enumVal>
           </variable>
-          <!-- same CV, leading zero for SplitVal bug-->
-          <variable item="Turnout 5 Address Route 7" CV="115.25.042,115.25.42" 
+          <!-- same CV -->
+          <variable item="Turnout 5 Address Route 7" CV="115.25.42,115.25.42" 
                 default="1" mask="XXXXXVVVVVVV VVVVXXXXXXXX">
             <qualifier>
                 <variableref>Turnout 5    Mode Route 7</variableref>
@@ -1874,8 +1874,8 @@
                   </enumChoice>
               </enumVal>
           </variable>
-          <!-- same CV, leading zero for SplitVal bug-->
-          <variable item="Turnout 6 Address Route 7" CV="115.25.042,115.25.42" 
+          <!-- same CV -->
+          <variable item="Turnout 6 Address Route 7" CV="115.25.42,115.25.42" 
                 default="1" mask="XXXXXVVVVVVVXXXXXXXXXXXXXXXX VVVVXXXXXXXXXXXXXXXXXXXXXXXX">
             <qualifier>
                 <variableref>Turnout 6    Mode Route 7</variableref>
@@ -1899,8 +1899,8 @@
                   </enumChoice>
               </enumVal>
           </variable>
-          <!-- same CV, leading zero for SplitVal bug-->
-          <variable item="Turnout 7 Address Route 7" CV="115.25.043,115.25.43" 
+          <!-- same CV -->
+          <variable item="Turnout 7 Address Route 7" CV="115.25.43,115.25.43" 
                 default="1" mask="XXXXXVVVVVVV VVVVXXXXXXXX">
             <qualifier>
                 <variableref>Turnout 7    Mode Route 7</variableref>
@@ -1924,8 +1924,8 @@
                   </enumChoice>
               </enumVal>
           </variable>
-          <!-- same CV, leading zero for SplitVal bug-->
-          <variable item="Turnout 8 Address Route 7" CV="115.25.043,115.25.43" 
+          <!-- same CV -->
+          <variable item="Turnout 8 Address Route 7" CV="115.25.43,115.25.43" 
                 default="1" mask="XXXXXVVVVVVVXXXXXXXXXXXXXXXX VVVVXXXXXXXXXXXXXXXXXXXXXXXX">
             <qualifier>
                 <variableref>Turnout 8    Mode Route 7</variableref>
@@ -1951,8 +1951,8 @@
                   </enumChoice>
               </enumVal>
           </variable>
-          <!-- same CV, leading zero for SplitVal bug-->
-          <variable item="Turnout 1 Address Route 8" CV="115.25.044,115.25.44" 
+          <!-- same CV -->
+          <variable item="Turnout 1 Address Route 8" CV="115.25.44,115.25.44" 
                 default="1" mask="XXXXXVVVVVVV VVVVXXXXXXXX">
             <qualifier>
                 <variableref>Turnout 1    Mode Route 8</variableref>
@@ -1976,8 +1976,8 @@
                   </enumChoice>
               </enumVal>
           </variable>
-          <!-- same CV, leading zero for SplitVal bug-->
-          <variable item="Turnout 2 Address Route 8" CV="115.25.044,115.25.44"
+          <!-- same CV -->
+          <variable item="Turnout 2 Address Route 8" CV="115.25.44,115.25.44"
                 default="1" mask="XXXXXVVVVVVVXXXXXXXXXXXXXXXX VVVVXXXXXXXXXXXXXXXXXXXXXXXX">
             <qualifier>
                 <variableref>Turnout 2    Mode Route 8</variableref>
@@ -2001,8 +2001,8 @@
                   </enumChoice>
               </enumVal>
           </variable>
-          <!-- same CV, leading zero for SplitVal bug-->
-          <variable item="Turnout 3 Address Route 8" CV="115.25.045,115.25.45" 
+          <!-- same CV -->
+          <variable item="Turnout 3 Address Route 8" CV="115.25.45,115.25.45" 
                 default="1" mask="XXXXXVVVVVVV VVVVXXXXXXXX">
             <qualifier>
                 <variableref>Turnout 3    Mode Route 8</variableref>
@@ -2026,8 +2026,8 @@
                   </enumChoice>
               </enumVal>
           </variable>
-          <!-- same CV, leading zero for SplitVal bug-->
-          <variable item="Turnout 4 Address Route 8" CV="115.25.045,115.25.45" 
+          <!-- same CV -->
+          <variable item="Turnout 4 Address Route 8" CV="115.25.45,115.25.45" 
                 default="1" mask="XXXXXVVVVVVVXXXXXXXXXXXXXXXX VVVVXXXXXXXXXXXXXXXXXXXXXXXX">
             <qualifier>
                 <variableref>Turnout 4    Mode Route 8</variableref>
@@ -2051,8 +2051,8 @@
                   </enumChoice>
               </enumVal>
           </variable>
-          <!-- same CV, leading zero for SplitVal bug-->
-          <variable item="Turnout 5 Address Route 8" CV="115.25.046,115.25.46" 
+          <!-- same CV -->
+          <variable item="Turnout 5 Address Route 8" CV="115.25.46,115.25.46" 
                 default="1" mask="XXXXXVVVVVVV VVVVXXXXXXXX">
             <qualifier>
                 <variableref>Turnout 5    Mode Route 8</variableref>
@@ -2076,8 +2076,8 @@
                   </enumChoice>
               </enumVal>
           </variable>
-          <!-- same CV, leading zero for SplitVal bug-->
-          <variable item="Turnout 6 Address Route 8" CV="115.25.046,115.25.46" 
+          <!-- same CV -->
+          <variable item="Turnout 6 Address Route 8" CV="115.25.46,115.25.46" 
                 default="1" mask="XXXXXVVVVVVVXXXXXXXXXXXXXXXX VVVVXXXXXXXXXXXXXXXXXXXXXXXX">
             <qualifier>
                 <variableref>Turnout 6    Mode Route 8</variableref>
@@ -2101,8 +2101,8 @@
                   </enumChoice>
               </enumVal>
           </variable>
-          <!-- same CV, leading zero for SplitVal bug-->
-          <variable item="Turnout 7 Address Route 8" CV="115.25.047,115.25.47" 
+          <!-- same CV -->
+          <variable item="Turnout 7 Address Route 8" CV="115.25.47,115.25.47" 
                 default="1" mask="XXXXXVVVVVVV VVVVXXXXXXXX">
             <qualifier>
                 <variableref>Turnout 7    Mode Route 8</variableref>
@@ -2126,8 +2126,8 @@
                   </enumChoice>
               </enumVal>
           </variable>
-          <!-- same CV, leading zero for SplitVal bug-->
-          <variable item="Turnout 8 Address Route 8" CV="115.25.047,115.25.47" 
+          <!-- same CV -->
+          <variable item="Turnout 8 Address Route 8" CV="115.25.47,115.25.47" 
                 default="1" mask="XXXXXVVVVVVVXXXXXXXXXXXXXXXX VVVVXXXXXXXXXXXXXXXXXXXXXXXX">
             <qualifier>
                 <variableref>Turnout 8    Mode Route 8</variableref>


### PR DESCRIPTION
1) Change infoOnly="yes" variables to allow their displayed content to be changed; they still won't read or write to the decoder.  This allows changing and saving the board ID on e.g. Digitrax DS64 and similar boards.

2) Update the SplitVarValue code to properly handle the split parts using the same underlying CV.  Aside from being a general bug fix, this allows the DS64 DecoderPro definition to properly write output addresses.