### PR TITLE
ZIMO Servo for 'small' Decoder disabled

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -289,7 +289,8 @@
             <ul>
                 <li>PD series disabled until an update 3.15+ is available</li>
                 <li>Added a "replacement" function for some decoders</li>
-                <li>D&H files have been renamed for sorting in the decoder selection window</li>
+                <li>D &amp; H files have been renamed for sorting in the decoder selection window</li>
+                <li>Decoder files renamed for sorted display</li>
             </ul>
 
         <h4>ESU</h4>
@@ -453,6 +454,7 @@
             <ul>
                 <li>Added replacement-feature for v4.x MS/MN decoder</li>
                 <li>Added some features from CV27 for FS/MS/MN decoders, in particular HLU-Options</li>
+                <li>The ‘small’ decoders MX600, 615, 616, 617, MN150, 160 and 250 do not support servos: CV and Pane servos are excluded</li>
                 <li>Minor optical corrections</li>
             </ul>
 

--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -454,7 +454,7 @@
             <ul>
                 <li>Added replacement-feature for v4.x MS/MN decoder</li>
                 <li>Added some features from CV27 for FS/MS/MN decoders, in particular HLU-Options</li>
-                <li>The ‘small’ decoders MX600, 615, 616, 617, MN150, 160 and 250 do not support servos: CV and Pane servos are excluded</li>
+                <li>The 'small' decoders MX600, 615, 616, 617, MN150, 160 and 250 do not support servos: CV and Pane servos are excluded</li>
                 <li>Minor optical corrections</li>
             </ul>
 

--- a/xml/decoders/Doehler_Haass_function_decoders_old.xml
+++ b/xml/decoders/Doehler_Haass_function_decoders_old.xml
@@ -19,6 +19,8 @@
          No reset on this model (confirmed by manufacturer) -->
   <version version="3" author="Pierre Billon" lastUpdated="20260805"/>
   <!-- 3 Added some translations   -->
+  <version version="3.1" author="Ronald Kuhn" lastUpdated="20260911"/>
+  <!-- 3.1 Decoder files renamed for sorted display   -->
   <decoder>
     <family name="Function Decoders (old)" mfg="Doehler und Haass">
       <model model="DHF250" lowVersionID="1" highVersionID="1" numOuts="2" numFns="9" productID="DHF250" comment="without cable" maxInputVolts="30V" maxTotalCurrent="1.0A" connector="other">

--- a/xml/decoders/Doehler_Haass_function_fw3.05_FH05B.xml
+++ b/xml/decoders/Doehler_Haass_function_fw3.05_FH05B.xml
@@ -12,8 +12,10 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" showEmptyPanes="no" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
+  <version version="2.1" author="Ronald Kuhn" lastUpdated="20260911"/>
+  <!--  Decoder files renamed for sorted display   -->
   <version version="2" author="Pierre Billon" lastUpdated="20210308"/>
-<!--  Added update paths to newest fw 3.12.050 -->
+  <!--  Added update paths to newest fw 3.12.050 -->
   <version version="1" author="Pierre Billon" lastUpdated="2016-12-14"/>
   <!--  Creation (new firmware).
         3 firmware versions are defined here (3.05 = 3.05.104, 3.05.114, 3.05.15).

--- a/xml/decoders/Doehler_Haass_function_fw3.06-07_FH05B-22A.xml
+++ b/xml/decoders/Doehler_Haass_function_fw3.06-07_FH05B-22A.xml
@@ -12,6 +12,8 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" showEmptyPanes="no" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
+  <version version="3.2" author="Ronald Kuhn" lastUpdated="20260911"/>
+  <!--  Decoder files renamed for sorted display   -->
   <version version="3.1" author="Pierre Billon" lastUpdated="20210312"/>
   <!--  Removed Firmware pane (outdated since fw 3.06 and
         introduction of CVs260-265: fw info now on "DH Info" page)

--- a/xml/decoders/Doehler_Haass_function_fw3.10-11_FH05B-18-22A.xml
+++ b/xml/decoders/Doehler_Haass_function_fw3.10-11_FH05B-18-22A.xml
@@ -12,6 +12,8 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" showEmptyPanes="no" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
+  <version version="4.3" author="Ronald Kuhn" lastUpdated="20260911"/>
+  <!--  Decoder files renamed for sorted display   -->
   <version version="4.2" author="Pierre Billon" lastUpdated="20260725"/>
   <!--  Fixed the gating of CV144 bits 3 and 4, the two GPIO brake settings. They were
         restricted to product IDs that no model in this file carries, so neither bit was

--- a/xml/decoders/Doehler_Haass_function_fw3.12_FH05B-18-22A.xml
+++ b/xml/decoders/Doehler_Haass_function_fw3.12_FH05B-18-22A.xml
@@ -12,6 +12,8 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" showEmptyPanes="no" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
+  <version version="1.4" author="Ronald Kuhn" lastUpdated="20260911"/>
+  <!--  Decoder files renamed for sorted display   -->
   <version version="1.3" author="Pierre Billon" lastUpdated="20260725"/>
   <!--  Two settings the D&amp;H CV table documents for this firmware but which were unreachable:
         - CV144 bits 3 and 4, the GPIO brake settings, were gated to product IDs that no model

