### PR TITLE
Remove Javadoc non-resolvable reference to spotbugs-annotations/4.9.8

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -2175,7 +2175,6 @@
             <link href="https://commons.apache.org/proper/commons-csv/apidocs/"/>
             <link href="https://logging.apache.org/log4j/1.x/apidocs/"/>
             <link href="https://commons.apache.org/proper/commons-lang/javadocs/api-release"/>
-            <link href="https://javadoc.io/static/com.github.spotbugs/spotbugs-annotations/4.9.8/"/>
             <link href="https://javadoc.io/doc/com.google.code.findbugs/jsr305/3.0.1/"/>
             <!-- marking this one offline as it doesn't currently serve the 'package-list' document -->
             <!-- The following Javadocs were built with JDK 11+ and can't be directly linked -->
@@ -2283,7 +2282,6 @@
 
             <link offline="true" href="https://www.javadoc.io/doc/com.github.purejavacomm/purejavacomm/1.0.1.RELEASE/" packagelistLoc="lib/purejavacomm-1.0.1-package-list"/>
             <link offline="true" href="https://www.javadoc.io/doc/com.alexandriasoftware.swing/jsplitbutton/1.3.1/" packagelistLoc="lib/jsplitbutton-1.3.1-package-list"/>
-             <link href="https://javadoc.io/static/com.github.spotbugs/spotbugs-annotations/4.9.8/"/>
             <link href="https://javadoc.io/doc/com.google.code.findbugs/jsr305/3.0.1/"/>
 
         </javadoc>


### PR DESCRIPTION
The Javadoc for spotbugs-annotations 4.9.8, which we use, is no longer available.  This removes the download reference, which in turn removes a Javadoc error that was preventing Jenkins from properly building the complete Javadoc for the web.

No functional changes.