### PR TITLE
Add a round cap to LE web track lines for Chrome/Chromium displays

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -718,6 +718,10 @@
             <li>Fixed a JSON schema validation gap where requesting an unrecognized
                 type from the LocoNet slot usage service could silently return the
                 wrong schema instead of an error.</li>
+            <li>Layout Editor panels displayed via Chrome and Chromium browsers
+                would show small notches in the track lines near turnouts and 
+                crossovers.  This was not present on other browsers.  Adding
+                a round cap to the end of the drawn lines reduces this effect.
         </ul>
 
     <h3>Where Used</h3>

--- a/web/js/panel.js
+++ b/web/js/panel.js
@@ -3994,6 +3994,8 @@ function $drawLine($p1x, $p1y, $p2x, $p2y, $color, $width, dashArray) {
     $gCtx.moveTo($p1x, $p1y);
     $gCtx.lineTo($p2x, $p2y);
 
+    //$gCtx.lineCap = 'round'; 
+    
     $gCtx.stroke();
 
     if (isDefined(dashArray)) {

--- a/web/js/panel.js
+++ b/web/js/panel.js
@@ -3994,7 +3994,7 @@ function $drawLine($p1x, $p1y, $p2x, $p2y, $color, $width, dashArray) {
     $gCtx.moveTo($p1x, $p1y);
     $gCtx.lineTo($p2x, $p2y);
 
-    //$gCtx.lineCap = 'round'; 
+    $gCtx.lineCap = 'round'; 
     
     $gCtx.stroke();
 


### PR DESCRIPTION
Layout Editor panels displayed via Chrome and Chromium browsers would show small notches in the track lines near turnouts and  crossovers.  This was not present on other browsers.  Adding a round cap to the end of the drawn lines reduces this effect.

Before:
<img width="775" height="211" alt="skitch" src="https://github.com/user-attachments/assets/2856c567-a8dc-4869-8eac-a73ebc7dce94" />

After:
<img width="821" height="224" alt="skitch" src="https://github.com/user-attachments/assets/87db948d-ef5f-4f32-8d04-d4aa70212872" />

Safari and Firebox browsers don't show the notch affect, and their display appears unchanged by this update.