--- a/xml/decoders/Doehler_Haass_function_fw3.13_FH05B-22A.xml
+++ b/xml/decoders/Doehler_Haass_function_fw3.13_FH05B-22A.xml
@@ -12,8 +12,8 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" showEmptyPanes="no" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
-  <version version="1.2" author="Ronald Kuhn" lastUpdated="20260828"/>
-  <!-- replacementModel added and small change, mail address deleted -->
+  <version version="1.2" author="Ronald Kuhn" lastUpdated="20260911"/>
+  <!-- replacementModel added and small change, mail address deleted, Decoder files renamed for sorted display -->
   <version version="1.1" author="Pierre Billon" lastUpdated="20260725"/>
   <!--  Firmware 3.13 completed and corrected:
         - Added CV401-412 function swapping, documented by D&amp;H since firmware 3.12 or earlier

--- a/xml/decoders/Doehler_Haass_function_fw3.14_FH05B-22A.xml
+++ b/xml/decoders/Doehler_Haass_function_fw3.14_FH05B-22A.xml
@@ -12,8 +12,8 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" showEmptyPanes="no" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
-  <version version="1.1" author="Ronald Kuhn" lastUpdated="20260828"/>
-  <!-- replacementModel added and small change -->
+  <version version="1.1" author="Ronald Kuhn" lastUpdated="20260911"/>
+  <!-- replacementModel added and small change, Decoder files renamed for sorted display -->
   <version version="1" author="Pierre Billon" lastUpdated="20260725"/>
   <!--  Creation (new firmware 3.14.095).
         Based on Doehler_Haass_fw3.13_FH05B-22A.xml

--- a/xml/decoders/Doehler_Haass_function_fw3.15_FH05B-22A.xml
+++ b/xml/decoders/Doehler_Haass_function_fw3.15_FH05B-22A.xml
@@ -12,6 +12,8 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" showEmptyPanes="no" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
+  <version version="1.1" author="Ronald Kuhn" lastUpdated="20260911"/>
+  <!--  Decoder files renamed for sorted display   -->
   <version version="1" author="Pierre Billon" lastUpdated="20260725"/>
   <!--  Creation (new firmware 3.15.016).
         Based on Doehler_Haass_fw3.14_FH05B-22A.xml

--- a/xml/decoders/Doehler_Haass_sound_fw1.00-04_SD18A.xml
+++ b/xml/decoders/Doehler_Haass_sound_fw1.00-04_SD18A.xml
@@ -12,6 +12,8 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" showEmptyPanes="no" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
+  <version version="4.1" author="Ronald Kuhn" lastUpdated="20260911"/>
+  <!--  Decoder files renamed for sorted display   -->
   <version version="4" author="Pierre Billon" lastUpdated="20260727"/>
   <!--  Firmware 1.01 identified by CV7=54 (was 1, which is 1.00); firmware 1.02.084 and 1.05.115 now identified  -->
   <version version="3.1" author="Pierre Billon" lastUpdated="20210416"/>

--- a/xml/decoders/Doehler_Haass_sound_fw1.00-04_SD21A.xml
+++ b/xml/decoders/Doehler_Haass_sound_fw1.00-04_SD21A.xml
@@ -12,6 +12,8 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" showEmptyPanes="no" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
+  <version version="4.1" author="Ronald Kuhn" lastUpdated="20260911"/>
+  <!--  Decoder files renamed for sorted display   -->
   <version version="4" author="Pierre Billon" lastUpdated="20260727"/>
   <!--  Firmware 1.01 identified by CV7=54 (was 1, which is 1.00); firmware 1.02.084 and 1.05.115 now identified  -->
   <version version="3.1" author="Pierre Billon" lastUpdated="20210416"/>

--- a/xml/decoders/Doehler_Haass_sound_fw1.06-07_SD10-16-18-21-22A.xml
+++ b/xml/decoders/Doehler_Haass_sound_fw1.06-07_SD10-16-18-21-22A.xml
@@ -12,6 +12,8 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" showEmptyPanes="no" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
+<version version="2.1" author="Ronald Kuhn" lastUpdated="20260911"/>
+<!--  Decoder files renamed for sorted display   -->
 <version version="2" author="Pierre Billon" lastUpdated="20260727"/>
 <!--  Firmware 1.08.027 and 1.09.117 identified by the 1.07 models, which have no definition of their own  -->
 <version version="1.1" author="Pierre Billon" lastUpdated="20210312"/>

--- a/xml/decoders/Doehler_Haass_sound_fw1.10_SD10-16-18-21-22A.xml
+++ b/xml/decoders/Doehler_Haass_sound_fw1.10_SD10-16-18-21-22A.xml
@@ -12,6 +12,8 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" showEmptyPanes="no" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
+<version version="1.2" author="Ronald Kuhn" lastUpdated="20260911"/>
+<!--  Decoder files renamed for sorted display   -->
 <version version="1.1" author="Pierre Billon" lastUpdated="20210312"/>
 <!--  Added update paths to newest fw 1.12.050 -->
 <version version="1" author="Ronald Kuhn" lastUpdated="2020-05-02"/>

--- a/xml/decoders/Doehler_Haass_sound_fw1.11_SD10-16-18-21-22A.xml
+++ b/xml/decoders/Doehler_Haass_sound_fw1.11_SD10-16-18-21-22A.xml
@@ -12,6 +12,8 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" showEmptyPanes="no" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
+<version version="2.1" author="Ronald Kuhn" lastUpdated="20260911"/>
+<!--  Decoder files renamed for sorted display   -->
 <version version="2" author="Pierre Billon" lastUpdated="20260727"/>
 <!--  Firmware 1.11.069 now identified  -->
 <version version="1.1" author="Pierre Billon" lastUpdated="20210312"/>

--- a/xml/decoders/Doehler_Haass_sound_fw1.12_SD05-10-16-18-21-22A.xml
+++ b/xml/decoders/Doehler_Haass_sound_fw1.12_SD05-10-16-18-21-22A.xml
@@ -12,6 +12,8 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" showEmptyPanes="no" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
+  <version version="1.3" author="Ronald Kuhn" lastUpdated="20260911"/>
+  <!--  Decoder files renamed for sorted display   -->
   <version version="1.2" author="Ronald Kuhn" lastUpdated="20230731"/>
   <!--  Added update paths to newest fw 1.13.112 -->
   <version version="1.1" author="Pierre Billon" lastUpdated="20210312"/>

--- a/xml/decoders/Doehler_Haass_sound_fw1.13_SD05-22A.xml
+++ b/xml/decoders/Doehler_Haass_sound_fw1.13_SD05-22A.xml
@@ -12,6 +12,8 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" showEmptyPanes="no" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
+<version version="2.1" author="Ronald Kuhn" lastUpdated="20260911"/>
+<!--  Decoder files renamed for sorted display   -->
 <version version="2" author="Pierre Billon" lastUpdated="20260727"/>
 <!--  Firmware 1.13.101 now identified; added CV137 bit 6 and CV28 bit 2, both new in 1.13  -->
 <version version="1" author="Ronald Kuhn" lastUpdated="2023-07-22"/>

--- a/xml/decoders/Doehler_Haass_susi_fw1.00_SH10A.xml
+++ b/xml/decoders/Doehler_Haass_susi_fw1.00_SH10A.xml
@@ -12,6 +12,8 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" showEmptyPanes="no" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
+  <version version="8.1" author="Ronald Kuhn" lastUpdated="20260911"/>
+  <!--  Decoder files renamed for sorted display   -->
   <version version="8" author="Pierre Billon" lastUpdated="20210308"/>
   <!--  Added update paths to newest fw 1.14.050 -->
   <version version="7" author="Ronald Kuhn" lastUpdated="2020-05-05"/>

--- a/xml/decoders/Doehler_Haass_susi_fw1.14_SH05-10A.xml
+++ b/xml/decoders/Doehler_Haass_susi_fw1.14_SH05-10A.xml
@@ -12,6 +12,8 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" showEmptyPanes="no" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
+  <version version="2.1" author="Ronald Kuhn" lastUpdated="20260911"/>
+  <!--  Decoder files renamed for sorted display   -->
   <version version="2" author="Pierre Billon" lastUpdated="20260727"/>
   <!--  Corrected the SH05A model comment  -->
   <version version="1.1" author="Ronald Kuhn" lastUpdated="20230731"/>

--- a/xml/decoders/Doehler_Haass_susi_fw1.15_SH05-10A.xml
+++ b/xml/decoders/Doehler_Haass_susi_fw1.15_SH05-10A.xml
@@ -12,6 +12,8 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" showEmptyPanes="no" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
+  <version version="2.1" author="Ronald Kuhn" lastUpdated="20260911"/>
+  <!--  Decoder files renamed for sorted display   -->
   <version version="2" author="Pierre Billon" lastUpdated="20260727"/>
   <!--  Corrected the SH05A and SH10A model comments  -->
   <version version="1" author="Ronald Kuhn" lastUpdated="20230720"/>

--- a/xml/decoders/Doehler_Haass_train_fw3.02_DH05-10AB.xml
+++ b/xml/decoders/Doehler_Haass_train_fw3.02_DH05-10AB.xml
@@ -12,6 +12,8 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" showEmptyPanes="no" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
+  <version version="4.1" author="Ronald Kuhn" lastUpdated="20260911"/>
+  <!--  Decoder files renamed for sorted display   -->
   <version version="4" author="Pierre Billon" lastUpdated="20151018"/>
   <!--  Merged DH05x and DH10x def files (same functions and outputs) -->
   <version version="3" author="Pierre Billon" lastUpdated="20150223"/>

--- a/xml/decoders/Doehler_Haass_train_fw3.02_DH05-10C_12-16-18A.xml
+++ b/xml/decoders/Doehler_Haass_train_fw3.02_DH05-10C_12-16-18A.xml
@@ -12,6 +12,8 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" showEmptyPanes="no" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
+  <version version="5.1" author="Ronald Kuhn" lastUpdated="20260911"/>
+  <!--  Decoder files renamed for sorted display   -->
   <version version="5" author="Pierre Billon" lastUpdated="20210308"/>
   <!--  Added update paths to newest fw 3.12.050 -->
   <version version="4" author="Pierre Billon" lastUpdated="20151018"/>

--- a/xml/decoders/Doehler_Haass_train_fw3.02_DH06A.xml
+++ b/xml/decoders/Doehler_Haass_train_fw3.02_DH06A.xml
@@ -12,6 +12,8 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" showEmptyPanes="no" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
+  <version version="3.2" author="Ronald Kuhn" lastUpdated="20260911"/>
+  <!--  Decoder files renamed for sorted display   -->
   <version version="3.1" author="Pierre Billon" lastUpdated="20211008"/>
   <!--  Variables now refering to Vars_common_pwr_normal.xml with specific defaults for this model
      (specific Vars_common_pwr_low.xml is deprecated and has been removed)

--- a/xml/decoders/Doehler_Haass_train_fw3.02_DHP160.xml
+++ b/xml/decoders/Doehler_Haass_train_fw3.02_DHP160.xml
@@ -12,6 +12,8 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" showEmptyPanes="no" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
+  <version version="3.1" author="Ronald Kuhn" lastUpdated="20260911"/>
+  <!--  Decoder files renamed for sorted display   -->
   <version version="3" author="Pierre Billon" lastUpdated="20150223"/>
   <!--  Moved dimmed lights/shunting mode from Adv. Mapping tab to standard mapping table.
 		Removed link to doehler_haass/Pane_map_adv.xml (F1(r), F2(r), as well as dimming/shuting now in std JMRI map pane)

--- a/xml/decoders/Doehler_Haass_train_fw3.02_DHP250.xml
+++ b/xml/decoders/Doehler_Haass_train_fw3.02_DHP250.xml
@@ -12,6 +12,8 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" showEmptyPanes="no" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
+  <version version="3.1" author="Ronald Kuhn" lastUpdated="20260911"/>
+  <!--  Decoder files renamed for sorted display   -->
   <version version="3" author="Pierre Billon" lastUpdated="20150223"/>
   <!--  Moved dimmed lights/shunting mode from Adv. Mapping tab to standard mapping table.
 		Removed link to doehler_haass/Pane_map_adv.xml (F1(r), F2(r), as well as dimming/shuting now in std JMRI map pane)

--- a/xml/decoders/Doehler_Haass_train_fw3.02_DHP260.xml
+++ b/xml/decoders/Doehler_Haass_train_fw3.02_DHP260.xml
@@ -12,6 +12,8 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" showEmptyPanes="no" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
+  <version version="3.1" author="Ronald Kuhn" lastUpdated="20260911"/>
+  <!--  Decoder files renamed for sorted display   -->
   <version version="3" author="Pierre Billon" lastUpdated="20150223"/>
   <!--  Moved dimmed lights/shunting mode from Adv. Mapping tab to standard mapping table.
 		Removed link to doehler_haass/Pane_map_adv.xml (F1(r), F2(r), as well as dimming/shuting now in std JMRI map pane)

--- a/xml/decoders/Doehler_Haass_train_fw3.02_FH05A.xml
+++ b/xml/decoders/Doehler_Haass_train_fw3.02_FH05A.xml
@@ -12,6 +12,8 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" showEmptyPanes="no" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
+  <version version="3.1" author="Ronald Kuhn" lastUpdated="20260911"/>
+  <!--  Decoder files renamed for sorted display   -->
   <version version="3" author="Pierre Billon" lastUpdated="20150223"/>
   <!--  Moved dimmed lights/shunting mode from Adv. Mapping tab to standard mapping table.
   		Removed link to doehler_haass/Pane_map_adv.xml (F1(r), F2(r), as well as dimming/shuting now in std JMRI map pane)

--- a/xml/decoders/Doehler_Haass_train_fw3.02_generic.xml
+++ b/xml/decoders/Doehler_Haass_train_fw3.02_generic.xml
@@ -12,6 +12,8 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" showEmptyPanes="no" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
+  <version version="3.1" author="Ronald Kuhn" lastUpdated="20260911"/>
+  <!--  Decoder files renamed for sorted display   -->
   <version version="3" author="Pierre Billon" lastUpdated="20150223"/>
   <!--  Moved dimmed lights/shunting mode from Adv. Mapping tab to standard mapping table.
 		Removed link to doehler_haass/Pane_map_adv.xml (F1(r), F2(r), as well as dimming/shuting now in std JMRI map pane)

--- a/xml/decoders/Doehler_Haass_train_fw3.03_DH05-10A.xml
+++ b/xml/decoders/Doehler_Haass_train_fw3.03_DH05-10A.xml
@@ -12,6 +12,8 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" showEmptyPanes="no" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
+  <version version="4.1" author="Ronald Kuhn" lastUpdated="20260911"/>
+  <!--  Decoder files renamed for sorted display   -->
   <version version="4" author="Pierre Billon" lastUpdated="20151018"/>
   <!--  Merged DH05x and DH10x def files (same functions and outputs) -->
   <version version="3" author="Pierre Billon" lastUpdated="20150223"/>

--- a/xml/decoders/Doehler_Haass_train_fw3.03_DH05-10B.xml
+++ b/xml/decoders/Doehler_Haass_train_fw3.03_DH05-10B.xml
@@ -12,6 +12,8 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" showEmptyPanes="no" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
+  <version version="4.1" author="Ronald Kuhn" lastUpdated="20260911"/>
+  <!--  Decoder files renamed for sorted display   -->
   <version version="4" author="Pierre Billon" lastUpdated="20151018"/>
   <!--  Merged DH05x and DH10x def files (same functions and outputs) -->
   <version version="3" author="Pierre Billon" lastUpdated="20150223"/>

--- a/xml/decoders/Doehler_Haass_train_fw3.03_DH05-10C_12-16-18-21A.xml
+++ b/xml/decoders/Doehler_Haass_train_fw3.03_DH05-10C_12-16-18-21A.xml
@@ -12,6 +12,8 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" showEmptyPanes="no" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
+  <version version="6.1" author="Ronald Kuhn" lastUpdated="20260911"/>
+  <!--  Decoder files renamed for sorted display   -->
   <version version="6" author="Pierre Billon" lastUpdated="20210308"/>
   <!--  Added update paths to newest fw 3.12.050 -->
   <version version="5" author="Pierre Billon" lastUpdated="20151018"/>

--- a/xml/decoders/Doehler_Haass_train_fw3.03_DH06A.xml
+++ b/xml/decoders/Doehler_Haass_train_fw3.03_DH06A.xml
@@ -12,6 +12,8 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" showEmptyPanes="no" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
+  <version version="3.2" author="Ronald Kuhn" lastUpdated="20260911"/>
+  <!--  Decoder files renamed for sorted display   -->
   <version version="3.1" author="Pierre Billon" lastUpdated="20211008"/>
   <!--  Variables now refering to Vars_common_pwr_normal.xml with specific defaults for this model
      (specific Vars_common_pwr_low.xml is deprecated and has been removed)

--- a/xml/decoders/Doehler_Haass_train_fw3.03_DHP160.xml
+++ b/xml/decoders/Doehler_Haass_train_fw3.03_DHP160.xml
@@ -12,6 +12,8 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" showEmptyPanes="no" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
+  <version version="3.1" author="Ronald Kuhn" lastUpdated="20260911"/>
+  <!--  Decoder files renamed for sorted display   -->
   <version version="3" author="Pierre Billon" lastUpdated="20150223"/>
   <!--  Moved dimmed lights/shunting mode from Adv. Mapping tab to standard mapping table.
 		Removed link to doehler_haass/Pane_map_adv.xml (F1(r), F2(r), as well as dimming/shuting now in std JMRI map pane)

--- a/xml/decoders/Doehler_Haass_train_fw3.03_DHP250.xml
+++ b/xml/decoders/Doehler_Haass_train_fw3.03_DHP250.xml
@@ -12,6 +12,8 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" showEmptyPanes="no" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
+  <version version="3.1" author="Ronald Kuhn" lastUpdated="20260911"/>
+  <!--  Decoder files renamed for sorted display   -->
   <version version="3" author="Pierre Billon" lastUpdated="20150223"/>
   <!--  Moved dimmed lights/shunting mode from Adv. Mapping tab to standard mapping table.
 		Removed link to doehler_haass/Pane_map_adv.xml (F1(r), F2(r), as well as dimming/shuting now in std JMRI map pane)

--- a/xml/decoders/zimo/CV107-CV199_MS-MN-FS.xml
+++ b/xml/decoders/zimo/CV107-CV199_MS-MN-FS.xml
@@ -7,6 +7,8 @@
 <!-- version 1.3,  05 April 2024  Ronald Kuhn.   very small correction by CV154 bit0  -->
 <!-- version 1.4  31 July 2026  Pierre Billon - renamed from CV100-CV199_MS_series.xml; the name now states the CV range held and the decoder series it applies to (holds CV107-199). Added CV197-199, the effects for FO11-FO13, and CV186-189, Panto 1-4 Also: superseded CV151 and CV157 for the software version 5 families: CV151 becomes a 0-99 value, CV157 runs to F28 with 29 selecting F0; added the missing French labels -->
 <!-- version 1.5   05 Aug 2026 Pierre Billon - Added French and German translations -->
+<!-- version 1.6 - 11 Sep 2026 Ronald Kuhn - exclusion Servo-CV for MN150, MN160, MN250 -->
+
 <variables xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
  <xi:include href="http://jmri.org/xml/decoders/nmra/userId.xml"/>
   <!-- Used unrelated item names used to place CV107-108 on the Lights pane -->
@@ -2806,7 +2808,7 @@
     <label xml:lang="cs">Chování funkční výstup 8</label>
     <label xml:lang="de">FA8 Verhalten</label>
   </variable>
-  <variable item="Servo Protocol" CV="161" mask="XXXXXXXV" default="0" exclude="">
+  <variable item="Servo Protocol" CV="161" mask="XXXXXXXV" default="0" exclude="120,121,122,151,161,166,177,194,195,197,199">
     <xi:include href="http://jmri.org/xml/decoders/parts/enum-NegPosPulse.xml"/>
     <label>Servo Protocol</label>
     <label xml:lang="fr">Protocole du servo</label>
@@ -2814,7 +2816,7 @@
     <label xml:lang="cs">Protokol serva</label>
     <label xml:lang="de">Servo Protokoll</label>
   </variable>
-  <variable item="Servo Control Signal" CV="161" mask="XXXXXXVX" default="0" exclude="">
+  <variable item="Servo Control Signal" CV="161" mask="XXXXXXVX" default="0" exclude="120,121,122,151,161,166,177,194,195,197,199">
     <enumVal>
       <enumChoice choice="Only Active for movement" value="0">
         <choice>Only Active for movement</choice>
@@ -2837,7 +2839,7 @@
     <label xml:lang="cs">Řídící signál serva</label>
     <label xml:lang="de">Servo Steuersignal</label>
   </variable>
-  <variable item="Servo Centering" CV="161" mask="XXXXXVXX" default="0" exclude="">
+  <variable item="Servo Centering" CV="161" mask="XXXXXVXX" default="0" exclude="120,121,122,151,161,166,177,194,195,197,199">
     <enumVal>
       <enumChoice choice="Moves to centre in dual key if both Fn's off">
         <choice>Moves to centre in dual key if both Fn's off</choice>
@@ -2860,56 +2862,56 @@
     <label xml:lang="cs">Středová poloha serva</label>
     <label xml:lang="de">Servo Mittelstellung</label>
   </variable>
-  <variable item="Servo 1 Left Stop" CV="162" default="49" exclude="">
+  <variable item="Servo 1 Left Stop" CV="162" default="49" exclude="120,121,122,151,161,166,177,194,195,197,199">
     <decVal/>
     <label>Servo 1 Left Stop</label>
     <label xml:lang="it">Servo 1 Stop Sinistro</label>
     <label xml:lang="cs">Koncová poloha vlevo servo 1</label>
     <label xml:lang="de">Endstellung links</label>
   </variable>
-  <variable item="Servo 1 Right Stop" CV="163" default="205" exclude="">
+  <variable item="Servo 1 Right Stop" CV="163" default="205" exclude="120,121,122,151,161,166,177,194,195,197,199">
     <decVal/>
     <label>Servo 1 Right Stop</label>
     <label xml:lang="it">Servo 1 Stop Destro</label>
     <label xml:lang="cs">Koncová poloha vpravo servo 1</label>
     <label xml:lang="de">Endstellung rechts</label>
   </variable>
-  <variable item="Servo 1 Centre" CV="164" default="127" exclude="">
+  <variable item="Servo 1 Centre" CV="164" default="127" exclude="120,121,122,151,161,166,177,194,195,197,199">
     <decVal/>
     <label>Servo 1 Centre</label>
     <label xml:lang="it">Servo 1 Centro</label>
     <label xml:lang="cs">Středová poloha servo 1</label>
     <label xml:lang="de">Mittelstellung</label>
   </variable>
-  <variable item="Servo 1 Rotation Speed" CV="165" default="30" exclude="">
+  <variable item="Servo 1 Rotation Speed" CV="165" default="30" exclude="120,121,122,151,161,166,177,194,195,197,199">
     <decVal/>
     <label>Servo 1 Rotation Speed</label>
     <label xml:lang="it">Servo 1 Velocità rotazione</label>
     <label xml:lang="cs">Rychlost přestavování servo 1</label>
     <label xml:lang="de">Umlaufzeit</label>
   </variable>
-  <variable item="Servo 2 Left Stop" CV="166" default="49" exclude="">
+  <variable item="Servo 2 Left Stop" CV="166" default="49" exclude="120,121,122,151,161,166,177,194,195,197,199">
     <decVal/>
     <label>Servo 2 Left Stop</label>
     <label xml:lang="it">Servo 2 Stop Sinistro</label>
     <label xml:lang="cs">Koncová poloha vlevo servo 2</label>
     <label xml:lang="de">Endstellung links</label>
   </variable>
-  <variable item="Servo 2 Right Stop" CV="167" default="205" exclude="">
+  <variable item="Servo 2 Right Stop" CV="167" default="205" exclude="120,121,122,151,161,166,177,194,195,197,199">
     <decVal/>
     <label>Servo 2 Right Stop</label>
     <label xml:lang="it">Servo 2 Stop Destro</label>
     <label xml:lang="cs">Koncová poloha vpravo servo 2</label>
     <label xml:lang="de">Endstellung rechts</label>
   </variable>
-  <variable item="Servo 2 Centre" CV="168" default="127" exclude="">
+  <variable item="Servo 2 Centre" CV="168" default="127" exclude="120,121,122,151,161,166,177,194,195,197,199">
     <decVal/>
     <label>Servo 2 Centre</label>
     <label xml:lang="it">Servo 2 Centro</label>
     <label xml:lang="cs">Středová poloha servo 2</label>
     <label xml:lang="de">Mittelstellung</label>
   </variable>
-  <variable item="Servo 2 Rotation Speed" CV="169" default="30" exclude="">
+  <variable item="Servo 2 Rotation Speed" CV="169" default="30" exclude="120,121,122,151,161,166,177,194,195,197,199">
     <decVal/>
     <label>Servo 2 Rotation Speed</label>
     <label xml:lang="it">Servo 2 Velocità rotazione</label>
@@ -2986,14 +2988,14 @@
     <label xml:lang="de">Geschwindigkeit Analog</label>
     <label xml:lang="cs">Analog Maximální napětí</label>
   </variable>
-  <variable item="Servo 1 Function Allocation" CV="181" default="0" exclude="">
+  <variable item="Servo 1 Function Allocation" CV="181" default="0" exclude="120,121,122,151,161,166,177,194,195,197,199">
     <xi:include href="http://jmri.org/xml/decoders/zimo/enum-Fx_servo.xml"/>
     <label>Servo 1 Function Allocation</label>
     <label xml:lang="it">Servo 1 allocaz.Funzioni</label>
     <label xml:lang="cs">Přiřazení funkcí servo 1</label>
     <label xml:lang="de">Funktionszuordnung</label>
   </variable>
-  <variable item="Servo 2 Function Allocation" CV="182" default="0" exclude="">
+  <variable item="Servo 2 Function Allocation" CV="182" default="0" exclude="120,121,122,151,161,166,177,194,195,197,199">
     <xi:include href="http://jmri.org/xml/decoders/zimo/enum-Fx_servo.xml"/>
     <label>Servo 2 Function Allocation</label>
     <label xml:lang="it">Servo 2 allocaz.Funzioni</label>

--- a/xml/decoders/zimo/CV161-CV185Servo.xml
+++ b/xml/decoders/zimo/CV161-CV185Servo.xml
@@ -9,9 +9,10 @@
 <!-- version 1.3 - Ronald Kuhn - exclusion for MX615 and MX616 -->
 <!-- version 1.4 - Ronald Kuhn - correction of some default values -->
 <!-- version 1.5 - Pierre Billon - Added French translations -->
+<!-- version 1.6 - Ronald Kuhn, 20260911 - exclusion for MX600, MX615, MX616, MX617 -->
 
 <variables xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
-  <variable item="Servo Protocol" CV="161" mask="XXXXXXXV" default="0" exclude="194,195">
+  <variable item="Servo Protocol" CV="161" mask="XXXXXXXV" default="0" exclude="120,121,122,151,161,166,177,194,195,197,199">
     <xi:include href="http://jmri.org/xml/decoders/parts/enum-NegPosPulse.xml"/>
     <label>Servo Protocol</label>
     <label xml:lang="fr">Protocole du servo</label>
@@ -19,7 +20,7 @@
     <label xml:lang="cs">Protokol serva</label>
     <label xml:lang="de">Servo Protokoll</label>
   </variable>
-  <variable item="Servo Control Signal" CV="161" mask="XXXXXXVX" default="0" exclude="194,195">
+  <variable item="Servo Control Signal" CV="161" mask="XXXXXXVX" default="0" exclude="120,121,122,151,161,166,177,194,195,197,199">
     <enumVal>
       <enumChoice choice="Only Active for movement" value="0">
         <choice>Only Active for movement</choice>
@@ -42,7 +43,7 @@
     <label xml:lang="cs">Řídící signál serva</label>
     <label xml:lang="de">Servo Steuersignal</label>
   </variable>
-  <variable item="Servo Centering" CV="161" mask="XXXXXVXX" default="0" exclude="194,195">
+  <variable item="Servo Centering" CV="161" mask="XXXXXVXX" default="0" exclude="120,121,122,151,161,166,177,194,195,197,199">
     <enumVal>
       <enumChoice choice="Moves to centre in dual key if both Fn's off">
         <choice>Moves to centre in dual key if both Fn's off</choice>
@@ -65,56 +66,56 @@
     <label xml:lang="cs">Středová poloha serva</label>
     <label xml:lang="de">Servo Mittelstellung</label>
   </variable>
-  <variable item="Servo 1 Left Stop" CV="162" default="49" exclude="194,195">
+  <variable item="Servo 1 Left Stop" CV="162" default="49" exclude="120,121,122,151,161,166,177,194,195,197,199">
     <decVal/>
     <label>Servo 1 Left Stop</label>
     <label xml:lang="it">Servo 1 Stop Sinistro</label>
     <label xml:lang="cs">Koncová poloha vlevo servo 1</label>
     <label xml:lang="de">Endstellung links</label>
   </variable>
-  <variable item="Servo 1 Right Stop" CV="163" default="205" exclude="194,195">
+  <variable item="Servo 1 Right Stop" CV="163" default="205" exclude="120,121,122,151,161,166,177,194,195,197,199">
     <decVal/>
     <label>Servo 1 Right Stop</label>
     <label xml:lang="it">Servo 1 Stop Destro</label>
     <label xml:lang="cs">Koncová poloha vpravo servo 1</label>
     <label xml:lang="de">Endstellung rechts</label>
   </variable>
-  <variable item="Servo 1 Centre" CV="164" default="127" exclude="194,195">
+  <variable item="Servo 1 Centre" CV="164" default="127" exclude="120,121,122,151,161,166,177,194,195,197,199">
     <decVal/>
     <label>Servo 1 Centre</label>
     <label xml:lang="it">Servo 1 Centro</label>
     <label xml:lang="cs">Středová poloha servo 1</label>
     <label xml:lang="de">Mittelstellung</label>
   </variable>
-  <variable item="Servo 1 Rotation Speed" CV="165" default="10" exclude="194,195">
+  <variable item="Servo 1 Rotation Speed" CV="165" default="10" exclude="120,121,122,151,161,166,177,194,195,197,199">
     <decVal/>
     <label>Servo 1 Rotation Speed</label>
     <label xml:lang="it">Servo 1 Velocità rotazione</label>
     <label xml:lang="cs">Rychlost přestavování servo 1</label>
     <label xml:lang="de">Umlaufzeit</label>
   </variable>
-  <variable item="Servo 2 Left Stop" CV="166" default="49" exclude="194,195">
+  <variable item="Servo 2 Left Stop" CV="166" default="49" exclude="120,121,122,151,161,166,177,194,195,197,199">
     <decVal/>
     <label>Servo 2 Left Stop</label>
     <label xml:lang="it">Servo 2 Stop Sinistro</label>
     <label xml:lang="cs">Koncová poloha vlevo servo 2</label>
     <label xml:lang="de">Endstellung links</label>
   </variable>
-  <variable item="Servo 2 Right Stop" CV="167" default="205" exclude="194,195">
+  <variable item="Servo 2 Right Stop" CV="167" default="205" exclude="120,121,122,151,161,166,177,194,195,197,199">
     <decVal/>
     <label>Servo 2 Right Stop</label>
     <label xml:lang="it">Servo 2 Stop Destro</label>
     <label xml:lang="cs">Koncová poloha vpravo servo 2</label>
     <label xml:lang="de">Endstellung rechts</label>
   </variable>
-  <variable item="Servo 2 Centre" CV="168" default="127" exclude="194,195">
+  <variable item="Servo 2 Centre" CV="168" default="127" exclude="120,121,122,151,161,166,177,194,195,197,199">
     <decVal/>
     <label>Servo 2 Centre</label>
     <label xml:lang="it">Servo 2 Centro</label>
     <label xml:lang="cs">Středová poloha servo 2</label>
     <label xml:lang="de">Mittelstellung</label>
   </variable>
-  <variable item="Servo 2 Rotation Speed" CV="169" default="10" exclude="194,195">
+  <variable item="Servo 2 Rotation Speed" CV="169" default="10" exclude="120,121,122,151,161,166,177,194,195,197,199">
     <decVal/>
     <label>Servo 2 Rotation Speed</label>
     <label xml:lang="it">Servo 2 Velocità rotazione</label>
@@ -177,14 +178,14 @@
     <label xml:lang="cs">Rychlost přestavování servo 4</label>
     <label xml:lang="de">Umlaufzeit</label>
   </variable>
-  <variable item="Servo 1 Function Allocation" CV="181" default="0" exclude="194,195">
+  <variable item="Servo 1 Function Allocation" CV="181" default="0" exclude="120,121,122,151,161,166,177,194,195,197,199">
     <xi:include href="http://jmri.org/xml/decoders/zimo/enum-Fx_servo.xml"/>
     <label>Servo 1 Function Allocation</label>
     <label xml:lang="it">Servo 1 allocaz.Funzioni</label>
     <label xml:lang="cs">Přiřazení funkcí servo 1</label>
     <label xml:lang="de">Funktionszuordnung</label>
   </variable>
-  <variable item="Servo 2 Function Allocation" CV="182" default="0" exclude="194,195">
+  <variable item="Servo 2 Function Allocation" CV="182" default="0" exclude="120,121,122,151,161,166,177,194,195,197,199">
     <xi:include href="http://jmri.org/xml/decoders/zimo/enum-Fx_servo.xml"/>
     <label>Servo 2 Function Allocation</label>
     <label xml:lang="it">Servo 2 allocaz.Funzioni</label>

--- a/xml/decoders/zimo/PaneServos2.xml
+++ b/xml/decoders/zimo/PaneServos2.xml
@@ -5,7 +5,9 @@
 <!-- version 1.2 - Ronald Kuhn - add more german translation -->
 <!-- version 1.3 - Ronald Kuhn - small visual improvement -->
 <!-- version 1.4 - Pierre Billon - Added French and German translations -->
-<pane xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
+<!-- version 1.5 - Ronald Kuhn, 20260911 - exclusion for MX600, MX615, MX616, MX617, MN150, MN160, MN250 -->
+
+<pane exclude="120,121,122,151,161,166,177,194,195,197,199" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
   <name>Servos</name>
   <name xml:lang="fr">Servos</name>
   <name xml:lang="de">Servos</name>


### PR DESCRIPTION
The ‘small’ decoders MX600, 615, 616, 617, MN150, 160 and 250 do not support servos: CV and Pane servos are excluded. Version and author for D &amp; H added.